### PR TITLE
LPD-34481 Unable to reference roles when adding Segments through the Site Initializer

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/segments-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/segments-entries.json
@@ -1,6 +1,7 @@
 [
 	{
 		"active": "true",
+		"criteria": "{\"criteria\":{\"user\":{\"conjunction\":\"and\",\"filterString\":\"(roleIds eq '[$ROLE_ID:Test Role 1$]')\",\"typeValue\":\"model\"}},\"filterStrings\":{\"model\":\"(roleIds eq '[$ROLE_ID:Test Role 1$]')\"}}",
 		"name_i18n": {
 			"en-US": "Test Segments Entry 1"
 		},
@@ -9,6 +10,7 @@
 	},
 	{
 		"active": "false",
+		"criteria": "{\"criteria\":{\"user\":{\"conjunction\":\"and\",\"filterString\":\"(roleIds eq '[$ROLE_ID:Test Role 2$]')\",\"typeValue\":\"model\"}},\"filterStrings\":{\"model\":\"(roleIds eq '[$ROLE_ID:Test Role 2$]')\"}}",
 		"name_i18n": {
 			"en-US": "Test Segments Entry 2"
 		},

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -3586,21 +3586,41 @@ public class BundleSiteInitializerTest {
 			_segmentsEntryLocalService.fetchSegmentsEntry(
 				_group.getGroupId(), "TEST-SEGMENTS-ENTRY-1");
 
+		Role role1 = _roleLocalService.fetchRole(
+			_group.getCompanyId(), "Test Role 1");
+
 		Assert.assertNotNull(segmentsEntry1);
 		Assert.assertTrue(segmentsEntry1.isActive());
 		Assert.assertEquals(
 			"Test Segments Entry 1",
 			segmentsEntry1.getName(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"criteria\":{\"user\":{\"conjunction\":\"and\",\"",
+				"filterString\":\"(roleIds eq '", role1.getRoleId(), "')\",\"",
+				"typeValue\":\"model\"}},\"filterStrings\":{\"model\":\"(",
+				"roleIds eq '", role1.getRoleId(), "')\"}}"),
+			segmentsEntry1.getCriteria());
 
 		SegmentsEntry segmentsEntry2 =
 			_segmentsEntryLocalService.fetchSegmentsEntry(
 				_group.getGroupId(), "TEST-SEGMENTS-ENTRY-2");
+
+		Role role2 = _roleLocalService.fetchRole(
+			_group.getCompanyId(), "Test Role 2");
 
 		Assert.assertNotNull(segmentsEntry2);
 		Assert.assertFalse(segmentsEntry2.isActive());
 		Assert.assertEquals(
 			"Test Segments Entry 2",
 			segmentsEntry2.getName(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"criteria\":{\"user\":{\"conjunction\":\"and\",\"",
+				"filterString\":\"(roleIds eq '", role2.getRoleId(), "')\",\"",
+				"typeValue\":\"model\"}},\"filterStrings\":{\"model\":\"(",
+				"roleIds eq '", role2.getRoleId(), "')\"}}"),
+			segmentsEntry2.getCriteria());
 
 		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
 			_group.getGroupId(), false, "/test-public-layout");

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -3780,6 +3780,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 			return;
 		}
 
+		json = _replace(json, stringUtilReplaceValues);
+
 		JSONArray jsonArray = _jsonFactory.createJSONArray(json);
 
 		for (int i = 0; i < jsonArray.length(); i++) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34481

# How am I fixing it?

There is an existing `replace` function that is used in other methods to fill in variables.

# How can you verify that it works?

In `site-initializer/site-initializer-extender/site-initializer-extender-test` run `gw testIntegration --tests *.BundleSiteInitializerTest`

/cc @david-truong @mrjohn1911