### PR TITLE
LPD-22768 timeline modal dropdown options

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -9,10 +9,21 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-import {createPortletURL, fetch, getPortletId} from 'frontend-js-web';
+import {
+	createPortletURL,
+	fetch,
+	getPortletId,
+	navigate as basicNavigate,
+	sub,
+} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import TimelineDropdownMenu from './TimelineDropdownMenu';
+import TimelineDropdownMenu, {
+	createDiscardURL,
+	createEditURL,
+	createMoveURL,
+	createViewURL,
+} from './TimelineDropdownMenu';
 import {
 	WORKFLOW_STATUS_APPROVED,
 	WORKFLOW_STATUS_DRAFT,
@@ -77,6 +88,37 @@ const PublicationTimeline = ({
 		);
 	};
 
+	const onActionDropdownItemClick = ({action, itemData}) => {
+		if (action.data.id === 'discard') {
+			basicNavigate(
+				createDiscardURL(
+					itemData.id,
+					namespace,
+					timelineClassNameId,
+					timelineClassPK
+				)
+			);
+		}
+		else if (action.data.id === 'edit') {
+			basicNavigate(createEditURL(itemData.id, timelineEditURL));
+		}
+		else if (action.data.id === 'move') {
+			basicNavigate(
+				createMoveURL(
+					itemData.id,
+					namespace,
+					timelineClassNameId,
+					timelineClassPK
+				)
+			);
+		}
+		else if (action.data.id === 'view') {
+			basicNavigate(
+				createViewURL(itemData.id, namespace, itemData.ctEntryId)
+			);
+		}
+	};
+
 	const renderModal = () => {
 		if (!showModal) {
 			return '';
@@ -102,8 +144,46 @@ const PublicationTimeline = ({
 						creationMenu={null}
 						id="PublicationTimelineEntityHistoryTable"
 						items={timelineItems}
+						itemsActions={[
+							{
+								data: {
+									id: 'discard',
+									permissionKey: 'get',
+								},
+								icon: 'times-circle',
+								label: Liferay.Language.get('discard'),
+							},
+							{
+								data: {
+									id: 'edit',
+									permissionKey: 'get',
+								},
+								icon: 'pencil',
+								label: sub(
+									Liferay.Language.get('edit-in-x'),
+									Liferay.Language.get('publication')
+								),
+							},
+							{
+								data: {
+									id: 'move',
+									permissionKey: 'get',
+								},
+								icon: 'move-folder',
+								label: Liferay.Language.get('move-changes'),
+							},
+							{
+								data: {
+									id: 'view',
+									permissionKey: 'get',
+								},
+								icon: 'list-ul',
+								label: Liferay.Language.get('review-change'),
+							},
+						]}
 						itemsPerPage={10}
 						namespace={namespace}
+						onActionDropdownItemClick={onActionDropdownItemClick}
 						selectedItemsKey="id"
 						showManagementBar={false}
 						showPagination={true}
@@ -122,6 +202,7 @@ const PublicationTimeline = ({
 											label: Liferay.Language.get(
 												'publication'
 											),
+											localizeLabel: true,
 											sortable: true,
 										},
 										{
@@ -130,11 +211,13 @@ const PublicationTimeline = ({
 											label: Liferay.Language.get(
 												'status'
 											),
+											localizeLabel: true,
 											sortable: true,
 										},
 										{
 											fieldName: 'ctEntryUser',
 											label: Liferay.Language.get('user'),
+											localizeLabel: true,
 											sortable: true,
 										},
 										{
@@ -142,6 +225,7 @@ const PublicationTimeline = ({
 											label: Liferay.Language.get(
 												'changed'
 											),
+											localizeLabel: true,
 											sortable: true,
 										},
 										{
@@ -150,6 +234,7 @@ const PublicationTimeline = ({
 											label: Liferay.Language.get(
 												'last-modified'
 											),
+											localizeLabel: true,
 											sortable: true,
 										},
 									],

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
@@ -15,6 +15,75 @@ import {
 	WORKFLOW_STATUS_EXPIRED,
 } from './WorkflowStatusLabel';
 
+const createMVCRenderCommandURL = (
+	ctCollectionId,
+	mvcRenderCommandName,
+	namespace,
+	additionalParams = {}
+) => {
+	return createPortletURL(themeDisplay.getLayoutRelativeControlPanelURL(), {
+		ctCollectionId,
+		mvcRenderCommandName,
+		p_p_id: getPortletId(namespace),
+		...additionalParams,
+	}).toString();
+};
+
+export function createDiscardURL(
+	ctCollectionId,
+	namespace,
+	timelineClassNameId,
+	timelineClassPK
+) {
+	return createMVCRenderCommandURL(
+		ctCollectionId,
+		'/change_tracking/view_discard',
+		namespace,
+		{
+			modelClassNameId: timelineClassNameId,
+			modelClassPK: timelineClassPK,
+		}
+	);
+}
+
+export function createEditURL(ctCollectionId, timelineEditURL) {
+	return createPortletURL(timelineEditURL, {
+		ctCollectionId,
+	}).toString();
+}
+
+export function createMoveURL(
+	ctCollectionId,
+	namespace,
+	timelineClassNameId,
+	timelineClassPK
+) {
+	return createMVCRenderCommandURL(
+		ctCollectionId,
+		'/change_tracking/view_move_changes',
+		namespace,
+		{
+			modelClassNameId: timelineClassNameId,
+			modelClassPK: timelineClassPK,
+		}
+	);
+}
+
+export function createViewURL(
+	ctCollectionId,
+	namespace,
+	timelineItemCtEntryId
+) {
+	return createMVCRenderCommandURL(
+		ctCollectionId,
+		'/change_tracking/view_change',
+		namespace,
+		{
+			ctEntryId: timelineItemCtEntryId,
+		}
+	);
+}
+
 export default function TimelineDropdownMenu({
 	deleteURL,
 	editURL,
@@ -33,45 +102,26 @@ export default function TimelineDropdownMenu({
 	if (Liferay.FeatureFlags['LPD-20556']) {
 		const ctCollectionId = timelineItem.id;
 
-		const createMVCRenderCommandURL = (
-			mvcRenderCommandName,
-			additionalParams = {}
-		) => {
-			return createPortletURL(
-				themeDisplay.getLayoutRelativeControlPanelURL(),
-				{
-					ctCollectionId,
-					mvcRenderCommandName,
-					p_p_id: getPortletId(namespace),
-					...additionalParams,
-				}
-			).toString();
-		};
-
-		const discardURL = createMVCRenderCommandURL(
-			'/change_tracking/view_discard',
-			{
-				modelClassNameId: timelineClassNameId,
-				modelClassPK: timelineClassPK,
-			}
-		);
-
-		const checkoutURL = createPortletURL(timelineEditURL, {
+		const discardURL = createDiscardURL(
 			ctCollectionId,
-		}).toString();
-
-		const moveURL = createMVCRenderCommandURL(
-			'/change_tracking/view_move_changes',
-			{
-				modelClassNameId: timelineClassNameId,
-				modelClassPK: timelineClassPK,
-			}
+			namespace,
+			timelineClassNameId,
+			timelineClassPK
 		);
-		const viewURL = createMVCRenderCommandURL(
-			'/change_tracking/view_change',
-			{
-				ctEntryId: timelineItem.ctEntryId,
-			}
+
+		const checkoutURL = createEditURL(ctCollectionId, timelineEditURL);
+
+		const moveURL = createMoveURL(
+			ctCollectionId,
+			namespace,
+			timelineClassNameId,
+			timelineClassPK
+		);
+
+		const viewURL = createViewURL(
+			ctCollectionId,
+			namespace,
+			timelineItem.ctEntryId
 		);
 
 		if (

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
@@ -12,6 +12,7 @@ import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+import {JournalPage} from '../journal-web/pages/JournalPage';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -60,10 +61,11 @@ test.beforeEach(
 
 			if (i !== publicationCount - 1) {
 				await journalPage.goto();
-				const webContentHeader = page.getByRole('heading', {
-					name: 'Web Content',
-				});
-				await expect(webContentHeader).toBeVisible();
+				await page
+					.getByRole('heading', {
+						name: 'Web Content',
+					})
+					.waitFor();
 				await journalPage.goToJournalArticleAction(
 					'Delete',
 					articleTitle
@@ -87,40 +89,53 @@ test.afterEach(async ({apiHelpers, changeTrackingPage, journalPage, page}) => {
 	await changeTrackingPage.workOnProduction();
 
 	await journalPage.goto();
-	await page.getByRole('heading', {name: 'Web Content'}).isVisible();
+	await page.getByRole('heading', {name: 'Web Content'}).waitFor();
 	await journalPage.goToJournalArticleAction('Delete', articleTitle);
 });
+
+const getEntityHistoryModalLocator = (page: Page) => {
+	return page.locator('.entity-history-modal');
+};
+
+const getPublicationTimelineLocator = (page: Page) => {
+	return page.locator('.publication-timeline');
+};
+
+const goToPublicationTimelineModal = async (
+	page: Page,
+	journalPage: JournalPage
+) => {
+	await journalPage.goto();
+	await page.getByRole('heading', {name: 'Web Content'}).waitFor();
+	await journalPage.goToJournalArticleAction('Edit', articleTitle);
+	await page.getByRole('tab', {name: 'Properties'}).waitFor();
+
+	await page.locator('.change-tracking-timeline-button').click();
+
+	const publicationTimelineLocator = getPublicationTimelineLocator(page);
+
+	await publicationTimelineLocator.getByText('Modified').first().waitFor();
+	await publicationTimelineLocator
+		.getByRole('button', {name: 'View More'})
+		.click();
+
+	await getEntityHistoryModalLocator(page)
+		.getByRole('heading', {name: 'View All History'})
+		.waitFor();
+};
 
 test('LPD-22759 Allow users to view the entire history of an entity in a popup modal', async ({
 	journalPage,
 	page,
 }) => {
-	await journalPage.goto();
-	await page.getByRole('heading', {name: 'Web Content'}).isVisible();
-	await journalPage.goToJournalArticleAction('Edit', articleTitle);
-	await page.getByRole('tab', {name: 'Properties'}).waitFor();
-
-	await page.locator('.change-tracking-timeline-button').click();
-	await page
-		.locator('.publication-timeline')
-		.getByText('Modified')
-		.first()
-		.isVisible();
-	await page
-		.locator('.publication-timeline')
-		.getByRole('button', {name: 'View More'})
-		.click();
-	await page
-		.locator('.entity-history-modal')
-		.getByRole('heading', {name: 'View All History'})
-		.isVisible();
+	await goToPublicationTimelineModal(page, journalPage);
 
 	for (let i = 0; i < ctCollections.length; i++) {
 		if (i !== ctCollections.length - 1) {
 			await expect(
-				page
-					.locator('.entity-history-modal')
-					.getByText(ctCollections[i].name)
+				getEntityHistoryModalLocator(page).getByText(
+					ctCollections[i].name
+				)
 			).toBeVisible();
 		}
 	}

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
@@ -140,3 +140,37 @@ test('LPD-22759 Allow users to view the entire history of an entity in a popup m
 		}
 	}
 });
+
+test('LPD-22768 Add options to interact with the same entity in other publications via a popup modal', async ({
+	journalPage,
+	page,
+}) => {
+	await goToPublicationTimelineModal(page, journalPage);
+
+	const entityHistoryModalLocator = getEntityHistoryModalLocator(page);
+
+	const firstDropdown = entityHistoryModalLocator
+		.locator('.item-actions .dropdown svg.lexicon-icon-ellipsis-v')
+		.first();
+
+	await firstDropdown.waitFor();
+	await firstDropdown.click();
+
+	await expect(
+		entityHistoryModalLocator.getByRole('menuitem', {name: 'Discard'})
+	).toBeVisible();
+
+	await expect(
+		entityHistoryModalLocator.getByRole('menuitem', {
+			name: 'Edit in Publication',
+		})
+	).toBeVisible();
+
+	await expect(
+		entityHistoryModalLocator.getByRole('menuitem', {name: 'Move Changes'})
+	).toBeVisible();
+
+	await expect(
+		entityHistoryModalLocator.getByRole('menuitem', {name: 'Review Change'})
+	).toBeVisible();
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22768

Move Changes and Discard error caused by https://liferay.atlassian.net/browse/LPD-35620

I'm not sure how to handle the permissions check in [these requirements mentioned here](https://liferay.atlassian.net/browse/LPD-22768) in the React side. Should I pass that info in from the backend? I don't think the other areas where we had the timeline item dropdown options previously implemented (in the recent tickets that I think Noor did) had these permission checks either.
