### PR TITLE
LPD-42050 Duplicated groupKey when updating a non-group type group with different locale

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
@@ -1318,6 +1319,49 @@ public class GroupServiceTest {
 	}
 
 	@Test
+	public void testUpdateGroupWithDifferentDefaultLocale() throws Exception {
+		Group group = _groupLocalService.addGroup(
+			TestPropsValues.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			null, 0, GroupConstants.DEFAULT_LIVE_GROUP_ID,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Spanish"
+			).put(
+				LocaleUtil.US, "English"
+			).build(),
+			null, GroupConstants.TYPE_SITE_OPEN, true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, null, true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertGroupKeyWithDifferentDefaultLocale(group, "Spanish");
+	}
+
+	@Test
+	public void testUpdateGroupWithDifferentDefaultLocaleAndCompanyTypeGroup()
+		throws Exception {
+
+		long classPK = RandomTestUtil.nextLong();
+
+		Group group2 = _groupLocalService.addGroup(
+			TestPropsValues.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			Company.class.getName(), classPK,
+			GroupConstants.DEFAULT_LIVE_GROUP_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				() -> {
+					Group group1 = GroupTestUtil.addGroup();
+
+					return group1.getName(LocaleUtil.getDefault());
+				}
+			).build(),
+			null, GroupConstants.TYPE_SITE_OPEN, true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, null, true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertGroupKeyWithDifferentDefaultLocale(
+			group2, String.valueOf(classPK));
+	}
+
+	@Test
 	public void testValidChangeAvailableLanguageIds() throws Exception {
 		_group = GroupTestUtil.addGroup(GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
@@ -1371,6 +1415,29 @@ public class GroupServiceTest {
 			_groupService.getGroupsCount(
 				TestPropsValues.getCompanyId(), parentGroupId, nameSearch,
 				true));
+	}
+
+	private void _assertGroupKeyWithDifferentDefaultLocale(
+			Group group, String expectedGroupKey)
+		throws Exception {
+
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		try {
+			LocaleUtil.setDefault(
+				LocaleUtil.SPAIN.getLanguage(), LocaleUtil.SPAIN.getCountry(),
+				LocaleUtil.SPAIN.getVariant());
+
+			group = _groupLocalService.updateGroup(
+				group.getGroupId(), group.getTypeSettings());
+
+			Assert.assertEquals(expectedGroupKey, group.getGroupKey());
+		}
+		finally {
+			LocaleUtil.setDefault(
+				defaultLocale.getLanguage(), defaultLocale.getCountry(),
+				defaultLocale.getVariant());
+		}
 	}
 
 	private Locale _getLocale() {
@@ -1459,6 +1526,9 @@ public class GroupServiceTest {
 
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4055,8 +4055,13 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 				Map<Locale, String> nameMap = group.getNameMap();
 
+				String className = group.getClassName();
+
 				if ((nameMap != null) &&
-					Validator.isNotNull(nameMap.get(defaultLocale))) {
+					Validator.isNotNull(nameMap.get(defaultLocale)) &&
+					((group.getClassNameId() <= 0) ||
+					 (group.getType() == GroupConstants.TYPE_DEPOT) ||
+					 className.equals(Group.class.getName()))) {
 
 					group.setGroupKey(nameMap.get(defaultLocale));
 				}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-42050

# How am I fixing it?

Groups that aren't of the `group` type use their `classPK` as the `groupKey`. This update logic didn't take this into account. Now the `groupKey` is only updated if it is tied to the group's name.

# How can you verify that it works?

In `site-test` run `gw testIntegration --tests *.GroupServiceTest`