### PR TITLE
LPD-38936 Update to new locator due to changes in Web Content UI (see LPD-35921)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
@@ -275,11 +275,15 @@ definition {
 			pageName = "Test Source Page",
 			pageType = "Pages");
 
-		PortletEntry.changeLocale(locale = "es-ES");
+		PortletEntry.changeLocale(
+			locale = "es-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 
-		PortletEntry.changeLocale(locale = "ca-ES");
+		PortletEntry.changeLocale(
+			locale = "ca-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 
@@ -297,11 +301,15 @@ definition {
 			version = "1.1",
 			webContentTitle = "Web Content Article");
 
-		PortletEntry.changeLocale(locale = "es-ES");
+		PortletEntry.changeLocale(
+			locale = "es-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "");
 
-		PortletEntry.changeLocale(locale = "ca-ES");
+		PortletEntry.changeLocale(
+			locale = "ca-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "");
 
@@ -313,11 +321,15 @@ definition {
 			version = "1.1",
 			webContentTitle = "Web Content Article");
 
-		PortletEntry.changeLocale(locale = "es-ES");
+		PortletEntry.changeLocale(
+			locale = "es-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 
-		PortletEntry.changeLocale(locale = "ca-ES");
+		PortletEntry.changeLocale(
+			locale = "ca-ES",
+			translated = "true");
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38936

# How am I fixing it?

The Web Content UI has changed so the locator needs to be updated. The same fix was applied in LPD-35921.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=FriendlyURLService#CanReAddSameFriendlyURLForDifferentLanguageInWebContentAfterRemoveTheTranslation`