### PR TITLE
LPD-39408 Pagination on Custom Site Templates at Site creation refreshes the page

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
@@ -128,6 +128,8 @@ public class SelectSiteInitializerDisplayContext {
 			"/site_admin/select_site_initializer"
 		).setRedirect(
 			getBackURL()
+		).setTabs1(
+			_getTabs1()
 		).setParameter(
 			"backURLTitle",
 			ParamUtil.getString(_httpServletRequest, "backURLTitle")

--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -5,15 +5,21 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {sitesPageTest} from '../../fixtures/sitesPageTest';
+import {LayoutSetPrototype} from '../../helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
 import {checkAccessibility} from '../../utils/checkAccessibility';
+import getRandomString from '../../utils/getRandomString';
 import {selectSiteInitializerPagesTest} from './fixtures/selectSiteInitializerPagesTest';
 
 const test = mergeTests(
+	apiHelpersTest,
 	isolatedSiteTest,
 	loginTest(),
-	selectSiteInitializerPagesTest
+	selectSiteInitializerPagesTest,
+	sitesPageTest
 );
 
 test('Check select site initializers accessibility', async ({
@@ -41,3 +47,48 @@ test('Check select site initializers accessibility', async ({
 		selectors: ['.portlet-content-container'],
 	});
 });
+
+test(
+	'Ensure pagination works properly for Custom Site Templates tab',
+	{
+		tag: '@LPD-39408',
+	},
+	async ({apiHelpers, page, selectSiteInitializerPage, sitesPage}) => {
+		const layoutSetPrototypes = [];
+
+		for (let i = 0; i < 5; i++) {
+			const layoutSetPrototype: LayoutSetPrototype =
+				await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+					getRandomString()
+				);
+
+			layoutSetPrototypes.push(layoutSetPrototype);
+		}
+
+		await selectSiteInitializerPage.goto();
+
+		await sitesPage.customSiteTemplatesItem.click();
+
+		await page.getByLabel('Items per Page').click();
+
+		await page.getByRole('option', {name: '4  Entries per Page'}).click();
+
+		await expect(
+			page.getByText('Showing 1 to 4 of 5 entries.')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Provided by Liferay'})
+		).not.toHaveClass(/active/);
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Custom Site Templates'})
+		).toHaveClass(/active/);
+
+		for (let i = 0; i < layoutSetPrototypes.length; i++) {
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.deleteLayoutSetPrototypes(
+				layoutSetPrototypes[i].layoutSetPrototypeId.toString()
+			);
+		}
+	}
+);

--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -6,7 +6,6 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
-import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {sitesPageTest} from '../../fixtures/sitesPageTest';
 import {LayoutSetPrototype} from '../../helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
@@ -16,7 +15,6 @@ import {selectSiteInitializerPagesTest} from './fixtures/selectSiteInitializerPa
 
 const test = mergeTests(
 	apiHelpersTest,
-	isolatedSiteTest,
 	loginTest(),
 	selectSiteInitializerPagesTest,
 	sitesPageTest
@@ -25,12 +23,11 @@ const test = mergeTests(
 test('Check select site initializers accessibility', async ({
 	page,
 	selectSiteInitializerPage,
-	site,
 }) => {
 
 	// Go to site initializers selection page
 
-	await selectSiteInitializerPage.goto(site.friendlyUrlPath);
+	await selectSiteInitializerPage.goto();
 
 	// Check all of them have correct label
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39408

# How am I fixing it?

The tab the user is currently on is missing from the portlet URL. This adds the parameter so that they stay in the current tab when clicking on search results.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-39408'`