### PR TITLE
LPD-40870 Exclude other team's tests for the site-management routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9310,9 +9310,24 @@
     # Site Management
     #
 
+    modules.includes[js-unit][site-management]=${site.management.testing.modules}
+
+    modules.includes[modules-semantic-versioning][site-management]=${site.management.testing.modules}
+
+    modules.includes.public[modules-semantic-versioning][site-management]=${site.management.testing.modules}
+
     playwright.test.project[playwright-js-tomcat90-mysql57][site-management]=\
         site-admin-web,\
         site-navigation-admin-web
+
+    site.management.testing.modules=\
+        apps/click-to-chat/**,\
+        apps/friendly-url/**,\
+        apps/portal-url-builder/**,\
+        apps/redirect/**,\
+        apps/site/**,\
+        apps/site-initializer/**,\
+        apps/site-navigation/**
 
     test.batch.class.names.includes[site-management]=\
         **/friendly-url-service/**/*Test.java,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40870

# How am I fixing it?

Currently, the `site-management` routine runs a number of unnecessary tests. With these changes it is now executing 228 less tests per execution. The two runs have been compared (before and after the changes) and there is no loss of tests relating to Site Management.