### PR TITLE
LPD-43349 Add the modelClassPK to searchContext when asset is created in publication

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/history/JournalArticleCTCollectionHistoryProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/history/JournalArticleCTCollectionHistoryProvider.java
@@ -137,6 +137,11 @@ public class JournalArticleCTCollectionHistoryProvider
 				"modelClassNameId", new Long[] {classNameId});
 
 			if (journalArticle == null) {
+				if (classPK > 0) {
+					searchContext.setAttribute(
+						"modelClassPK", new Long[] {classPK});
+				}
+
 				return;
 			}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/history/KBArticleCTCollectionHistoryProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/history/KBArticleCTCollectionHistoryProvider.java
@@ -135,6 +135,11 @@ public class KBArticleCTCollectionHistoryProvider
 				"modelClassNameId", new Long[] {classNameId});
 
 			if (kbArticle == null) {
+				if (classPK > 0) {
+					searchContext.setAttribute(
+						"modelClassPK", new Long[] {classPK});
+				}
+
 				return;
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-43349

When getting the searchContext from the HistoryProvider, the CTCollectionThreadLocal is set to production. So when the asset is created in the publication, it will not exist in production and the modelClassPK will not be added to the searchContext.