### PR TITLE
LPD-34884 Slow performance when viewing list of Sites while groups.complex.sql.class.names includes Group model

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1380,7 +1380,7 @@ public class GroupFinderImpl
 
 	private String _getCondition(String join) {
 		if (Validator.isNotNull(join)) {
-			int pos = join.indexOf("WHERE");
+			int pos = join.lastIndexOf("WHERE");
 
 			if (pos != -1) {
 				join = StringPool.OPEN_PARENTHESIS + join.substring(pos + 5);
@@ -1577,7 +1577,7 @@ public class GroupFinderImpl
 
 	private String _removeWhere(String join) {
 		if (Validator.isNotNull(join)) {
-			int pos = join.indexOf("WHERE");
+			int pos = join.lastIndexOf("WHERE");
 
 			if (pos != -1) {
 				join = join.substring(0, pos);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1175,6 +1175,9 @@ public class GroupFinderImpl
 					userId = permissionChecker.getUserId();
 				}
 
+				queryPos.add(userId);
+				queryPos.add(userId);
+
 				int hasUserRole = 0;
 
 				Long companyId = CompanyThreadLocal.getCompanyId();

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1193,8 +1193,6 @@ public class GroupFinderImpl
 
 				queryPos.add(hasUserRole);
 
-				queryPos.add(userId);
-
 				Role siteAdminRole = RoleLocalServiceUtil.fetchRole(
 					companyId, RoleConstants.SITE_ADMINISTRATOR);
 

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -186,11 +186,15 @@
 						roleId, userId
 					FROM
 						UserGroupRole
+					WHERE
+						userId = ?
 					UNION ALL
 					SELECT
 						roleId, userid
 					FROM
 						Users_Roles
+					WHERE
+						userId = ?
 				) Roles
 			ON
 				Users_Groups.userId = Roles.userId

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -204,14 +204,11 @@
 			WHERE
 			(? = 1) OR
 			(
-				(Roles.userId = ?) AND
 				(
-					(
-						(Roles.roleId = ?) OR
-						(Roles.roleId = ?)
-					) OR
-					(BITAND(CAST_LONG(ResourcePermission.actionIds), ?) != 0)
-				)
+					(Roles.roleId = ?) OR
+					(Roles.roleId = ?)
+				) OR
+				(BITAND(CAST_LONG(ResourcePermission.actionIds), ?) != 0)
 			)
 		]]>
 	</sql>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34884

# How am I fixing it?

This query serves to filter out groups based on a user's permissions. Previously, it was fetching all of the users and their roles for all groups. Later, when checking the permission, it then filtered based on the user's ID.

With this change it now filters based on the user's ID earlier so we are not fetching all users, thus increasing the performance.

# How can you verify that it works?

In `site-test` run `gw testIntegration --tests *.GroupFinderTest`

No new tests are being added because this is a performance fix and the logic is already being tested.