### PR TITLE
LPD-41522

### DIFF
--- a/modules/apps/portlet/portlet-friendly-url-test/src/testIntegration/java/com/liferay/portlet/friendly/url/test/FriendlyURLResolverRegistryUtilTest.java
+++ b/modules/apps/portlet/portlet-friendly-url-test/src/testIntegration/java/com/liferay/portlet/friendly/url/test/FriendlyURLResolverRegistryUtilTest.java
@@ -150,6 +150,30 @@ public class FriendlyURLResolverRegistryUtilTest {
 	}
 
 	@Test
+	public void testGetFriendlyURLResolverWithNegativeServiceRanking() {
+		FriendlyURLResolver sampleFriendlyURLResolver =
+			new SampleFriendlyURLResolver();
+
+		FriendlyURLResolver defaultCanonicalURLSeparatorFriendlyURLResolver =
+			FriendlyURLResolverRegistryUtil.getFriendlyURLResolver(
+				_CANONICAL_URL_SEPARATOR);
+
+		ServiceRegistration<FriendlyURLResolver> serviceRegistration =
+			_bundleContext.registerService(
+				FriendlyURLResolver.class, sampleFriendlyURLResolver,
+				MapUtil.singletonDictionary("service.ranking", -1000));
+
+		try {
+			_assertFriendlyURLResolver(
+				defaultCanonicalURLSeparatorFriendlyURLResolver,
+				sampleFriendlyURLResolver);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Test
 	public void testOverride() {
 		Bundle bundle = FrameworkUtil.getBundle(
 			FriendlyURLResolverRegistryUtilTest.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/FriendlyURLResolverRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/FriendlyURLResolverRegistryUtil.java
@@ -7,7 +7,6 @@ package com.liferay.portal.kernel.portlet;
 
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
-import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceComparator;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 
 import java.util.ArrayList;
@@ -75,7 +74,6 @@ public class FriendlyURLResolverRegistryUtil {
 		SystemBundleUtil.getBundleContext();
 	private static final ServiceTrackerList<FriendlyURLResolver>
 		_serviceTrackerList = ServiceTrackerListFactory.open(
-			_bundleContext, FriendlyURLResolver.class,
-			new PropertyServiceReferenceComparator<>("service.ranking"));
+			_bundleContext, FriendlyURLResolver.class);
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41522

# How am I fixing it?

OSGi already orders the services by their ranking. This comparator is unnecessary and actually does not work properly when used in conjunction with `service.ranking`. By default an OSGi's service ranking is 0. However, this comparator handles null values in a particular way, which in most cases makes sense, but here a null value is actually 0.

The changes simply remove the comparator and let OSGi sort the services for us.

# How can you verify that it works?

In `portlet-friendly-url-test` run `gw testIntegration --tests *.FriendlyURLResolverRegistryUtilTest`