### PR TITLE
LPD-37652 Move site initializer tests back to Solutions until they are assigned to their new teams

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -11659,28 +11659,28 @@
         Breadcrumb Widget,\
         Click to Chat,\
         Friendly URL Service,\
+        Navigation Menus,\
+        Site Initializer Extender,\
+        Sitemap Protocol,\
+        Sites Administration,\
+        Sites Directory Widget,\
+        Upgrades Site Management,\
+        URL Redirections
+
+    testray.team.solutions.component.names=\
         Liferay Learn Site Initializer,\
         Liferay Online,\
         Liferaybotics,\
+        Marketplace,\
         Masterclass,\
-        Navigation Menus,\
         OSB Site Initializer EVP,\
-        Site Initializer Extender,\
+        Patching Tool,\
         Site Initializer Liferay Marketplace,\
         Site Initializer Raylife AP,\
         Site Initializer Raylife D2C,\
         Site Initializer Testray,\
-        Sitemap Protocol,\
-        Sites Administration,\
-        Sites Directory Widget,\
         Team Extranet,\
-        Upgrades Site Management,\
-        Upgrades Solutions,\
-        URL Redirections
-
-    testray.team.solutions.component.names=\
-        Marketplace,\
-        Patching Tool
+        Upgrades Solutions
 
 ##
 ## Utilities


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-37652

As part of organizing test suites this moves the site initializer templates back to the Solutions team for the time being until a consensus is reached on which teams will support which templates.