### PR TITLE
LPD-38654 Publication bar disappears after clicking on published timeline icon

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
@@ -231,6 +231,19 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 						"getCTEntry", _ctCollectionModelResourcePermission);
 				}
 			).put(
+				"delete",
+				() -> {
+					if (ctCollection.getStatus() !=
+							WorkflowConstants.STATUS_DRAFT) {
+
+						return null;
+					}
+
+					return addAction(
+						ActionKeys.DELETE, ctEntry.getCtCollectionId(),
+						"getCTEntry", _ctCollectionModelResourcePermission);
+				}
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, ctEntry.getCtCollectionId(), "getCTEntry",

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
@@ -660,6 +660,16 @@ public class ChangeTrackingIndicatorDynamicInclude extends BaseDynamicInclude {
 			data.put("timelineClassNameId", classNameId);
 			data.put("timelineClassPK", classPK);
 			data.put(
+				"timelineDeleteURL",
+				PortletURLBuilder.create(
+					_portal.getControlPanelPortletURL(
+						httpServletRequest, themeDisplay.getScopeGroup(),
+						CTPortletKeys.PUBLICATIONS, 0, 0,
+						PortletRequest.ACTION_PHASE)
+				).setActionName(
+					"/change_tracking/delete_ct_collection"
+				).buildString());
+			data.put(
 				"timelineEditURL",
 				PortletURLBuilder.create(
 					_portal.getControlPanelPortletURL(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
@@ -669,9 +669,13 @@ public class ChangeTrackingIndicatorDynamicInclude extends BaseDynamicInclude {
 				).setActionName(
 					"/change_tracking/delete_ct_collection"
 				).buildString());
-			data.put(
-				"timelineEditURL",
-				PortletURLBuilder.create(
+
+			String timelineEditURL = null;
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					themeDisplay.getCompanyId(), "LPD-20556")) {
+
+				timelineEditURL = PortletURLBuilder.create(
 					_portal.getControlPanelPortletURL(
 						httpServletRequest, themeDisplay.getScopeGroup(),
 						CTPortletKeys.PUBLICATIONS, 0, 0,
@@ -680,7 +684,22 @@ public class ChangeTrackingIndicatorDynamicInclude extends BaseDynamicInclude {
 					"/change_tracking/checkout_ct_collection"
 				).setRedirect(
 					_portal.getCurrentURL(httpServletRequest)
-				).buildString());
+				).buildString();
+			}
+			else {
+				timelineEditURL = PortletURLBuilder.create(
+					_portal.getControlPanelPortletURL(
+						httpServletRequest, themeDisplay.getScopeGroup(),
+						CTPortletKeys.PUBLICATIONS, 0, 0,
+						PortletRequest.RENDER_PHASE)
+				).setMVCRenderCommandName(
+					"/change_tracking/edit_ct_collection"
+				).setRedirect(
+					_portal.getCurrentURL(httpServletRequest)
+				).buildString();
+			}
+
+			data.put("timelineEditURL", timelineEditURL);
 			data.put("timelineIconClass", "change-tracking-timeline-icon");
 			data.put("timelineIconName", "time");
 			data.put(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -57,6 +57,7 @@ export default function ChangeTrackingIndicator({
 	spritemap,
 	timelineClassNameId,
 	timelineClassPK,
+	timelineDeleteURL,
 	timelineEditURL,
 	timelineIconClass,
 	timelineIconName,
@@ -747,6 +748,7 @@ export default function ChangeTrackingIndicator({
 						spritemap={spritemap}
 						timelineClassNameId={timelineClassNameId}
 						timelineClassPK={timelineClassPK}
+						timelineDeleteURL={timelineDeleteURL}
 						timelineEditURL={timelineEditURL}
 						timelineItemsURL={timelineItemsURL}
 						viewTimelineHistoryURL={viewTimelineHistoryURL}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -174,7 +174,9 @@ const PublicationTimeline = ({
 												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.update
-												? getEditURL(timelineItem.id)
+												? getEditURL(
+														timelineItem.ctCollectionId
+													)
 												: undefined
 										}
 										namespace={namespace}
@@ -182,7 +184,9 @@ const PublicationTimeline = ({
 											timelineItem.ctCollectionStatus
 												.code ===
 											WORKFLOW_STATUS_APPROVED
-												? getRevertURL(timelineItem.id)
+												? getRevertURL(
+														timelineItem.ctCollectionId
+													)
 												: undefined
 										}
 										reviewURL={
@@ -190,7 +194,9 @@ const PublicationTimeline = ({
 												.code !==
 												WORKFLOW_STATUS_PENDING &&
 											!!timelineItem.actions.get
-												? getReviewURL(timelineItem.id)
+												? getReviewURL(
+														timelineItem.ctCollectionId
+													)
 												: undefined
 										}
 										timelineItem={

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -52,18 +52,6 @@ const PublicationTimeline = ({
 		).toString();
 	};
 
-	const getDeleteURL = (ctCollectionId, url) => {
-		return createPortletURL(url, {
-			ctCollectionId,
-		});
-	};
-
-	const getEditURL = (ctCollectionId, url) => {
-		return createPortletURL(url, {
-			ctCollectionId,
-		});
-	};
-
 	const getRevertURL = (ctCollectionId) => {
 		return createMVCRenderCommandURL(
 			ctCollectionId,
@@ -162,9 +150,12 @@ const PublicationTimeline = ({
 												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.delete
-												? getDeleteURL(
-														timelineItem.ctCollectionId,
-														timelineDeleteURL
+												? createPortletURL(
+														timelineDeleteURL,
+														{
+															ctCollectionId:
+																timelineItem.ctCollectionId,
+														}
 													)
 												: undefined
 										}
@@ -173,9 +164,12 @@ const PublicationTimeline = ({
 												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.update
-												? getEditURL(
-														timelineItem.ctCollectionId,
-														timelineEditURL
+												? createPortletURL(
+														timelineEditURL,
+														{
+															ctCollectionId:
+																timelineItem.ctCollectionId,
+														}
 													)
 												: undefined
 										}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -177,6 +177,7 @@ const PublicationTimeline = ({
 												? getEditURL(timelineItem.id)
 												: undefined
 										}
+										namespace={namespace}
 										revertURL={
 											timelineItem.ctCollectionStatus
 												.code ===
@@ -190,6 +191,11 @@ const PublicationTimeline = ({
 												WORKFLOW_STATUS_PENDING &&
 											!!timelineItem.actions.get
 												? getReviewURL(timelineItem.id)
+												: undefined
+										}
+										timelineItem={
+											timelineDeleteURL
+												? timelineItem
 												: undefined
 										}
 									/>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -58,11 +58,10 @@ const PublicationTimeline = ({
 		});
 	};
 
-	const getEditURL = (ctCollectionId) => {
-		return createMVCRenderCommandURL(
+	const getEditURL = (ctCollectionId, url) => {
+		return createPortletURL(url, {
 			ctCollectionId,
-			'/change_tracking/edit_ct_collection'
-		);
+		});
 	};
 
 	const getRevertURL = (ctCollectionId) => {
@@ -175,7 +174,8 @@ const PublicationTimeline = ({
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.update
 												? getEditURL(
-														timelineItem.ctCollectionId
+														timelineItem.ctCollectionId,
+														timelineEditURL
 													)
 												: undefined
 										}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -26,6 +26,7 @@ const PublicationTimeline = ({
 	spritemap,
 	timelineClassNameId,
 	timelineClassPK,
+	timelineDeleteURL,
 	timelineEditURL,
 	timelineItemsURL,
 	viewTimelineHistoryURL,
@@ -49,6 +50,12 @@ const PublicationTimeline = ({
 				...additionalParams,
 			}
 		).toString();
+	};
+
+	const getDeleteURL = (ctCollectionId, url) => {
+		return createPortletURL(url, {
+			ctCollectionId,
+		});
 	};
 
 	const getEditURL = (ctCollectionId) => {
@@ -156,8 +163,10 @@ const PublicationTimeline = ({
 												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.delete
-												? timelineItem.actions.delete
-														.href
+												? getDeleteURL(
+														timelineItem.ctCollectionId,
+														timelineDeleteURL
+													)
 												: undefined
 										}
 										editURL={

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -152,7 +152,8 @@ const PublicationTimeline = ({
 								{timelineItem.actions ? (
 									<TimelineDropdownMenu
 										deleteURL={
-											timelineItem.status.code ===
+											timelineItem.ctCollectionStatus
+												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.delete
 												? timelineItem.actions.delete
@@ -160,20 +161,23 @@ const PublicationTimeline = ({
 												: undefined
 										}
 										editURL={
-											timelineItem.status.code ===
+											timelineItem.ctCollectionStatus
+												.code ===
 												WORKFLOW_STATUS_DRAFT &&
 											!!timelineItem.actions.update
 												? getEditURL(timelineItem.id)
 												: undefined
 										}
 										revertURL={
-											timelineItem.status.code ===
+											timelineItem.ctCollectionStatus
+												.code ===
 											WORKFLOW_STATUS_APPROVED
 												? getRevertURL(timelineItem.id)
 												: undefined
 										}
 										reviewURL={
-											timelineItem.status.code !==
+											timelineItem.ctCollectionStatus
+												.code !==
 												WORKFLOW_STATUS_PENDING &&
 											!!timelineItem.actions.get
 												? getReviewURL(timelineItem.id)

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
@@ -226,6 +226,12 @@ export default function TimelineDropdownMenu({
 	});
 
 	if (deleteURL) {
+		const deleteRedirectURL = createMVCRenderCommandURL(
+			timelineItem.ctCollectionId,
+			'/change_tracking/view_publications',
+			namespace
+		);
+
 		dropdownItems.push(
 			{type: 'divider'},
 			{
@@ -237,9 +243,7 @@ export default function TimelineDropdownMenu({
 						),
 						onConfirm: (isConfirmed) => {
 							if (isConfirmed) {
-								fetch(deleteURL, {
-									method: 'DELETE',
-								}).then((response) => {
+								fetch(deleteURL).then((response) => {
 									if (response.ok) {
 										showNotification(
 											sub(
@@ -252,11 +256,10 @@ export default function TimelineDropdownMenu({
 											),
 											false,
 											() => {
-												setTimeout(
-													() =>
-														window.location.reload(),
-													1250
-												);
+												setTimeout(() => {
+													window.location.href =
+														deleteRedirectURL;
+												}, 1250);
 											}
 										);
 									}


### PR DESCRIPTION
This is an update for: https://liferay.atlassian.net/browse/LPD-38654

Problem: the publication bar would disappear after clicking on the timeline icon when viewing a document library and the ff was disabled

After fixing it I discovered that the deleteURL was broken, and after that the editURL was broken as well, so this PR aims to fix these issues.