### PR TITLE
LPD-41951 Add new test rule to ensure correct available and default locale

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletLocalizedFriendlyURLTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletLocalizedFriendlyURLTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -21,7 +20,6 @@ import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -34,13 +32,12 @@ import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import javax.portlet.PortletPreferences;
 
@@ -48,7 +45,6 @@ import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -62,6 +58,10 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Sergio González
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "es_ES", "fr_CA"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class FriendlyURLServletLocalizedFriendlyURLTest {
 
@@ -72,15 +72,6 @@ public class FriendlyURLServletLocalizedFriendlyURLTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_availableLocales = _language.getAvailableLocales();
-		_defaultLocale = LocaleUtil.getDefault();
-
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(),
-			Arrays.asList(
-				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.US),
-			LocaleUtil.US);
-
 		_nameMap = HashMapBuilder.put(
 			LocaleUtil.CANADA_FRENCH, "Accueil"
 		).put(
@@ -96,12 +87,6 @@ public class FriendlyURLServletLocalizedFriendlyURLTest {
 		).put(
 			LocaleUtil.US, "/home"
 		).build();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
 	}
 
 	@Before
@@ -901,13 +886,7 @@ public class FriendlyURLServletLocalizedFriendlyURLTest {
 
 	private static final String _VIRTUAL_HOSTNAME = "test.com";
 
-	private static Set<Locale> _availableLocales;
-	private static Locale _defaultLocale;
 	private static Map<Locale, String> _friendlyURLMap;
-
-	@Inject
-	private static Language _language;
-
 	private static Map<Locale, String> _nameMap;
 
 	@Inject

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -53,7 +52,6 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -62,6 +60,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.redirect.model.RedirectEntry;
@@ -76,7 +75,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
@@ -100,6 +98,10 @@ import org.springframework.mock.web.MockServletContext;
 /**
  * @author László Csontos
  */
+@LanguageIds(
+	availableLanguageIds = {"en_GB", "en_US", "hu_HU"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class FriendlyURLServletTest {
 
@@ -110,7 +112,6 @@ public class FriendlyURLServletTest {
 
 	@Before
 	public void setUp() throws Exception {
-		PropsValues.LOCALES_ENABLED = new String[] {"en_US", "hu_HU", "de_DE"};
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = true;
 
 		LanguageUtil.init();
@@ -123,7 +124,7 @@ public class FriendlyURLServletTest {
 		_layout = LayoutTestUtil.addTypePortletLayout(_group);
 
 		List<Locale> availableLocales = Arrays.asList(
-			LocaleUtil.US, LocaleUtil.GERMANY, LocaleUtil.HUNGARY);
+			LocaleUtil.US, LocaleUtil.UK, LocaleUtil.HUNGARY);
 
 		_group = GroupTestUtil.updateDisplaySettings(
 			_group.getGroupId(), availableLocales, LocaleUtil.US);
@@ -153,114 +154,83 @@ public class FriendlyURLServletTest {
 	public void tearDown() throws Exception {
 		ServiceContextThreadLocal.popServiceContext();
 
-		PropsValues.LOCALES_ENABLED = PropsUtil.getArray(
-			PropsKeys.LOCALES_ENABLED);
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE));
-
-		LanguageUtil.init();
 	}
 
 	@Test
 	public void testGetRedirectForAlternativeSite() throws Throwable {
-		Set<Locale> availableLocales = LanguageUtil.getAvailableLocales();
-		Locale defaultLocale = LocaleUtil.getDefault();
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.US, "home"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.HUNGARY, "/home-hu"
+			).put(
+				LocaleUtil.UK, "/home-gb"
+			).put(
+				LocaleUtil.US, "/home"
+			).build());
 
-		List<Locale> enabledLocales = Arrays.asList(
-			LocaleUtil.US, LocaleUtil.UK, LocaleUtil.HUNGARY);
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/en/home", true, false),
+			"/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/en/home", true, true),
+			"/en/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/en/home", true, true),
+			"/en-US/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/hu/home-hu", true, true),
+			"/hu/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/en-GB/home-gb", true, true),
+			"/en-GB/home");
 
-		CompanyTestUtil.resetCompanyLocales(
-			PortalUtil.getDefaultCompanyId(), enabledLocales, LocaleUtil.US);
+		String publicGroupFriendlyURL =
+			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+				_group.getFriendlyURL();
 
-		try {
-			_group = GroupTestUtil.updateDisplaySettings(
-				_group.getGroupId(), enabledLocales, LocaleUtil.US);
-
-			Layout layout = LayoutTestUtil.addTypePortletLayout(
-				_group.getGroupId(), false,
-				HashMapBuilder.put(
-					LocaleUtil.US, "home"
-				).build(),
-				HashMapBuilder.put(
-					LocaleUtil.HUNGARY, "/home-hu"
-				).put(
-					LocaleUtil.UK, "/home-gb"
-				).put(
-					LocaleUtil.US, "/home"
-				).build());
-
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/en/home", true, false),
-				"/home-gb");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/en/home", true, true),
-				"/en/home-gb");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/en/home", true, true),
-				"/en-US/home-gb");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/hu/home-hu", true, true),
-				"/hu/home-gb");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/en-GB/home-gb", true, true),
-				"/en-GB/home");
-
-			String publicGroupFriendlyURL =
-				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
-					_group.getFriendlyURL();
-
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(
-					StringBundler.concat(
-						"/en", publicGroupFriendlyURL, "/home"),
-					true, false),
-				publicGroupFriendlyURL + "/home-gb");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(
-					StringBundler.concat(
-						"/en", publicGroupFriendlyURL, "/home"),
-					true, true),
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(
+				StringBundler.concat("/en", publicGroupFriendlyURL, "/home"),
+				true, false),
+			publicGroupFriendlyURL + "/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(
+				StringBundler.concat("/en", publicGroupFriendlyURL, "/home"),
+				true, true),
+			StringBundler.concat("/en", publicGroupFriendlyURL, "/home-gb"));
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(
+				StringBundler.concat("/en", publicGroupFriendlyURL, "/home"),
+				true, true),
+			StringBundler.concat("/en-US", publicGroupFriendlyURL, "/home-gb"));
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(
+				StringBundler.concat("/hu", publicGroupFriendlyURL, "/home-hu"),
+				true, true),
+			StringBundler.concat("/hu", publicGroupFriendlyURL, "/home-gb"));
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(
 				StringBundler.concat(
-					"/en", publicGroupFriendlyURL, "/home-gb"));
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(
-					StringBundler.concat(
-						"/en", publicGroupFriendlyURL, "/home"),
-					true, true),
-				StringBundler.concat(
-					"/en-US", publicGroupFriendlyURL, "/home-gb"));
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(
-					StringBundler.concat(
-						"/hu", publicGroupFriendlyURL, "/home-hu"),
-					true, true),
-				StringBundler.concat(
-					"/hu", publicGroupFriendlyURL, "/home-gb"));
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(
-					StringBundler.concat(
-						"/en-GB", publicGroupFriendlyURL, "/home-gb"),
-					true, true),
-				StringBundler.concat(
-					"/en-GB", publicGroupFriendlyURL, "/home"));
+					"/en-GB", publicGroupFriendlyURL, "/home-gb"),
+				true, true),
+			StringBundler.concat("/en-GB", publicGroupFriendlyURL, "/home"));
 
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance(getURL(layout), false, false),
-				"/fr/home");
-			_testGetRedirectForAlternativeSite(
-				_redirectConstructor2.newInstance("/en/home", true, true),
-				"/fr/home-gb");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance(getURL(layout), false, false),
+			"/fr/home");
+		_testGetRedirectForAlternativeSite(
+			_redirectConstructor2.newInstance("/en/home", true, true),
+			"/fr/home-gb");
 
-			PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = false;
+		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = false;
 
-			_testGetRedirectForAlternativeSite(null, "/fr/home");
-			_testGetRedirectForAlternativeSite(null, "/fr/home-gb");
-		}
-		finally {
-			CompanyTestUtil.resetCompanyLocales(
-				PortalUtil.getDefaultCompanyId(), availableLocales,
-				defaultLocale);
-		}
+		_testGetRedirectForAlternativeSite(null, "/fr/home");
+		_testGetRedirectForAlternativeSite(null, "/fr/home-gb");
 	}
 
 	@Test
@@ -404,7 +374,7 @@ public class FriendlyURLServletTest {
 		testGetI18nRedirect("/fr", "/en");
 		testGetI18nRedirect("/hu", "/hu");
 		testGetI18nRedirect("/en", "/en");
-		testGetI18nRedirect("/de_DE", "/de_DE");
+		testGetI18nRedirect("/en_GB", "/en_GB");
 		testGetI18nRedirect("/en_US", "/en_US");
 	}
 
@@ -598,12 +568,11 @@ public class FriendlyURLServletTest {
 			HashMapBuilder.put(
 				locale, "/home"
 			).put(
-				LocaleUtil.GERMANY, "/home1"
+				LocaleUtil.UK, "/home1"
 			).build());
 
 		GroupTestUtil.updateDisplaySettings(
-			group.getGroupId(), Arrays.asList(LocaleUtil.GERMANY),
-			LocaleUtil.GERMANY);
+			group.getGroupId(), Arrays.asList(LocaleUtil.UK), LocaleUtil.UK);
 
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -52,6 +53,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Lourdes Fernández Besada
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "es_ES"}, defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class InputTagTest {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/LanguageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/LanguageResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LanguageIds;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -26,6 +27,10 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "es_ES", "fr_FR", "zh_CN"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class LanguageResourceTest extends BaseLanguageResourceTestCase {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -80,6 +81,9 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "es_ES"}, defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class NavigationMenuResourceTest
 	extends BaseNavigationMenuResourceTestCase {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/test/util/test/JournalTestUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/test/util/test/JournalTestUtilTest.java
@@ -23,18 +23,16 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,6 +44,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Manuel de la Peña
  */
+@LanguageIds(availableLanguageIds = "en_US", defaultLanguageId = "en_US")
 @RunWith(Arquillian.class)
 public class JournalTestUtilTest {
 
@@ -129,22 +128,8 @@ public class JournalTestUtilTest {
 
 	@Test(expected = LocaleException.class)
 	public void testAddDDMStructureWithNonexistingLocale() throws Exception {
-		Set<Locale> availableLocales = LanguageUtil.getAvailableLocales();
-		Locale defaultLocale = LocaleUtil.getDefault();
-
-		try {
-			CompanyTestUtil.resetCompanyLocales(
-				PortalUtil.getDefaultCompanyId(), Arrays.asList(LocaleUtil.US),
-				LocaleUtil.US);
-
-			DDMStructureTestUtil.addStructure(
-				JournalArticle.class.getName(), LocaleUtil.CANADA);
-		}
-		finally {
-			CompanyTestUtil.resetCompanyLocales(
-				PortalUtil.getDefaultCompanyId(), availableLocales,
-				defaultLocale);
-		}
+		DDMStructureTestUtil.addStructure(
+			JournalArticle.class.getName(), LocaleUtil.CANADA);
 	}
 
 	@Test

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -9,12 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.action.UpdateLanguageAction;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -25,7 +23,6 @@ import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -39,6 +36,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 
@@ -47,14 +45,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.servlet.http.HttpSession;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +60,10 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Ricardo Couso
  */
+@LanguageIds(
+	availableLanguageIds = {"de_DE", "en_GB", "en_US", "fr_FR"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class UpdateLanguageActionTest {
 
@@ -72,33 +71,6 @@ public class UpdateLanguageActionTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_originalAvailableLocales = _language.getAvailableLocales();
-		_originalDefaultLocale = LocaleUtil.getDefault();
-		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
-
-		_language.init();
-
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
-
-		PropsValues.LOCALES_ENABLED = TransformUtil.transformToArray(
-			_availableLocales, locale -> _language.getLanguageId(locale),
-			String.class);
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		_language.init();
-
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(), _originalAvailableLocales,
-			_originalDefaultLocale);
-
-		PropsValues.LOCALES_ENABLED = _originalLocalesEnabled;
-	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -495,16 +467,6 @@ public class UpdateLanguageActionTest {
 	private static final List<Locale> _availableLocales = Arrays.asList(
 		LocaleUtil.GERMANY, LocaleUtil.FRANCE, LocaleUtil.UK, LocaleUtil.US);
 	private static final Locale _defaultLocale = LocaleUtil.US;
-
-	@Inject
-	private static Language _language;
-
-	private static Set<Locale> _originalAvailableLocales;
-	private static Locale _originalDefaultLocale;
-	private static String[] _originalLocalesEnabled;
-
-	@Inject
-	private static Portal _portal;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/test/I18nServletTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/test/I18nServletTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 
@@ -37,10 +38,8 @@ import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,6 +53,10 @@ import org.springframework.mock.web.MockServletContext;
 /**
  * @author Juan González
  */
+@LanguageIds(
+	availableLanguageIds = {"en_GB", "en_US", "es_ES", "fr_CA"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class I18nServletTest extends I18nServlet {
 
@@ -61,41 +64,6 @@ public class I18nServletTest extends I18nServlet {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_availableLocales = _language.getAvailableLocales();
-		_defaultLocale = LocaleUtil.getDefault();
-		_hebrewLocale = new Locale("iw", "IL");
-		_localesEnabled = PropsValues.LOCALES_ENABLED;
-
-		_language.init();
-
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(),
-			Arrays.asList(
-				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.UK,
-				LocaleUtil.US, _hebrewLocale),
-			LocaleUtil.US);
-
-		PropsValues.LOCALES_ENABLED = new String[] {
-			_language.getLanguageId(LocaleUtil.CANADA_FRENCH),
-			_language.getLanguageId(LocaleUtil.SPAIN),
-			_language.getLanguageId(LocaleUtil.UK),
-			_language.getLanguageId(LocaleUtil.US),
-			_language.getLanguageId(_hebrewLocale)
-		};
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		_language.init();
-
-		CompanyTestUtil.resetCompanyLocales(
-			_portal.getDefaultCompanyId(), _availableLocales, _defaultLocale);
-
-		PropsValues.LOCALES_ENABLED = _localesEnabled;
-	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -391,38 +359,66 @@ public class I18nServletTest extends I18nServlet {
 
 	@Test
 	public void testSendRedirectWithLegacyLanguageCode() throws Exception {
-		MockServletContext mockServletContext = new MockServletContext();
+		Locale hebrewLocale = new Locale("iw", "IL");
 
-		String contextPath = StringPool.SLASH + RandomTestUtil.randomString(10);
+		Set<Locale> availableLocales = _language.getAvailableLocales();
+		Locale defaultLocale = LocaleUtil.getDefault();
+		String[] localesEnabled = PropsValues.LOCALES_ENABLED;
 
-		mockServletContext.setContextPath(contextPath);
+		try {
+			_language.init();
 
-		init(new MockServletConfig(mockServletContext));
+			CompanyTestUtil.resetCompanyLocales(
+				_portal.getDefaultCompanyId(),
+				Arrays.asList(LocaleUtil.US, hebrewLocale), LocaleUtil.US);
 
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
+			PropsValues.LOCALES_ENABLED = new String[] {
+				_language.getLanguageId(LocaleUtil.US),
+				_language.getLanguageId(hebrewLocale)
+			};
 
-		mockHttpServletRequest.setServletPath(
-			String.format(
-				"/%s_%s", _hebrewLocale.getLanguage(),
-				_hebrewLocale.getCountry()));
+			MockServletContext mockServletContext = new MockServletContext();
 
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
+			String contextPath =
+				StringPool.SLASH + RandomTestUtil.randomString(10);
 
-		sendRedirect(
-			mockHttpServletRequest, mockHttpServletResponse,
-			getI18nData(mockHttpServletRequest));
+			mockServletContext.setContextPath(contextPath);
 
-		Assert.assertEquals(
-			HttpServletResponse.SC_MOVED_PERMANENTLY,
-			mockHttpServletResponse.getStatus());
+			init(new MockServletConfig(mockServletContext));
 
-		Assert.assertEquals(
-			String.format(
-				"%s/%s-%s/", contextPath, _hebrewLocale.getLanguage(),
-				_hebrewLocale.getCountry()),
-			mockHttpServletResponse.getHeader("Location"));
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.setServletPath(
+				String.format(
+					"/%s_%s", hebrewLocale.getLanguage(),
+					hebrewLocale.getCountry()));
+
+			MockHttpServletResponse mockHttpServletResponse =
+				new MockHttpServletResponse();
+
+			sendRedirect(
+				mockHttpServletRequest, mockHttpServletResponse,
+				getI18nData(mockHttpServletRequest));
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_MOVED_PERMANENTLY,
+				mockHttpServletResponse.getStatus());
+
+			Assert.assertEquals(
+				String.format(
+					"%s/%s-%s/", contextPath, hebrewLocale.getLanguage(),
+					hebrewLocale.getCountry()),
+				mockHttpServletResponse.getHeader("Location"));
+		}
+		finally {
+			_language.init();
+
+			CompanyTestUtil.resetCompanyLocales(
+				_portal.getDefaultCompanyId(), availableLocales, defaultLocale);
+
+			PropsValues.LOCALES_ENABLED = localesEnabled;
+		}
 	}
 
 	@Test
@@ -587,14 +583,8 @@ public class I18nServletTest extends I18nServlet {
 	private static final boolean _ORIGINAL_LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE =
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE;
 
-	private static Set<Locale> _availableLocales;
-	private static Locale _defaultLocale;
-	private static Locale _hebrewLocale;
-
 	@Inject
 	private static Language _language;
-
-	private static String[] _localesEnabled;
 
 	@Inject
 	private static Portal _portal;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
@@ -88,6 +89,10 @@ import org.junit.runner.RunWith;
  * @author Roberto Díaz
  * @author Sergio González
  */
+@LanguageIds(
+	availableLanguageIds = {"de_DE", "en", "en_US", "es_ES", "pt_BR", "zh_CN"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 @Sync(cleanTransaction = true)
 public class GroupServiceTest {

--- a/portal-test/src/com/liferay/portal/test/rule/LanguageIdTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LanguageIdTestRule.java
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.rule.ClassTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.util.PropsValues;
+
+import org.junit.runner.Description;
+
+/**
+ * @author Jonathan McCann
+ */
+public class LanguageIdTestRule extends ClassTestRule<Void> {
+
+	public static final LanguageIdTestRule INSTANCE = new LanguageIdTestRule();
+
+	@Override
+	protected void afterClass(Description description, Void v)
+		throws Throwable {
+
+		LanguageIds languageIds = description.getAnnotation(LanguageIds.class);
+
+		if (languageIds == null) {
+			return;
+		}
+
+		_setCompanyLocales(
+			_originalAvailableLanguageIds, _originalDefaultLanguageId,
+			_originalLocalesEnabled);
+	}
+
+	@Override
+	protected Void beforeClass(Description description) throws Throwable {
+		LanguageIds languageIds = description.getAnnotation(LanguageIds.class);
+
+		if (languageIds == null) {
+			return null;
+		}
+
+		_originalAvailableLanguageIds = StringUtil.merge(
+			LocaleUtil.toLanguageIds(LanguageUtil.getAvailableLocales()));
+		_originalDefaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getDefault());
+		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
+
+		_setCompanyLocales(
+			ArrayUtil.toString(
+				languageIds.availableLanguageIds(), StringPool.BLANK),
+			languageIds.defaultLanguageId(),
+			languageIds.availableLanguageIds());
+
+		return null;
+	}
+
+	private void _setCompanyLocales(
+			String availableLanguageIds, String defaultLanguageId,
+			String[] localesEnabled)
+		throws Exception {
+
+		LanguageUtil.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			PortalUtil.getDefaultCompanyId(), availableLanguageIds,
+			defaultLanguageId);
+
+		PropsValues.LOCALES_ENABLED = localesEnabled;
+	}
+
+	private String _originalAvailableLanguageIds;
+	private String _originalDefaultLanguageId;
+	private String[] _originalLocalesEnabled;
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/LanguageIds.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LanguageIds.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.test.rule;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Jonathan McCann
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LanguageIds {
+
+	public String[] availableLanguageIds();
+
+	public String defaultLanguageId();
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -37,6 +37,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 		}
 
 		testRules.add(FeatureFlagTestRule.INSTANCE);
+		testRules.add(LanguageIdTestRule.INSTANCE);
 		testRules.add(PortalRunModeClassTestRule.INSTANCE);
 		testRules.add(SynchronousDestinationTestRule.INSTANCE);
 		testRules.add(DataGuardTestRule.INSTANCE);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41951

In certain cases, the portal does not have the correct available or default locales. This causes tests to fail when they shouldn't be.

# How am I fixing it?

These changes introduce a new test rule that allows defining the available and default language IDs. This makes it so that test classes that need certain locales can define them easily and have the locales reset automatically after the test finishes.

9ae78868abd2c9afd54895f59e5235bc33e337bf - This applies the test rule to tests that are currently failing due to this issue.

ad2045ad8d1c17158cffdad12a2b4ae14ab509da - This applies the test rule to other tests that use similar logic but may not be failing (yet).

There are other test classes that reset the locales but I was unable to apply the test rule because they either needed to change the locale in the middle of the test or they were changing the locales for a company other than the default one.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.InputTagTest` (among others)