### PR TITLE
LPD-37537 Navigation Menu portlet preferences not propagating from site template correctly

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -14,8 +14,10 @@ import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -28,6 +30,7 @@ import com.liferay.site.navigation.model.SiteNavigationMenu;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.ReadOnlyException;
@@ -119,47 +122,73 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 				PortletDataHandlerKeys.PORTLET_DATA) &&
 			MergeLayoutPrototypesThreadLocal.isInProgress()) {
 
-			String siteNavigationMenuExternalReferenceCode = StringPool.BLANK;
+			String siteNavigationMenuExternalReferenceCode =
+				portletPreferences.getValue(
+					"siteNavigationMenuExternalReferenceCode", null);
 
-			long originalPlid = MapUtil.getLong(
-				portletDataContext.getParameterMap(), "portletPreferencePlid");
+			SiteNavigationMenu siteNavigationMenu =
+				_siteNavigationMenuLocalService.
+					fetchSiteNavigationMenuByExternalReferenceCode(
+						siteNavigationMenuExternalReferenceCode,
+						portletDataContext.getSourceGroupId());
 
-			List<com.liferay.portal.kernel.model.PortletPreferences>
-				serviceBuilderPortletPreferencesList = null;
+			if (siteNavigationMenu != null) {
+				Map<Long, Long> groupIds =
+					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+						Group.class);
 
-			if (originalPlid == PortletKeys.PREFS_PLID_SHARED) {
-				serviceBuilderPortletPreferencesList =
-					_portletPreferencesLocalService.getPortletPreferences(
-						PortletKeys.PREFS_PLID_SHARED,
-						portletDataContext.getPortletId());
+				long groupId = MapUtil.getLong(
+					groupIds,
+					GetterUtil.getLong(siteNavigationMenu.getGroupId()));
+
+				SiteNavigationMenu existingSiteNavigationMenu =
+					_siteNavigationMenuLocalService.
+						fetchSiteNavigationMenuByExternalReferenceCode(
+							siteNavigationMenuExternalReferenceCode, groupId);
+
+				if (existingSiteNavigationMenu == null) {
+					try {
+						Layout layout = layoutLocalService.getLayout(
+							portletDataContext.getPlid());
+
+						PortletPreferences existingPortletPreferences = null;
+
+						if (layout.isPortletEmbedded(
+								portletDataContext.getPortletId(),
+								layout.getGroupId())) {
+
+							existingPortletPreferences =
+								PortletPreferencesFactoryUtil.
+									getLayoutPortletSetup(
+										layout.getCompanyId(),
+										layout.getGroupId(),
+										PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+										PortletKeys.PREFS_PLID_SHARED,
+										portletDataContext.getPortletId(),
+										null);
+						}
+						else {
+							existingPortletPreferences =
+								PortletPreferencesFactoryUtil.getPortletSetup(
+									layout, portletDataContext.getPortletId(),
+									StringPool.BLANK);
+						}
+
+						siteNavigationMenuExternalReferenceCode =
+							existingPortletPreferences.getValue(
+								"siteNavigationMenuExternalReferenceCode",
+								StringPool.BLANK);
+					}
+					catch (PortalException portalException) {
+						PortletDataException portletDataException =
+							new PortletDataException(portalException);
+
+						throw portletDataException;
+					}
+				}
 			}
 			else {
-				serviceBuilderPortletPreferencesList =
-					_portletPreferencesLocalService.getPortletPreferences(
-						portletDataContext.getPlid(),
-						portletDataContext.getPortletId());
-			}
-
-			if (!serviceBuilderPortletPreferencesList.isEmpty()) {
-				for (com.liferay.portal.kernel.model.PortletPreferences
-						serviceBuilderPortletPreferences :
-							serviceBuilderPortletPreferencesList) {
-
-					if (serviceBuilderPortletPreferences.getCompanyId() !=
-							portletDataContext.getCompanyId()) {
-
-						continue;
-					}
-
-					PortletPreferences originalPortletPreferences =
-						_portletPreferenceValueLocalService.getPreferences(
-							serviceBuilderPortletPreferences);
-
-					siteNavigationMenuExternalReferenceCode =
-						originalPortletPreferences.getValue(
-							"siteNavigationMenuExternalReferenceCode",
-							StringPool.BLANK);
-				}
+				siteNavigationMenuExternalReferenceCode = StringPool.BLANK;
 			}
 
 			try {
@@ -181,6 +210,9 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 
 		return portletPreferences;
 	}
+
+	@Reference
+	protected LayoutLocalService layoutLocalService;
 
 	private void _importSiteNavigationMenuReference(
 			PortletDataContext portletDataContext)
@@ -217,13 +249,6 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 
 	@Reference(target = "(name=CommonPortletDisplayTemplateImportCapability)")
 	private Capability _importCapability;
-
-	@Reference(unbind = "-")
-	private PortletPreferencesLocalService _portletPreferencesLocalService;
-
-	@Reference(unbind = "-")
-	private PortletPreferenceValueLocalService
-		_portletPreferenceValueLocalService;
 
 	@Reference(unbind = "-")
 	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
@@ -8,14 +8,11 @@ package com.liferay.site.navigation.menu.web.internal.exportimport.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
-import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
-import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -23,10 +20,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portlet.display.template.test.util.BaseExportImportTestCase;
 import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
@@ -151,69 +146,6 @@ public class SiteNavigationMenuExportImportTest
 			"1",
 			portletPreferences.getValue(
 				"siteNavigationMenuType", StringPool.BLANK));
-	}
-
-	@Test
-	public void testSiteTemplatePropagationWhenDuplicateSiteNavigationMenusExist()
-		throws Exception {
-
-		Group group = GroupTestUtil.addGroup();
-
-		LayoutSetPrototype layoutSetPrototype =
-			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
-
-		Layout prototypeLayout = LayoutTestUtil.addTypePortletLayout(
-			layoutSetPrototype.getGroup(), true);
-
-		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
-
-		_sites.updateLayoutSetPrototypesLinks(
-			group, layoutSetPrototype.getLayoutSetPrototypeId(), 0, true, true);
-
-		Layout layout = _layoutLocalService.getFriendlyURLLayout(
-			group.getGroupId(), false, prototypeLayout.getFriendlyURL());
-
-		layout.setLayoutPrototypeUuid(prototypeLayout.getUuid());
-		layout.setLayoutPrototypeLinkEnabled(true);
-
-		_layoutLocalService.updateLayout(layout);
-
-		String name = RandomTestUtil.randomString();
-
-		SiteNavigationMenuTestUtil.addSiteNavigationMenu(group, name);
-
-		LayoutTestUtil.addPortletToLayout(
-			prototypeLayout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
-			HashMapBuilder.put(
-				"siteNavigationMenuExternalReferenceCode",
-				() -> {
-					SiteNavigationMenu siteNavigationMenu =
-						SiteNavigationMenuTestUtil.addSiteNavigationMenu(
-							layoutSetPrototype.getGroup(), name);
-
-					return new String[] {
-						siteNavigationMenu.getExternalReferenceCode()
-					};
-				}
-			).build());
-
-		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
-		_sites.mergeLayoutSetPrototypeLayouts(
-			group, group.getPublicLayoutSet());
-
-		LayoutSet layoutSet = layoutSetPrototype.getLayoutSet();
-
-		UnicodeProperties layoutSetPrototypeSettingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		Assert.assertEquals(
-			0,
-			GetterUtil.getInteger(
-				layoutSetPrototypeSettingsUnicodeProperties.getProperty(
-					Sites.MERGE_FAIL_COUNT)));
 	}
 
 	private void _publishLayouts() throws Exception {

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.navigation.menu.web.internal.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
+import com.liferay.sites.kernel.util.Sites;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Moral
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class SiteNavigationMenuPropagationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testSiteTemplatePropagationWhenDuplicateSiteNavigationMenusExist()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		LayoutSetPrototype layoutSetPrototype =
+			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+
+		Layout prototypeLayout = LayoutTestUtil.addTypePortletLayout(
+			layoutSetPrototype.getGroup(), true);
+
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		_sites.updateLayoutSetPrototypesLinks(
+			group, layoutSetPrototype.getLayoutSetPrototypeId(), 0, true, true);
+
+		Layout layout = _layoutLocalService.getFriendlyURLLayout(
+			group.getGroupId(), false, prototypeLayout.getFriendlyURL());
+
+		layout.setLayoutPrototypeUuid(prototypeLayout.getUuid());
+		layout.setLayoutPrototypeLinkEnabled(true);
+
+		_layoutLocalService.updateLayout(layout);
+
+		String name = RandomTestUtil.randomString();
+
+		SiteNavigationMenuTestUtil.addSiteNavigationMenu(group, name);
+
+		LayoutTestUtil.addPortletToLayout(
+			prototypeLayout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"siteNavigationMenuExternalReferenceCode",
+				() -> {
+					SiteNavigationMenu siteNavigationMenu =
+						SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+							layoutSetPrototype.getGroup(), name);
+
+					return new String[] {
+						siteNavigationMenu.getExternalReferenceCode()
+					};
+				}
+			).build());
+
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
+
+		_sites.mergeLayoutSetPrototypeLayouts(
+			group, group.getPublicLayoutSet());
+
+		LayoutSet layoutSet = layoutSetPrototype.getLayoutSet();
+
+		UnicodeProperties layoutSetPrototypeSettingsUnicodeProperties =
+			layoutSet.getSettingsProperties();
+
+		Assert.assertEquals(
+			0,
+			GetterUtil.getInteger(
+				layoutSetPrototypeSettingsUnicodeProperties.getProperty(
+					Sites.MERGE_FAIL_COUNT)));
+	}
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private Sites _sites;
+
+}

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -8,6 +8,7 @@ package com.liferay.site.navigation.menu.web.internal.exportimport.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -28,7 +30,10 @@ import com.liferay.site.navigation.model.SiteNavigationMenu;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
 import com.liferay.sites.kernel.util.Sites;
 
+import javax.portlet.PortletPreferences;
+
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,58 +53,64 @@ public class SiteNavigationMenuPropagationTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Test
-	public void testSiteTemplatePropagationWhenDuplicateSiteNavigationMenusExist()
-		throws Exception {
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
 
-		Group group = GroupTestUtil.addGroup();
+		_layoutSetPrototype = LayoutTestUtil.addLayoutSetPrototype(
+			RandomTestUtil.randomString());
 
-		LayoutSetPrototype layoutSetPrototype =
-			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
-
-		Layout prototypeLayout = LayoutTestUtil.addTypePortletLayout(
-			layoutSetPrototype.getGroup(), true);
+		_prototypeLayout = LayoutTestUtil.addTypePortletLayout(
+			_layoutSetPrototype.getGroup(), true);
 
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
 		_sites.updateLayoutSetPrototypesLinks(
-			group, layoutSetPrototype.getLayoutSetPrototypeId(), 0, true, true);
+			_group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+			true);
 
-		Layout layout = _layoutLocalService.getFriendlyURLLayout(
-			group.getGroupId(), false, prototypeLayout.getFriendlyURL());
+		_layout = _layoutLocalService.getFriendlyURLLayout(
+			_group.getGroupId(), false, _prototypeLayout.getFriendlyURL());
 
-		layout.setLayoutPrototypeUuid(prototypeLayout.getUuid());
-		layout.setLayoutPrototypeLinkEnabled(true);
+		_layout.setLayoutPrototypeUuid(_prototypeLayout.getUuid());
+		_layout.setLayoutPrototypeLinkEnabled(true);
 
-		_layoutLocalService.updateLayout(layout);
+		_layout = _layoutLocalService.updateLayout(_layout);
+
+		_siteNavigationMenu1 = SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+			_layoutSetPrototype.getGroup(), RandomTestUtil.randomString());
+
+		_siteNavigationMenu2 = SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+			_layoutSetPrototype.getGroup(), RandomTestUtil.randomString());
+
+		SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+			_group, _siteNavigationMenu1.getExternalReferenceCode(),
+			_siteNavigationMenu1.getName());
+
+		_portletId = _addSiteNavigationMenuWidgetToPage(
+			_siteNavigationMenu1.getExternalReferenceCode());
+
+		_propagateLayout();
+	}
+
+	@Test
+	public void testSiteTemplatePropagationWhenDuplicateSiteNavigationMenusExist()
+		throws Exception {
 
 		String name = RandomTestUtil.randomString();
 
-		SiteNavigationMenuTestUtil.addSiteNavigationMenu(group, name);
+		SiteNavigationMenuTestUtil.addSiteNavigationMenu(_group, name);
 
-		LayoutTestUtil.addPortletToLayout(
-			prototypeLayout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
-			HashMapBuilder.put(
-				"siteNavigationMenuExternalReferenceCode",
-				() -> {
-					SiteNavigationMenu siteNavigationMenu =
-						SiteNavigationMenuTestUtil.addSiteNavigationMenu(
-							layoutSetPrototype.getGroup(), name);
+		SiteNavigationMenu siteNavigationMenu =
+			SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+				_layoutSetPrototype.getGroup(), name);
 
-					return new String[] {
-						siteNavigationMenu.getExternalReferenceCode()
-					};
-				}
-			).build());
+		_addSiteNavigationMenuWidgetToPage(
+			siteNavigationMenu.getExternalReferenceCode());
 
-		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+		_propagateLayout();
 
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
-		_sites.mergeLayoutSetPrototypeLayouts(
-			group, group.getPublicLayoutSet());
-
-		LayoutSet layoutSet = layoutSetPrototype.getLayoutSet();
+		LayoutSet layoutSet = _layoutSetPrototype.getLayoutSet();
 
 		UnicodeProperties layoutSetPrototypeSettingsUnicodeProperties =
 			layoutSet.getSettingsProperties();
@@ -111,11 +122,105 @@ public class SiteNavigationMenuPropagationTest {
 					Sites.MERGE_FAIL_COUNT)));
 	}
 
+	@Test
+	public void testSiteTemplatePropagationWhenSiteNavigationMenuDoesNotExist()
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreference(
+			_prototypeLayout, _portletId,
+			"siteNavigationMenuExternalReferenceCode",
+			_siteNavigationMenu2.getExternalReferenceCode());
+
+		_propagateLayout();
+
+		_assertSiteNavigationMenuExternalReferenceCode(
+			_siteNavigationMenu1.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testSiteTemplatePropagationWithDifferentSiteNavigationMenu()
+		throws Exception {
+
+		SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+			_group, _siteNavigationMenu2.getExternalReferenceCode(),
+			_siteNavigationMenu2.getName());
+
+		LayoutTestUtil.updateLayoutPortletPreference(
+			_prototypeLayout, _portletId,
+			"siteNavigationMenuExternalReferenceCode",
+			_siteNavigationMenu2.getExternalReferenceCode());
+
+		_propagateLayout();
+
+		_assertSiteNavigationMenuExternalReferenceCode(
+			_siteNavigationMenu2.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testSiteTemplatePropagationWithRemovedSiteNavigationMenu()
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreference(
+			_prototypeLayout, _portletId,
+			"siteNavigationMenuExternalReferenceCode", StringPool.BLANK);
+
+		_propagateLayout();
+
+		_assertSiteNavigationMenuExternalReferenceCode(StringPool.BLANK);
+	}
+
+	private String _addSiteNavigationMenuWidgetToPage(
+			String siteNavigationMenuExternalReferenceCode)
+		throws Exception {
+
+		return LayoutTestUtil.addPortletToLayout(
+			_prototypeLayout,
+			SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"siteNavigationMenuExternalReferenceCode",
+				new String[] {siteNavigationMenuExternalReferenceCode}
+			).build());
+	}
+
+	private void _assertSiteNavigationMenuExternalReferenceCode(
+		String siteNavigationMenuExternalReferenceCode) {
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_group.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _layout.getPlid(),
+				_portletId);
+
+		Assert.assertEquals(
+			siteNavigationMenuExternalReferenceCode,
+			portletPreferences.getValue(
+				"siteNavigationMenuExternalReferenceCode", StringPool.BLANK));
+	}
+
+	private void _propagateLayout() throws Exception {
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
+
+		_sites.mergeLayoutSetPrototypeLayouts(
+			_group, _group.getPublicLayoutSet());
+	}
+
+	private Group _group;
+	private Layout _layout;
+
 	@Inject
 	private LayoutLocalService _layoutLocalService;
 
+	private LayoutSetPrototype _layoutSetPrototype;
+	private String _portletId;
+
 	@Inject
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	private Layout _prototypeLayout;
+	private SiteNavigationMenu _siteNavigationMenu1;
+	private SiteNavigationMenu _siteNavigationMenu2;
 
 	@Inject
 	private Sites _sites;

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/test/util/SiteNavigationMenuTestUtil.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/test/util/SiteNavigationMenuTestUtil.java
@@ -90,4 +90,14 @@ public class SiteNavigationMenuTestUtil {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
+	public static SiteNavigationMenu addSiteNavigationMenu(
+			Group group, String externalReferenceCode, String name)
+		throws PortalException {
+
+		return SiteNavigationMenuLocalServiceUtil.addSiteNavigationMenu(
+			externalReferenceCode, TestPropsValues.getUserId(),
+			group.getGroupId(), name,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37537

# How am I fixing it?

Instead of trying to find the associated portlet preferences and looping through them this will now find the Navigation Menu itself. If the menu exists then it will be used otherwise the preferences will not be updated.

# How can you verify that it works?

In `modules/apps/site-navigation/site-navigation-test` run `gw testIntegration --tests *.SiteNavigationMenuPropagationTest`