### PR TITLE
LPD-43196 Redirect URLs doesn't handle property locale.prepend.friendly.url.style when it's value is set to 3

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -861,8 +861,9 @@ public class FriendlyURLServlet extends HttpServlet {
 	}
 
 	private String _getLocalizedFriendlyURL(
-		HttpServletRequest httpServletRequest, Layout layout, Locale locale,
-		Locale originalLocale) {
+			HttpServletRequest httpServletRequest, Layout layout, Locale locale,
+			Locale originalLocale)
+		throws PortalException {
 
 		String requestURI = _getRequestURI(httpServletRequest);
 
@@ -937,9 +938,19 @@ public class FriendlyURLServlet extends HttpServlet {
 			portal.getCompanyId(httpServletRequest),
 			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
 
-		if ((localePrependFriendlyURLStyle == 0) ||
-			((localePrependFriendlyURLStyle == 1) &&
-			 locale.equals(LocaleUtil.getDefault()))) {
+		User user = _getUser(httpServletRequest);
+
+		Locale userLocale = user.getLocale();
+
+		if (!user.isGuestUser() && (localePrependFriendlyURLStyle == 3) &&
+			locale.equals(userLocale)) {
+
+			appendI18nPath = false;
+		}
+		else if ((localePrependFriendlyURLStyle == 0) ||
+				 (((localePrependFriendlyURLStyle == 1) ||
+				   (localePrependFriendlyURLStyle == 3)) &&
+				  locale.equals(LocaleUtil.getDefault()))) {
 
 			appendI18nPath = false;
 		}
@@ -1132,8 +1143,9 @@ public class FriendlyURLServlet extends HttpServlet {
 	}
 
 	private Locale _setAlternativeLayoutFriendlyURL(
-		long companyId, HttpServletRequest httpServletRequest, Layout layout,
-		String friendlyURL, SiteFriendlyURL siteFriendlyURL) {
+			long companyId, HttpServletRequest httpServletRequest,
+			Layout layout, String friendlyURL, SiteFriendlyURL siteFriendlyURL)
+		throws PortalException {
 
 		List<LayoutFriendlyURL> layoutFriendlyURLs =
 			layoutFriendlyURLLocalService.getLayoutFriendlyURLs(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletLocalizedFriendlyURLTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletLocalizedFriendlyURLTest.java
@@ -160,6 +160,27 @@ public class FriendlyURLServletLocalizedFriendlyURLTest {
 	}
 
 	@Test
+	public void testIncludeI18nPathCustomLocaleAlgorithm3() throws Exception {
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
+
+		try {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE = 3;
+
+			_assertLocalizedSiteLayoutFriendlyURL(
+				_group.getGroupId(),
+				LayoutTestUtil.addTypePortletLayout(
+					_group.getGroupId(), false, _nameMap, _friendlyURLMap),
+				"/inicio", LocaleUtil.BRAZIL, LocaleUtil.BRAZIL, "/inicio",
+				true);
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
+	}
+
+	@Test
 	public void testIncludeI18nPathDefaultLocaleAlgorithm0() throws Exception {
 		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
 			_group.getCompanyId());
@@ -218,6 +239,26 @@ public class FriendlyURLServletLocalizedFriendlyURLTest {
 				LayoutTestUtil.addTypePortletLayout(
 					_group.getGroupId(), false, _nameMap, _friendlyURLMap),
 				"/home", LocaleUtil.US, LocaleUtil.US, "/home", true);
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
+	}
+
+	@Test
+	public void testIncludeI18nPathDefaultLocaleAlgorithm3() throws Exception {
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
+
+		try {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE = 3;
+
+			_assertLocalizedSiteLayoutFriendlyURL(
+				_group.getGroupId(),
+				LayoutTestUtil.addTypePortletLayout(
+					_group.getGroupId(), false, _nameMap, _friendlyURLMap),
+				"/home", LocaleUtil.US, LocaleUtil.US, "/home", false);
 		}
 		finally {
 			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-43196

Steps to reproduce are in the Ticket.

To test if it works, just follow the steps or run in `<portal-home>/modules/apps/friendly-url/friendly-url-test/`:

 `gw testIntegration --tests FriendlyURLServletLocalizedFriendlyURLTest.testIncludeI18nPathCustomLocaleAlgorithm3`
 `gw testIntegration --tests FriendlyURLServletLocalizedFriendlyURLTest.testIncludeI18nPathDefaultLocaleAlgorithm3`
 
 