### PR TITLE
LPD-40248 Site Initializer: Custom Name configuration not working for Site Navigation Menu

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-2/src/main/resources/site-initializer/site-navigation-menus.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-2/src/main/resources/site-initializer/site-navigation-menus.json
@@ -4,8 +4,12 @@
 			{
 				"externalReferenceCode": "TESTSITENAVIGATIONMENUITEM1",
 				"friendlyURL": "/test-public-layout",
+				"name_i18n": {
+					"en_US": "Test Layout"
+				},
 				"privateLayout": false,
-				"type": "layout"
+				"type": "layout",
+				"useCustomName": true
 			},
 			{
 				"externalReferenceCode": "TESTSITENAVIGATIONMENUITEM2",

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -3676,6 +3676,10 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(
 			SiteNavigationMenuItemTypeConstants.LAYOUT,
 			siteNavigationMenuItem1.getType());
+		Assert.assertFalse(
+			StringUtil.contains(
+				siteNavigationMenuItem1.getTypeSettings(), "useCustomName",
+				StringPool.BLANK));
 
 		SiteNavigationMenuItem siteNavigationMenuItem2 =
 			siteNavigationMenuItems.get(1);
@@ -3747,6 +3751,14 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(
 			SiteNavigationMenuItemTypeConstants.LAYOUT,
 			siteNavigationMenuItem1.getType());
+		Assert.assertTrue(
+			StringUtil.contains(
+				siteNavigationMenuItem1.getTypeSettings(), "useCustomName",
+				StringPool.BLANK));
+		Assert.assertTrue(
+			StringUtil.contains(
+				siteNavigationMenuItem1.getTypeSettings(), "Test Layout",
+				StringPool.BLANK));
 
 		SiteNavigationMenuItem siteNavigationMenuItem2 =
 			siteNavigationMenuItems.get(1);

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -3894,6 +3894,24 @@ public class BundleSiteInitializer implements SiteInitializer {
 				typeSettings =
 					siteNavigationMenuItemType.getTypeSettingsFromLayout(
 						layout);
+
+				boolean useCustomName = menuItemJSONObject.getBoolean(
+					"useCustomName");
+
+				if (useCustomName) {
+					UnicodePropertiesBuilder.UnicodePropertiesWrapper
+						unicodePropertiesWrapper =
+							_getNavigationMenuItemUnicodePropertiesWrapper(
+								menuItemJSONObject);
+
+					if (unicodePropertiesWrapper != null) {
+						typeSettings = unicodePropertiesWrapper.load(
+							typeSettings
+						).put(
+							"useCustomName", useCustomName
+						).buildString();
+					}
+				}
 			}
 			else if (type.equals(SiteNavigationMenuItemTypeConstants.NODE)) {
 				UnicodePropertiesBuilder.UnicodePropertiesWrapper


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40248

# How am I fixing it?

Currently, the site initializer does not take into account whether or not a page item has a custom name. These changes use the existing method to get the localized names and merges it with the layout's type settings.

# How can you verify that it works?

In `site-initializer-extender-test` run `gw testIntegration --tests *.BundleSiteInitializerTest`