### PR TITLE
LPD-41951 Make these tests more robust by ensuring they have the correct locales set

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
@@ -9,7 +9,9 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.friendly.url.taglib.servlet.taglib.InputTag;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -17,6 +19,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -33,14 +36,20 @@ import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.portlet.PortletPreferences;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,6 +70,33 @@ public class InputTagTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalAvailableLocales = _language.getAvailableLocales();
+		_originalDefaultLocale = LocaleUtil.getDefault();
+		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
+
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
+
+		PropsValues.LOCALES_ENABLED = TransformUtil.transformToArray(
+			_availableLocales, locale -> _language.getLanguageId(locale),
+			String.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _originalAvailableLocales,
+			_originalDefaultLocale);
+
+		PropsValues.LOCALES_ENABLED = _originalLocalesEnabled;
+	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -235,6 +271,20 @@ public class InputTagTest {
 		}
 	}
 
+	private static final List<Locale> _availableLocales = Arrays.asList(
+		LocaleUtil.SPAIN, LocaleUtil.US);
+	private static final Locale _defaultLocale = LocaleUtil.US;
+
+	@Inject
+	private static Language _language;
+
+	private static Set<Locale> _originalAvailableLocales;
+	private static Locale _originalDefaultLocale;
+	private static String[] _originalLocalesEnabled;
+
+	@Inject
+	private static Portal _portal;
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -252,8 +302,5 @@ public class InputTagTest {
 
 	@Inject
 	private Localization _localization;
-
-	@Inject
-	private Portal _portal;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -30,12 +30,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -55,6 +57,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -64,6 +67,7 @@ import javax.annotation.Generated;
 import javax.ws.rs.core.MultivaluedHashMap;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -87,6 +91,30 @@ public abstract class BaseLanguageResourceTestCase {
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		_originalAvailableLocales = _language.getAvailableLocales();
+		_originalDefaultLocale = LocaleUtil.getDefault();
+		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
+
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
+
+		PropsValues.LOCALES_ENABLED = TransformUtil.transformToArray(
+			_availableLocales, locale -> _language.getLanguageId(locale),
+			String.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _originalAvailableLocales,
+			_originalDefaultLocale);
+
+		PropsValues.LOCALES_ENABLED = _originalLocalesEnabled;
 	}
 
 	@Before
@@ -1222,10 +1250,24 @@ public abstract class BaseLanguageResourceTestCase {
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseLanguageResourceTestCase.class);
 
+	private static final List<Locale> _availableLocales = Arrays.asList(
+		LocaleUtil.CHINA, LocaleUtil.FRANCE, LocaleUtil.SPAIN, LocaleUtil.US);
+	private static final Locale _defaultLocale = LocaleUtil.US;
+
 	private static DateFormat _dateFormat;
+
+	@Inject
+	private static com.liferay.portal.kernel.language.Language _language;
 
 	@Inject
 	private com.liferay.headless.delivery.resource.v1_0.LanguageResource
 		_languageResource;
+
+	private static Set<Locale> _originalAvailableLocales;
+	private static Locale _originalDefaultLocale;
+	private static String[] _originalLocalesEnabled;
+
+	@Inject
+	private static Portal _portal;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -34,11 +34,13 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -61,12 +63,14 @@ import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalService;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -118,6 +122,19 @@ public class NavigationMenuResourceTest
 			ExpandoColumnConstants.STRING, StringPool.BLANK);
 
 		_expandoColumnNames.add(expandoColumn2.getName());
+
+		_originalAvailableLocales = _language.getAvailableLocales();
+		_originalDefaultLocale = LocaleUtil.getDefault();
+		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
+
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
+
+		PropsValues.LOCALES_ENABLED = TransformUtil.transformToArray(
+			_availableLocales, locale -> _language.getLanguageId(locale),
+			String.class);
 	}
 
 	@AfterClass
@@ -135,6 +152,14 @@ public class NavigationMenuResourceTest
 			_expandoColumnLocalService.deleteColumn(
 				_originalExpandoTable.getTableId(), expandoColumnName);
 		}
+
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _originalAvailableLocales,
+			_originalDefaultLocale);
+
+		PropsValues.LOCALES_ENABLED = _originalLocalesEnabled;
 	}
 
 	@Before
@@ -940,6 +965,10 @@ public class NavigationMenuResourceTest
 		navigationMenuResource.deleteNavigationMenu(postNavigationMenu.getId());
 	}
 
+	private static final List<Locale> _availableLocales = Arrays.asList(
+		LocaleUtil.SPAIN, LocaleUtil.US);
+	private static final Locale _defaultLocale = LocaleUtil.US;
+
 	@Inject
 	private static ExpandoColumnLocalService _expandoColumnLocalService;
 
@@ -948,7 +977,16 @@ public class NavigationMenuResourceTest
 	@Inject
 	private static ExpandoTableLocalService _expandoTableLocalService;
 
+	@Inject
+	private static Language _language;
+
+	private static Set<Locale> _originalAvailableLocales;
+	private static Locale _originalDefaultLocale;
 	private static ExpandoTable _originalExpandoTable;
+	private static String[] _originalLocalesEnabled;
+
+	@Inject
+	private static Portal _portal;
 
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;
@@ -963,9 +1001,6 @@ public class NavigationMenuResourceTest
 
 	@Inject
 	private FriendlyURLNormalizer _friendlyURLNormalizer;
-
-	@Inject
-	private Portal _portal;
 
 	@Inject
 	private ResourceActions _resourceActions;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.site.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
@@ -64,6 +65,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
 import java.util.ArrayList;
@@ -75,7 +77,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,6 +101,33 @@ public class GroupServiceTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalAvailableLocales = _language.getAvailableLocales();
+		_originalDefaultLocale = LocaleUtil.getDefault();
+		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
+
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
+
+		PropsValues.LOCALES_ENABLED = TransformUtil.transformToArray(
+			_availableLocales, locale -> _language.getLanguageId(locale),
+			String.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_language.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			_portal.getDefaultCompanyId(), _originalAvailableLocales,
+			_originalDefaultLocale);
+
+		PropsValues.LOCALES_ENABLED = _originalLocalesEnabled;
+	}
 
 	@Test
 	public void testAddCompanyStagingGroup() throws Exception {
@@ -1457,6 +1488,21 @@ public class GroupServiceTest {
 	private static final Log _log = LogFactoryUtil.getLog(
 		GroupServiceTest.class);
 
+	private static final List<Locale> _availableLocales = Arrays.asList(
+		LocaleUtil.BRAZIL, LocaleUtil.CHINA, LocaleUtil.ENGLISH,
+		LocaleUtil.GERMANY, LocaleUtil.SPAIN, LocaleUtil.US);
+	private static final Locale _defaultLocale = LocaleUtil.US;
+
+	@Inject
+	private static Language _language;
+
+	private static Set<Locale> _originalAvailableLocales;
+	private static Locale _originalDefaultLocale;
+	private static String[] _originalLocalesEnabled;
+
+	@Inject
+	private static Portal _portal;
+
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;
 
@@ -1479,13 +1525,7 @@ public class GroupServiceTest {
 	private GroupService _groupService;
 
 	@Inject
-	private Language _language;
-
-	@Inject
 	private OrganizationLocalService _organizationLocalService;
-
-	@Inject
-	private Portal _portal;
 
 	@Inject
 	private PortletPreferencesLocalService _portletPreferencesLocalService;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41951

# How am I fixing it?

These tests are flaky as they depend on certain locales being available in the portal. Whether it be a different test that doesn't clean up after itself or a portal configured with different locales, these tests will fail. The changes here ensure the locales that are needed are set and then it cleans up after itself.

These tests individually will pass locally however when run on CI will start to fail. Before forwarding let's make sure everything is passing.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.InputTagTest`
In `headless-delivery-test` run `gw testIntegration --tests *.LanguageResourceTest`
In `headless-delivery-test` run `gw testIntegration --tests *.NavigationMenuResourceTest`
In `site-test` run `gw testIntegration --tests *.GroupServiceTest`