### PR TITLE
LPD-43051 Fix FriendlyURLSeparatorCompanyConfigurationDisplayContextTest

### DIFF
--- a/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
@@ -323,6 +323,7 @@ public class FriendlyURLSeparatorCompanyConfigurationDisplayContextTest {
 		Company company = new CompanyImpl();
 
 		company.setCompanyId(0);
+		company.setGroupId(0);
 
 		themeDisplay.setCompany(company);
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43051

# How am I fixing it?

LPD-40144 made it so that the company's group would be fetched if the group ID didn't exist yet. Since this is a unit test we should supply a group ID to avoid this.

# How can you verify that it works?

In `friendly-url-web` run `gw test --tests "FriendlyURLSeparatorCompanyConfigurationDisplayContextTest"`