### PR TITLE
LPD-34884 Slow performance when viewing list of Sites while groups.complex.sql.class.names includes Group model

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupFinderTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupFinderTest.java
@@ -118,6 +118,25 @@ public class GroupFinderTest {
 
 		Assert.assertTrue(groups.contains(withActionIdGroup));
 		Assert.assertFalse(groups.contains(withoutActionIdGroup));
+
+		// Parameter order is important. See LPD-34884.
+
+		groups = _groupFinder.findByC_C_PG_N_D(
+			TestPropsValues.getCompanyId(),
+			new long[] {_portal.getClassNameId(Group.class)},
+			GroupConstants.ANY_PARENT_GROUP_ID, new String[] {null},
+			new String[] {null},
+			LinkedHashMapBuilder.<String, Object>put(
+				"active", true
+			).put(
+				"actionId", _arbitraryResourceAction.getActionId()
+			).put(
+				"userId", _user.getUserId()
+			).build(),
+			true, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(groups.contains(withActionIdGroup));
+		Assert.assertFalse(groups.contains(withoutActionIdGroup));
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1162,18 +1162,18 @@ public class GroupFinderImpl
 			return;
 		}
 
+		if (params.containsKey("actionId")) {
+			Long userId = _getUserId(params);
+
+			queryPos.add(userId);
+			queryPos.add(userId);
+		}
+
 		for (Map.Entry<String, Object> entry : params.entrySet()) {
 			String key = entry.getKey();
 
 			if (key.equals("actionId")) {
-				Long userId = (Long)params.get("userId");
-
-				if (Validator.isNull(userId)) {
-					PermissionChecker permissionChecker =
-						PermissionThreadLocal.getPermissionChecker();
-
-					userId = permissionChecker.getUserId();
-				}
+				Long userId = _getUserId(params);
 
 				int hasUserRole = 0;
 
@@ -1445,6 +1445,19 @@ public class GroupFinderImpl
 		_joinMap = joinMap;
 
 		return _joinMap;
+	}
+
+	private Long _getUserId(Map<String, Object> params) {
+		Long currentUserId = (Long)params.get("userId");
+
+		if (Validator.isNull(currentUserId)) {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			currentUserId = permissionChecker.getUserId();
+		}
+
+		return currentUserId;
 	}
 
 	private Map<String, String> _getWhereMap() {

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1377,7 +1377,7 @@ public class GroupFinderImpl
 
 	private String _getCondition(String join) {
 		if (Validator.isNotNull(join)) {
-			int pos = join.indexOf("WHERE");
+			int pos = join.lastIndexOf("WHERE");
 
 			if (pos != -1) {
 				join = StringPool.OPEN_PARENTHESIS + join.substring(pos + 5);
@@ -1587,7 +1587,7 @@ public class GroupFinderImpl
 
 	private String _removeWhere(String join) {
 		if (Validator.isNotNull(join)) {
-			int pos = join.indexOf("WHERE");
+			int pos = join.lastIndexOf("WHERE");
 
 			if (pos != -1) {
 				join = join.substring(0, pos);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1190,8 +1190,6 @@ public class GroupFinderImpl
 
 				queryPos.add(hasUserRole);
 
-				queryPos.add(userId);
-
 				Role siteAdminRole = RoleLocalServiceUtil.fetchRole(
 					companyId, RoleConstants.SITE_ADMINISTRATOR);
 

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -186,11 +186,15 @@
 						roleId, userId
 					FROM
 						UserGroupRole
+					WHERE
+						userId = ?
 					UNION ALL
 					SELECT
 						roleId, userid
 					FROM
 						Users_Roles
+					WHERE
+						userId = ?
 				) Roles
 			ON
 				Users_Groups.userId = Roles.userId

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -204,14 +204,11 @@
 			WHERE
 			(? = 1) OR
 			(
-				(Roles.userId = ?) AND
 				(
-					(
-						(Roles.roleId = ?) OR
-						(Roles.roleId = ?)
-					) OR
-					(BITAND(CAST_LONG(ResourcePermission.actionIds), ?) != 0)
-				)
+					(Roles.roleId = ?) OR
+					(Roles.roleId = ?)
+				) OR
+				(BITAND(CAST_LONG(ResourcePermission.actionIds), ?) != 0)
 			)
 		]]>
 	</sql>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34884

# How am I fixing it?

This query serves to filter out groups based on a user's permissions. Previously, it was fetching all of the users and their roles for all groups. Later, when checking the permission, it then filtered based on the user's ID.

With this change it now filters based on the user's ID earlier so we are not fetching all users, thus increasing the performance.

This differs from https://github.com/liferay-site-management/liferay-portal/pull/1354 in when the parameters are set. Now, it will work regardless of the parameter order.

# How can you verify that it works?

In `site-test` run `gw testIntegration --tests *.GroupFinderTest`