### PR TITLE
LPD-38937 Use ConfigurationTestUtil to reduce flakiness and ensure the configuration has been updated before trying to retrieve it

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/configuration/manager/test/FriendlyURLSeparatorConfigurationManagerTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/configuration/manager/test/FriendlyURLSeparatorConfigurationManagerTest.java
@@ -118,9 +118,21 @@ public class FriendlyURLSeparatorConfigurationManagerTest {
 		JSONObject friendlyURLSeparatorsJSONObject = JSONUtil.put(
 			JournalArticle.class.getName(), "/test1/");
 
-		_friendlyURLSeparatorConfigurationManager.
-			updateFriendlyURLSeparatorCompanyConfiguration(
-				_companyId, friendlyURLSeparatorsJSONObject.toString());
+		ConfigurationTestUtil.updateConfiguration(
+			FriendlyURLSeparatorCompanyConfiguration.class.getName(),
+			() -> {
+				_friendlyURLSeparatorConfigurationManager.
+					updateFriendlyURLSeparatorCompanyConfiguration(
+						_companyId, friendlyURLSeparatorsJSONObject.toString());
+
+				Configuration configuration =
+					_configurationAdmin.getConfiguration(
+						FriendlyURLSeparatorCompanyConfiguration.class.
+							getName(),
+						StringPool.QUESTION);
+
+				configuration.update();
+			});
 
 		FriendlyURLSeparatorCompanyConfiguration
 			friendlyURLSeparatorCompanyConfiguration =


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38937

# How am I fixing it?

The test's flakiness comes from the configuration not being updated in time for the retrieval call. Using the ConfigurationTestUtil now gives it time and emulates the logic in testGetFriendlyURLSeparatorsJSON.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.FriendlyURLSeparatorConfigurationManagerTest`