### PR TITLE
LPD-43048 Add missing test paths for the site-management routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9302,14 +9302,17 @@
         apps/site-navigation/**
 
     test.batch.class.names.includes[site-management]=\
-        **/friendly-url-service/**/*Test.java,\
-        **/friendly-url-test/**/*Test.java,\
+        **/click-to-chat/**/*Test.java,\
+        **/friendly-url-**/**/*Test.java,\
         **/headless/headless-delivery/**/*Language*Test.java,\
         **/headless/headless-delivery/**/*NavigationMenu*Test.java,\
-        **/redirect-test/**/*Test.java,\
-        **/site/site-admin-test/**/*Test.java,\
+        **/headless/headless-site/**/*Test.java,\
+        **/portal-url-builder/**/*Test.java,\
+        **/redirect-**/**/*Test.java,\
+        **/site/site-admin-**/**/*Test.java,\
         **/site/site-memberships-test/**/*Test.java,\
         **/site/site-test/**/*Test.java,\
+        **/site-initializer/site-initializer-extender/**/**/*Test.java,\
         **/site-navigation/**/*Test.java
 
     test.batch.dist.app.servers[site-management]=tomcat


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43048

# How am I fixing it?

When these components were inherited the tests were moved to the site-management routine. However, this list was incomplete and missing certain modules. This list should now be updated to reflected all the modules we are in charge of.