### PR TITLE
LPD-42500 Add "Unassign Roles" to Users tab

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.memberships.web.internal.display.context;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -17,7 +18,9 @@ import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -125,6 +128,14 @@ public class UserRolesDisplayContext {
 			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
 			new Integer[] {_getRoleType()}, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, roleSearch.getOrderByComparator());
+
+		List<Role> selectedRoles = _getSelectedRoles();
+
+		roles = ListUtil.filter(
+			roles,
+			role ->
+				(_isAssignRoles() && !selectedRoles.contains(role)) ||
+				(!_isAssignRoles() && selectedRoles.contains(role)));
 
 		if (group.isDepot()) {
 			roles = DepotRolesUtil.filterGroupRoles(
@@ -238,6 +249,13 @@ public class UserRolesDisplayContext {
 		return _roleType;
 	}
 
+	private List<Role> _getSelectedRoles() throws PortalException {
+		return TransformUtil.transform(
+			UserGroupRoleLocalServiceUtil.getUserGroupRoles(_getUserId()),
+			userGroupRole -> RoleLocalServiceUtil.fetchRole(
+				userGroupRole.getRoleId()));
+	}
+
 	private long _getUserId() throws PortalException {
 		User selUser = PortalUtil.getSelectedUser(_httpServletRequest, false);
 
@@ -248,6 +266,18 @@ public class UserRolesDisplayContext {
 		return 0;
 	}
 
+	private boolean _isAssignRoles() {
+		if (_assignRoles != null) {
+			return _assignRoles;
+		}
+
+		_assignRoles = ParamUtil.getBoolean(
+			_httpServletRequest, "assignRoles", true);
+
+		return _assignRoles;
+	}
+
+	private Boolean _assignRoles;
 	private String _displayStyle;
 	private String _eventName;
 	private Long _groupId;

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.memberships.web.internal.display.context;
 
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -30,7 +31,6 @@ import com.liferay.roles.admin.search.RoleSearch;
 import com.liferay.roles.admin.search.RoleSearchTerms;
 import com.liferay.site.memberships.constants.SiteMembershipsPortletKeys;
 import com.liferay.site.memberships.web.internal.util.DepotRolesUtil;
-import com.liferay.site.search.UserGroupRoleRoleChecker;
 
 import java.util.List;
 
@@ -147,10 +147,7 @@ public class UserRolesDisplayContext {
 		}
 
 		roleSearch.setResultsAndTotal(roles);
-		roleSearch.setRowChecker(
-			new UserGroupRoleRoleChecker(
-				_renderResponse,
-				PortalUtil.getSelectedUser(_httpServletRequest, false), group));
+		roleSearch.setRowChecker(new EmptyOnClickRowChecker(_renderResponse));
 
 		_roleSearch = roleSearch;
 

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
@@ -388,6 +388,20 @@ public class SiteMembershipsPortlet extends MVCPortlet {
 			userGroupId, group.getGroupId(), roleIds);
 	}
 
+	public void unassignUserGroupRole(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		Group group = _getGroup(actionRequest, actionResponse);
+
+		long[] roleIds = ParamUtil.getLongValues(actionRequest, "rowIds");
+
+		long userId = ParamUtil.getLong(actionRequest, "userId");
+
+		_userGroupRoleService.deleteUserGroupRoles(
+			userId, group.getGroupId(), roleIds);
+	}
+
 	@Override
 	protected void doDispatch(
 			RenderRequest renderRequest, RenderResponse renderResponse)

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/servlet/taglib/util/UserActionDropdownItemsProvider.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/servlet/taglib/util/UserActionDropdownItemsProvider.java
@@ -53,6 +53,28 @@ public class UserActionDropdownItemsProvider {
 				ActionKeys.ASSIGN_USER_ROLES),
 			_getAssignRolesActionUnsafeConsumer()
 		).add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "unassignRoles");
+				dropdownItem.putData(
+					"unassignUserGroupRoleURL",
+					PortletURLBuilder.createActionURL(
+						_renderResponse
+					).setMVCPath(
+						"/users_roles.jsp"
+					).setParameter(
+						"assignRoles", Boolean.FALSE
+					).setParameter(
+						"groupId", _themeDisplay.getSiteGroupIdOrLiveGroupId()
+					).setParameter(
+						"p_u_i_d", _user.getUserId()
+					).setWindowState(
+						LiferayWindowState.POP_UP
+					).buildString());
+				dropdownItem.putData("userId", _user.getUserId());
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "unassign-roles"));
+			}
+		).add(
 			() ->
 				GroupPermissionUtil.contains(
 					_themeDisplay.getPermissionChecker(),

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openSelectionModal} from 'frontend-js-web';
+import {
+	openConfirmModal,
+	openSelectionModal,
+	setFormValues,
+} from 'frontend-js-web';
 
 export const ACTIONS = {
 	assignRoles(itemData, portletNamespace) {
@@ -53,6 +57,39 @@ export const ACTIONS = {
 					submitForm(document.hrefFm, itemData.deleteGroupUsersURL);
 				}
 			},
+		});
+	},
+
+	unassignRoles(itemData, portletNamespace) {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('done'),
+			multiple: true,
+			onSelect(selectedItems) {
+				const unassignUserGroupRoleFm = document.getElementById(
+					`${portletNamespace}unassignUserGroupRoleFm`
+				);
+
+				setFormValues(unassignUserGroupRoleFm, {
+					userId: itemData.userId,
+				});
+
+				const input = document.createElement('input');
+
+				input.name = `${portletNamespace}rowIds`;
+
+				const selectedUserGroupIds = Array.prototype.map.call(
+					selectedItems,
+					(item) => item.value
+				);
+
+				input.value = selectedUserGroupIds.join();
+
+				unassignUserGroupRoleFm.appendChild(input);
+
+				submitForm(unassignUserGroupRoleFm);
+			},
+			title: Liferay.Language.get('unassign-roles'),
+			url: itemData.unassignUserGroupRoleURL,
 		});
 	},
 };

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -234,3 +234,10 @@ Team team = usersDisplayContext.getTeam();
 <aui:form cssClass="hide" method="post" name="editUserGroupRoleFm">
 	<aui:input name="tabs1" type="hidden" value="users" />
 </aui:form>
+
+<portlet:actionURL name="unassignUserGroupRole" var="unassignUserGroupRoleURL" />
+
+<aui:form action="<%= unassignUserGroupRoleURL %>" cssClass="hide" name="unassignUserGroupRoleFm">
+	<aui:input name="tabs1" type="hidden" value="users" />
+	<aui:input name="userId" type="hidden" />
+</aui:form>

--- a/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
@@ -147,3 +147,70 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Confirm roles are unassign from users tab',
+	{
+		tag: '@LPD-42500',
+	},
+	async ({apiHelpers, membershipsPage, page}) => {
+		const userAccount =
+			await apiHelpers.headlessAdminUser.postUserAccount();
+
+		await membershipsPage.goto();
+
+		await page.waitForTimeout(500);
+
+		await membershipsPage.assignAllUsersSiteMembership();
+
+		await membershipsPage.assignAllRolesToUser(userAccount.alternateName);
+
+		await membershipsPage.unassignAllRolesFromUser(
+			userAccount.alternateName
+		);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Unassign Roles'}),
+			timeout: 500,
+			trigger: page
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
+						userAccount.alternateName +
+						'"]'
+				)
+				.getByLabel('More actions'),
+		});
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Unassign Roles"]')
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_userGroupRoleRole_1"] label div'
+				)
+				.first()
+		).not.toBeVisible();
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Unassign Roles"]')
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_userGroupRoleRole_2"] label div'
+				)
+				.first()
+		).not.toBeVisible();
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Unassign Roles"]')
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_userGroupRoleRole_3"] label div'
+				)
+				.first()
+		).not.toBeVisible();
+
+		await apiHelpers.headlessAdminUser.deleteUserAccount(
+			Number(userAccount.id)
+		);
+	}
+);

--- a/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
@@ -17,6 +17,46 @@ export class MembershipsPage {
 		this.productMenuPage = new ProductMenuPage(page);
 	}
 
+	async assignAllRolesToUser(userName: String) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Assign Roles',
+			}),
+			timeout: 500,
+			trigger: this.page
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
+						userName +
+						'"]'
+				)
+				.getByLabel('More actions'),
+		});
+
+		await this.page.waitForTimeout(500);
+
+		await this.page
+			.frameLocator('iframe[title="Assign Roles"]')
+			.getByLabel('Select All Items on the Page')
+			.check();
+
+		await this.page.getByRole('button', {name: 'Done'}).click();
+	}
+
+	async assignAllUsersSiteMembership() {
+		await this.page.getByRole('button', {name: 'Add'}).click();
+
+		await this.page.waitForTimeout(500);
+
+		await this.page
+			.frameLocator('iframe[title="Assign Users to This Site"]')
+			.getByLabel('Select All Items on the Page')
+			.check();
+
+		await this.page.getByRole('button', {name: 'Done'}).click();
+	}
+
 	async assignSiteAdministratorRole() {
 		await clickAndExpectToBeVisible({
 			autoClick: true,
@@ -67,5 +107,32 @@ export class MembershipsPage {
 			timeout: 500,
 			trigger: this.page.getByLabel('Select All Items on the Page'),
 		});
+	}
+
+	async unassignAllRolesFromUser(userName: String) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Unassign Roles',
+			}),
+			timeout: 500,
+			trigger: this.page
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
+						userName +
+						'"]'
+				)
+				.getByLabel('More actions'),
+		});
+
+		await this.page.waitForTimeout(500);
+
+		await this.page
+			.frameLocator('iframe[title="Unassign Roles"]')
+			.getByLabel('Select All Items on the Page')
+			.check();
+
+		await this.page.getByRole('button', {name: 'Done'}).click();
 	}
 }


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-42500

This pull refers to a feature that allows the user to unassign user roles directly from the Users tab in Memberships.

 This could be tested by running `npm run playwright -- test -g 'LPD-42500' ` in `<liferay_home>/modules/test/playwright` or by executing the steps manually (the steps are described in the ticket).
 
 You can find a demonstration of this feature in the ticket.