### PR TITLE
LPD-37997 Site settings with repeated languages after changing Locale settings for instance

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteLanguageConfiguration.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteLanguageConfiguration.js
@@ -131,9 +131,11 @@ export default function SiteLanguageConfiguration({
 						{Liferay.Language.get('available-languages')}
 					</div>
 
-					{initialCurrentLanguages
-						.map((language) => language.label)
-						.join(', ')}
+					<p>
+						{initialCurrentLanguages
+							.map((language) => language.label)
+							.join(', ')}
+					</p>
 				</div>
 			) : (
 				<fieldset>

--- a/modules/test/playwright/pages/configuration-admin-web/LocalizationSiteSettingsPage.ts
+++ b/modules/test/playwright/pages/configuration-admin-web/LocalizationSiteSettingsPage.ts
@@ -9,12 +9,16 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {SiteSettingsPage} from './SiteSettingsPage';
 
 export class LocalizationSiteSettingsPage {
+	readonly availableLanguages: Locator;
 	readonly languageSelector: Locator;
 	readonly page: Page;
 	readonly saveButton: Locator;
 	readonly siteSettingsPage: SiteSettingsPage;
 
 	constructor(page: Page) {
+		this.availableLanguages = page.locator(
+			'[id="_com_liferay_site_admin_web_portlet_SiteSettingsPortlet_siteLanguageConfiguration"]'
+		);
 		this.languageSelector = page.getByRole('combobox');
 		this.page = page;
 		this.saveButton = page.getByRole('button', {name: 'Save'});

--- a/modules/test/playwright/tests/site-admin-web/fixtures/localizationPagesTest.ts
+++ b/modules/test/playwright/tests/site-admin-web/fixtures/localizationPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {LocalizationInstanceSettingsPage} from '../pages/LocalizationInstanceSettingsPage';
+
+const localizationPagesTest = test.extend<{
+	localizationInstanceSettingsPage: LocalizationInstanceSettingsPage;
+}>({
+	localizationInstanceSettingsPage: async ({page}, use) => {
+		await use(new LocalizationInstanceSettingsPage(page));
+	},
+});
+
+export {localizationPagesTest};

--- a/modules/test/playwright/tests/site-admin-web/pages/LocalizationInstanceSettingsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/pages/LocalizationInstanceSettingsPage.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {InstanceSettingsPage} from '../../../pages/configuration-admin-web/InstanceSettingsPage';
+
+export class LocalizationInstanceSettingsPage {
+	readonly instanceSettingsPage: InstanceSettingsPage;
+	readonly currentLanguages: Locator;
+	readonly defaultLanguage: Locator;
+
+	constructor(page: Page) {
+		this.instanceSettingsPage = new InstanceSettingsPage(page);
+		this.currentLanguages = page.getByLabel('Current');
+		this.defaultLanguage = page.getByRole('option', {selected: true});
+	}
+
+	async goto(configuration) {
+		await this.instanceSettingsPage.goToInstanceSetting(
+			'Localization',
+			configuration
+		);
+	}
+}

--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -5,15 +5,24 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {localizationSiteSettingsPageTest} from '../../fixtures/localizationSiteSettingsPageTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {checkAccessibility} from '../../utils/checkAccessibility';
+import getRandomString from '../../utils/getRandomString';
+import {localizationPagesTest} from '../site-admin-web/fixtures/localizationPagesTest';
 import {selectSiteInitializerPagesTest} from './fixtures/selectSiteInitializerPagesTest';
 
 const test = mergeTests(
+	applicationsMenuPageTest,
+	dataApiHelpersTest,
 	isolatedSiteTest,
+	localizationPagesTest,
 	loginTest(),
-	selectSiteInitializerPagesTest
+	selectSiteInitializerPagesTest,
+	localizationSiteSettingsPageTest
 );
 
 test('Check select site initializers accessibility', async ({
@@ -40,4 +49,102 @@ test('Check select site initializers accessibility', async ({
 		page,
 		selectors: ['.portlet-content-container'],
 	});
+});
+
+test('Check current site locales based on instance locales', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	localizationInstanceSettingsPage,
+	localizationSiteSettingsPage,
+	page,
+}) => {
+	const site = await apiHelpers.headlessSite.createSite({
+		name: getRandomString(),
+	});
+
+	apiHelpers.data.push({id: site.id, type: 'site'});
+
+	await localizationInstanceSettingsPage.goto('Language');
+
+	let currentInstanceLanguages =
+		await localizationInstanceSettingsPage.currentLanguages.allInnerTexts();
+
+	currentInstanceLanguages = currentInstanceLanguages[0].split('\n');
+
+	let defaultInstanceLanguage =
+		await localizationInstanceSettingsPage.defaultLanguage.textContent();
+
+	defaultInstanceLanguage = defaultInstanceLanguage.replace(/[\n\t]/g, '');
+
+	for (let i = 0; i < currentInstanceLanguages.length; i++) {
+		await expect
+			.soft(
+				page
+					.getByLabel('Current')
+					.getByRole('option', {name: currentInstanceLanguages[i]})
+			)
+			.toBeVisible();
+	}
+
+	await applicationsMenuPage.goToSite(site.name);
+
+	await localizationSiteSettingsPage.goto();
+
+	for (let i = 0; i < currentInstanceLanguages.length; i++) {
+		await expect
+			.soft(localizationSiteSettingsPage.availableLanguages)
+			.toContainText(currentInstanceLanguages[i]);
+	}
+
+	currentInstanceLanguages = currentInstanceLanguages.filter(
+		(item) => item !== defaultInstanceLanguage
+	);
+
+	await localizationInstanceSettingsPage.goto('Language');
+
+	for (let i = 0; i < currentInstanceLanguages.length; i++) {
+		await page.waitForTimeout(500);
+		await page
+			.getByLabel('Current')
+			.selectOption(currentInstanceLanguages[i]);
+		await page
+			.getByRole('button', {
+				name: 'Move selected items from Current to Available',
+			})
+			.click({force: true});
+	}
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await page.waitForTimeout(500);
+
+	await applicationsMenuPage.goToSite(site.name);
+
+	await localizationSiteSettingsPage.goto();
+
+	await expect
+		.soft(localizationSiteSettingsPage.availableLanguages)
+		.toContainText(defaultInstanceLanguage);
+
+	for (let i = 0; i < currentInstanceLanguages.length; i++) {
+		await expect
+			.soft(localizationSiteSettingsPage.availableLanguages)
+			.not.toContainText(currentInstanceLanguages[i]);
+	}
+
+	await localizationInstanceSettingsPage.goto('Language');
+
+	for (let i = 0; i < currentInstanceLanguages.length; i++) {
+		await page.waitForTimeout(500);
+		await page
+			.getByLabel('Available')
+			.selectOption(currentInstanceLanguages[i]);
+		await page
+			.getByRole('button', {
+				name: 'Move selected items from Available to Current',
+			})
+			.click({force: true});
+	}
+
+	await page.getByRole('button', {name: 'Save'}).click();
 });

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -2464,9 +2464,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			ListUtil.fromArray(oldLanguageIdsArray),
 			ListUtil.fromArray(StringUtil.split(newLanguageIds)));
 
-		if (ListUtil.isEmpty(removedLanguageIds)) {
-			return;
-		}
+		List<String> addedLanguageIds = ListUtil.remove(
+			ListUtil.fromArray(StringUtil.split(newLanguageIds)),
+			ListUtil.fromArray(oldLanguageIdsArray));
 
 		List<Group> groups = _groupLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -2480,9 +2480,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					GroupTable.INSTANCE.active.eq(true)
 				).and(
 					GroupTable.INSTANCE.site.eq(true)
-				).and(
-					GroupTable.INSTANCE.typeSettings.like(
-						"%inheritLocales=false%")
 				)
 			));
 
@@ -2490,31 +2487,66 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			UnicodeProperties groupTypeSettingsUnicodeProperties =
 				group.getTypeSettingsProperties();
 
+			boolean inheritLocales = GetterUtil.getBoolean(
+				groupTypeSettingsUnicodeProperties.getProperty(
+					"inheritLocales"));
+
+			if (inheritLocales) {
+				_updateGroupLocales(
+					group, groupTypeSettingsUnicodeProperties, newLanguageIds);
+
+				return;
+			}
+
 			String[] groupLanguageIds = StringUtil.split(
 				groupTypeSettingsUnicodeProperties.getProperty(
 					PropsKeys.LOCALES));
 
 			boolean updateLocales = false;
 
-			for (String removedLanguageId : removedLanguageIds) {
-				if (ArrayUtil.contains(groupLanguageIds, removedLanguageId)) {
-					groupLanguageIds = ArrayUtil.remove(
-						groupLanguageIds, removedLanguageId);
+			if (ListUtil.isNotEmpty(removedLanguageIds)) {
+				for (String removedLanguageId : removedLanguageIds) {
+					if (ArrayUtil.contains(
+							groupLanguageIds, removedLanguageId)) {
 
-					updateLocales = true;
+						groupLanguageIds = ArrayUtil.remove(
+							groupLanguageIds, removedLanguageId);
+
+						updateLocales = true;
+					}
+				}
+			}
+			else {
+				for (String addedLanguageId : addedLanguageIds) {
+					if (!ArrayUtil.contains(
+							groupLanguageIds, addedLanguageId)) {
+
+						groupLanguageIds = ArrayUtil.append(
+							groupLanguageIds, addedLanguageId);
+
+						updateLocales = true;
+					}
 				}
 			}
 
 			if (updateLocales) {
-				LanguageUtil.resetAvailableGroupLocales(group.getGroupId());
-
-				groupTypeSettingsUnicodeProperties.setProperty(
-					PropsKeys.LOCALES,
+				_updateGroupLocales(
+					group, groupTypeSettingsUnicodeProperties,
 					StringUtil.merge(groupLanguageIds, StringPool.COMMA));
-
-				_groupLocalService.updateGroup(group);
 			}
 		}
+	}
+
+	private void _updateGroupLocales(
+		Group group, UnicodeProperties groupTypeSettingsUnicodeProperties,
+		String newLanguageIds) {
+
+		LanguageUtil.resetAvailableGroupLocales(group.getGroupId());
+
+		groupTypeSettingsUnicodeProperties.setProperty(
+			PropsKeys.LOCALES, newLanguageIds);
+
+		_groupLocalService.updateGroup(group);
 	}
 
 	private static final String _DEFAULT_VIRTUAL_HOST = "localhost";

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4013,7 +4013,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				PropsKeys.LOCALES,
 				StringUtil.merge(
 					LocaleUtil.toLanguageIds(
-						LanguageUtil.getAvailableLocales(groupId))));
+						LanguageUtil.getAvailableLocales())));
 		}
 
 		String newLanguageIds = typeSettingsUnicodeProperties.getProperty(


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-37997

### How am I fixing it?
This change is basically removing the logic for selecting the current locale in the Site Settings from DisplaySettingsDisplayContext since this logic is already present in the SiteLanguageConfiguration file.

### How can you verify that it works?
Reproduce the steps described in the ticket and verify that the issue is no longer reproducing or run the `Check current site locales based on instance locales` test in `modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts`.