### PR TITLE
LPD-39433 Enable for web structures and templates the publication timeline history

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
@@ -703,12 +703,18 @@ public class ChangeTrackingIndicatorDynamicInclude extends BaseDynamicInclude {
 
 			data.put("timelineIconClass", "change-tracking-timeline-icon");
 			data.put("timelineIconName", "time");
-			data.put(
-				"timelineItemsURL",
-				StringBundler.concat(
-					_portal.getPortalURL(themeDisplay),
-					"/o/change-tracking-rest/v1.0/ct-entries/history?",
-					"classNameId=", classNameId, "&classPK=", classPK));
+
+			String timelineItemsURL = StringBundler.concat(
+				_portal.getPortalURL(themeDisplay),
+				"/o/change-tracking-rest/v1.0/ct-entries/history?",
+				"classNameId=", classNameId);
+
+			if (classPK != 0) {
+				timelineItemsURL = StringBundler.concat(
+					timelineItemsURL, "&classPK=", classPK);
+			}
+
+			data.put("timelineItemsURL", timelineItemsURL);
 
 			CTDisplayRenderer<?> ctDisplayRenderer =
 				_ctDisplayRendererRegistry.getCTDisplayRenderer(classNameId);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMStructuresDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMStructuresDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.journal.web.internal.display.context;
 
+import com.liferay.change.tracking.spi.constants.CTTimelineKeys;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
@@ -115,6 +116,11 @@ public class JournalEditDDMStructuresDisplayContext {
 	}
 
 	public Map<String, Object> getDataEngineLayoutBuilderHandlerContext() {
+		_httpServletRequest.setAttribute(
+			CTTimelineKeys.CLASS_NAME, DDMStructure.class.getName());
+		_httpServletRequest.setAttribute(
+			CTTimelineKeys.CLASS_PK, getDDMStructureId());
+
 		return HashMapBuilder.<String, Object>put(
 			"defaultLanguageId", getDefaultLanguageId()
 		).put(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.journal.web.internal.display.context;
 
+import com.liferay.change.tracking.spi.constants.CTTimelineKeys;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
@@ -142,6 +143,14 @@ public class JournalEditDDMTemplateDisplayContext {
 	public HashMap<String, Object> getDDMTemplateEditorContext(
 			long scopeGroupId)
 		throws Exception {
+
+		String ddmTemplateId = _httpServletRequest.getParameter(
+			"ddmTemplateId");
+
+		_httpServletRequest.setAttribute(
+			CTTimelineKeys.CLASS_NAME, DDMTemplate.class.getName());
+		_httpServletRequest.setAttribute(
+			CTTimelineKeys.CLASS_PK, ddmTemplateId);
 
 		return HashMapBuilder.<String, Object>put(
 			"editorAutocompleteData", getAutocompleteJSONObject()

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.exception.NoSuchStructureException;
 import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
 import com.liferay.dynamic.data.mapping.exception.StorageFieldRequiredException;
 import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToMapConverter;
 import com.liferay.dynamic.data.mapping.util.DDMTemplateHelper;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
@@ -279,23 +281,29 @@ public class JournalPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		try {
+			HttpServletRequest httpServletRequest =
+				_portal.getHttpServletRequest(renderRequest);
 			String path = getPath(renderRequest, renderResponse);
 
 			if (Objects.equals(path, "/edit_article.jsp") ||
 				Objects.equals(path, "/view_article_history.jsp")) {
 
-				ActionUtil.getArticle(
-					_portal.getHttpServletRequest(renderRequest));
+				ActionUtil.getArticle(httpServletRequest);
+			}
+			else if (Objects.equals(path, "/view_ddm_structures.jsp")) {
+				httpServletRequest.setAttribute(
+					CTTimelineKeys.CLASS_NAME, DDMStructure.class.getName());
+			}
+			else if (Objects.equals(path, "/view_ddm_templates.jsp")) {
+				httpServletRequest.setAttribute(
+					CTTimelineKeys.CLASS_NAME, DDMTemplate.class.getName());
 			}
 			else if (Validator.isNull(path)) {
-				HttpServletRequest httpServletRequest =
-					_portal.getHttpServletRequest(renderRequest);
-
 				httpServletRequest.setAttribute(
 					CTTimelineKeys.CLASS_NAME, JournalArticle.class.getName());
 			}
 			else {
-				_getFolder(_portal.getHttpServletRequest(renderRequest));
+				_getFolder(httpServletRequest);
 			}
 		}
 		catch (Exception exception) {

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
@@ -14,10 +14,12 @@ import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout, userData} from '../../utils/performLogin';
 import {waitForAlert} from '../../utils/waitForAlert';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
 	documentLibraryPagesTest,
 	isolatedSiteTest,
+	journalPagesTest,
 	apiHelpersTest,
 	featureFlagsTest({
 		'LPD-20556': true,
@@ -443,4 +445,78 @@ test('LPD-37842 Timeline icon is yellow for cross-publication edits.', async ({
 	await apiHelpers.headlessChangeTracking.deleteCTCollection(
 		ctCollection2.id
 	);
+});
+
+test('LPD-39412 Assert publication timeline history is enabled for structures', async ({
+	journalStructuresPage,
+	page,
+	site,
+}) => {
+	await journalStructuresPage.goto(site.friendlyUrlPath);
+
+	await page.getByRole('link', {name: 'Add'}).click();
+
+	await page
+		.getByLabel('Press enter to add Text field.')
+		.dragTo(page.getByText('Drag fields from the sidebar'));
+	await page.getByPlaceholder('Untitled Structure').pressSequentially(title1);
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await page.waitForTimeout(500);
+
+	await journalStructuresPage.goto(site.friendlyUrlPath);
+
+	const timelineButton = page.getByLabel('timeline-button');
+	await timelineButton.waitFor();
+	await timelineButton.click();
+
+	const timelineActionsButton = page.locator('.publication-timeline button');
+
+	await expect(timelineActionsButton).toBeVisible();
+
+	await page.getByText('Description').click();
+
+	await page.getByRole('link', {name: title1}).click();
+
+	await page.waitForTimeout(500);
+
+	await timelineButton.click();
+
+	await expect(timelineActionsButton).toBeVisible();
+});
+
+test('LPD-39412 Assert publication timeline history is enabled for templates', async ({
+	journalEditTemplatePage,
+	page,
+	site,
+}) => {
+	await journalEditTemplatePage.goto(site.friendlyUrlPath);
+
+	await page
+		.getByPlaceholder('Untitled Template')
+		.pressSequentially(title2, {delay: 50});
+
+	await page
+		.getByRole('button', {exact: true, name: 'Save and Continue'})
+		.click();
+
+	await page.waitForTimeout(500);
+
+	const timelineButton = page.getByLabel('timeline-button');
+	await timelineButton.waitFor();
+	await timelineButton.click();
+
+	const timelineActionsButton = page.locator('.publication-timeline button');
+
+	await expect(timelineActionsButton).toBeVisible();
+
+	await journalEditTemplatePage.goto(site.friendlyUrlPath);
+
+	await page.waitForTimeout(500);
+
+	await timelineButton.waitFor();
+	await timelineButton.click();
+
+	await expect(timelineActionsButton).toBeVisible();
 });


### PR DESCRIPTION
In progress, adding tests


This is an update for: [LPD-39433](https://liferay.atlassian.net/browse/LPD-39412)

The first commit relates to checking if the classPK is being passed or if it's null, some entities weren't responding well to the api with the `&classPK=0` at the end of the query, like ddmStructures and ddmTemplates.

