### PR TITLE
LPD-40801 Switch current and available locales due to UI changes made in LPD-39411

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/site/Site.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/site/Site.macro
@@ -570,13 +570,13 @@ definition {
 			locator1 = "SiteSettingsDisplaySettings#LANGUAGES_RADIO");
 
 		if (isSet(currentSiteLanguages)) {
-			while (IsElementPresent(index = 1, key_position = "left", locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION")) {
+			while (IsElementPresent(index = 1, key_position = "right", locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION")) {
 				Click(
 					index = 1,
-					key_position = "left",
+					key_position = "right",
 					locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION");
 
-				Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_LEFT_TO_RIGHT");
+				Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_RIGHT_TO_LEFT");
 			}
 
 			var defaultSiteLanguage = ${defaultSiteLanguage};
@@ -585,24 +585,24 @@ definition {
 				locator1 = "SiteSettingsDisplaySettings#DEFAULT_LANGUAGE_SELECT_FIELD",
 				value1 = ${defaultSiteLanguage});
 
-			while (IsElementPresent(index = 2, key_position = "right", locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION")) {
-				var currentSiteLanguage = selenium.getText("//div[contains(@class,'listbox-right')]//select/option");
+			while (IsElementPresent(index = 2, key_position = "left", locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION")) {
+				var currentSiteLanguage = selenium.getText("//div[contains(@class,'listbox-left')]//select/option");
 
 				if (${currentSiteLanguage} == ${defaultSiteLanguage}) {
 					Click(
 						index = 2,
-						key_position = "right",
+						key_position = "left",
 						locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION");
 
-					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_RIGHT_TO_LEFT");
+					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_LEFT_TO_RIGHT");
 				}
 				else {
 					Click(
 						index = 1,
-						key_position = "right",
+						key_position = "left",
 						locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_OPTION");
 
-					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_RIGHT_TO_LEFT");
+					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_LEFT_TO_RIGHT");
 				}
 			}
 
@@ -610,13 +610,13 @@ definition {
 				if (${currentSiteLanguage} != ${defaultSiteLanguage}) {
 					DoubleClick(
 						key_optionValue = ${currentSiteLanguage},
-						key_position = "left",
+						key_position = "right",
 						locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_SPECIFIC_OPTION");
 
-					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_LEFT_TO_RIGHT");
+					Click(locator1 = "SiteSettingsDisplaySettings#TRANSFER_ITEM_RIGHT_TO_LEFT");
 
 					AssertTextEquals.assertPartialText(
-						key_position = "right",
+						key_position = "left",
 						locator1 = "SiteSettingsDisplaySettings#LANGUAGES_SELECT_FIELD",
 						value1 = ${currentSiteLanguage});
 				}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40801

# How am I fixing it?

In LPD-39411 the Current and Available locale picklists swapped sides. These tests are now being updated to switch from left to right to handle this change.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#ConfigureSiteDefaultLanguage`