### PR TITLE
LPD-36519 The userId now comes from the service context (LPD-34765) so update the test accordingly

### DIFF
--- a/modules/apps/site/site-admin-test/src/testIntegration/java/com/liferay/site/admin/web/internal/initializer/test/BlankSiteInitializerTest.java
+++ b/modules/apps/site/site-admin-test/src/testIntegration/java/com/liferay/site/admin/web/internal/initializer/test/BlankSiteInitializerTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -56,7 +57,11 @@ public class BlankSiteInitializerTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
-		ServiceContextThreadLocal.pushServiceContext(new ServiceContext());
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUserId(TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 	}
 
 	@After


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36519

# How can you verify that it works?

In `site-admin-test` run `gw testIntegration --tests *.BlankSiteInitializerTest`

@mrjohn1911