### PR TITLE
LPD-36275 Searchbar in membership requests view is not working

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
@@ -25,6 +25,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "membership-requests"));
 
 <clay:management-toolbar
 	managementToolbarDisplayContext="<%= new ViewMembershipRequestsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, viewMembershipRequestsDisplayContext) %>"
+	showSearch="<%= false %>"
 />
 
 <liferay-ui:success key="membershipReplySent" message="your-reply-will-be-sent-to-the-user-by-email" />

--- a/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
@@ -14,9 +14,11 @@ export class ProductMenuPage {
 	readonly exportButton: Locator;
 	readonly formsButton: Locator;
 	readonly importButton: Locator;
+	readonly membershipsButton: Locator;
 	readonly openProductMenuButton: Locator;
 	readonly page: Page;
 	readonly pagesButton: Locator;
+	readonly peopleButton: Locator;
 	readonly productMenuHeader: Locator;
 	readonly publishingButton: Locator;
 	readonly siteBuilderButton: Locator;
@@ -42,8 +44,12 @@ export class ProductMenuPage {
 		this.importButton = page.getByRole('menuitem', {
 			name: 'Import',
 		});
+		this.membershipsButton = page.getByRole('menuitem', {
+			name: 'Memberships',
+		});
 		this.page = page;
 		this.pagesButton = page.getByRole('menuitem', {name: 'Pages'});
+		this.peopleButton = page.getByRole('menuitem', {name: 'People'});
 		this.openProductMenuButton = page.getByLabel('Open Product Menu');
 		this.closeProductMenuButton = page.getByLabel('Close Product Menu');
 		this.productMenuHeader = page.locator(
@@ -86,6 +92,11 @@ export class ProductMenuPage {
 	async goToForms() {
 		await this.contentAndDataButton.click();
 		await this.formsButton.click();
+	}
+
+	async goToMemberships() {
+		await this.peopleButton.click();
+		await this.membershipsButton.click();
 	}
 
 	async goToPages() {

--- a/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../fixtures/loginTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+
+export const test = mergeTests(loginTest(), productMenuPageTest);
+
+test(
+	'Confirm search bar does not display for membership requests',
+	{
+		tag: '@LPD-36275',
+	},
+	async ({page, productMenuPage}) => {
+		await productMenuPage.openProductMenuIfClosed();
+		await productMenuPage.goToMemberships();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'View Membership Requests',
+			}),
+			trigger: page.getByLabel('Options', {exact: true}),
+		});
+
+		await expect(page.getByPlaceholder('Search for')).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36275

# How am I fixing it?

The search bar's keywords are currently not used in any search query. Since the `MembershipRequest` table currently does not have relevant information to search it was decided to remove the search bar.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-36275'`