### PR TITLE
LPD-22216 Masterclass template fails when default locale is not en_US

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-2/src/main/resources/site-initializer/journal-articles/test-journal-folder-3/journal_article.xml
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-2/src/main/resources/site-initializer/journal-articles/test-journal-folder-3/journal_article.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]">
 	<dynamic-element index-type="keyword" instance-id="ivhhkvql" name="aField" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -1841,6 +1841,10 @@ public class BundleSiteInitializerTest {
 			Validator.isNull(journalArticle3.getDDMTemplateKey()));
 		Assert.assertEquals(
 			"Test Journal Article 3", journalArticle3.getTitle());
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(
+				_portal.getSiteDefaultLocale(_group.getGroupId())),
+			journalArticle3.getDefaultLanguageId());
 
 		List<JournalFolder> journalFolders = _journalFolderService.getFolders(
 			_group.getGroupId());

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2457,6 +2457,12 @@ public class BundleSiteInitializer implements SiteInitializer {
 			Map<String, String> stringUtilReplaceValues)
 		throws Exception {
 
+		stringUtilReplaceValues.put(
+			"LOCALE_DEFAULT",
+			LocaleUtil.toLanguageId(
+				_portal.getSiteDefaultLocale(
+					serviceContext.getScopeGroupId())));
+
 		_addOrUpdateJournalArticles(
 			null, "/site-initializer/journal-articles", serviceContext,
 			siteNavigationMenuItemSettingsBuilder, stringUtilReplaceValues);

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/blog-structure.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/blog-structure.xml
@@ -8,16 +8,16 @@
 			<![CDATA[
 				{
 					"availableLanguageIds": [
-						"en_US"
+						"[$LOCALE_DEFAULT$]"
 					],
-					"defaultLanguageId": "en_US",
+					"defaultLanguageId": "[$LOCALE_DEFAULT$]",
 					"fields": [
 						{
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataType": "string",
 							"direction": "[vertical]",
@@ -27,7 +27,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Title"
+								"[$LOCALE_DEFAULT$]": "Title"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -35,34 +35,34 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
 						},
 						{
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataType": "string",
 							"direction": "[vertical]",
@@ -72,7 +72,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Subtitle"
+								"[$LOCALE_DEFAULT$]": "Subtitle"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -80,24 +80,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -108,33 +108,33 @@
 							"fieldReference": "MainImage",
 							"indexType": "text",
 							"label": {
-								"en_US": "Main Image"
+								"[$LOCALE_DEFAULT$]": "Main Image"
 							},
 							"localizable": true,
 							"name": "MainImage",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": "{}"
+								"[$LOCALE_DEFAULT$]": "{}"
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "image",
 							"visibilityExpression": ""
 						},
 						{
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataType": "string",
 							"direction": "[vertical]",
@@ -144,7 +144,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Image Author"
+								"[$LOCALE_DEFAULT$]": "Image Author"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -152,24 +152,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -180,23 +180,23 @@
 							"fieldReference": "Body",
 							"indexType": "text",
 							"label": {
-								"en_US": "Body"
+								"[$LOCALE_DEFAULT$]": "Body"
 							},
 							"localizable": true,
 							"name": "Body",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "rich_text",
 							"visibilityExpression": ""

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/classroom-structure.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/classroom-structure.xml
@@ -8,17 +8,17 @@
 			<![CDATA[
 				{
 					"availableLanguageIds": [
-						"en_US"
+						"[$LOCALE_DEFAULT$]"
 					],
-					"defaultLanguageId": "en_US",
+					"defaultLanguageId": "[$LOCALE_DEFAULT$]",
 					"fields": [
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -31,7 +31,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Course Name"
+								"[$LOCALE_DEFAULT$]": "Course Name"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -39,24 +39,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -67,23 +67,23 @@
 							"fieldReference": "CourseVideoThumbnail",
 							"indexType": "text",
 							"label": {
-								"en_US": "Course Video Thumbnail"
+								"[$LOCALE_DEFAULT$]": "Course Video Thumbnail"
 							},
 							"localizable": true,
 							"name": "CourseVideoThumbnail",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": "{}"
+								"[$LOCALE_DEFAULT$]": "{}"
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "image",
 							"visibilityExpression": ""
@@ -94,7 +94,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module1",
 							"label": {
-								"en_US": "Module 1"
+								"[$LOCALE_DEFAULT$]": "Module 1"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -103,10 +103,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -119,7 +119,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Name"
+										"[$LOCALE_DEFAULT$]": "Module 1 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -127,34 +127,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -164,7 +164,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Description"
+										"[$LOCALE_DEFAULT$]": "Module 1 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -172,34 +172,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -209,7 +209,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Video URL"
+										"[$LOCALE_DEFAULT$]": "Module 1 Video URL"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -217,24 +217,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -253,7 +253,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module2",
 							"label": {
-								"en_US": "Module 2"
+								"[$LOCALE_DEFAULT$]": "Module 2"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -262,10 +262,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -278,7 +278,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Name"
+										"[$LOCALE_DEFAULT$]": "Module 2 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -286,34 +286,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -323,7 +323,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Description"
+										"[$LOCALE_DEFAULT$]": "Module 2 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -331,34 +331,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -368,7 +368,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Video URL"
+										"[$LOCALE_DEFAULT$]": "Module 2 Video URL"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -376,24 +376,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -412,7 +412,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module3",
 							"label": {
-								"en_US": "Module 3"
+								"[$LOCALE_DEFAULT$]": "Module 3"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -421,10 +421,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -437,7 +437,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Name"
+										"[$LOCALE_DEFAULT$]": "Module 3 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -445,34 +445,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -482,7 +482,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Description"
+										"[$LOCALE_DEFAULT$]": "Module 3 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -490,34 +490,34 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
 								},
 								{
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataType": "string",
 									"direction": "[vertical]",
@@ -527,7 +527,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Video URL"
+										"[$LOCALE_DEFAULT$]": "Module 3 Video URL"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -535,24 +535,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/course-structure.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/course-structure.xml
@@ -8,17 +8,17 @@
 			<![CDATA[
 				{
 					"availableLanguageIds": [
-						"en_US"
+						"[$LOCALE_DEFAULT$]"
 					],
-					"defaultLanguageId": "en_US",
+					"defaultLanguageId": "[$LOCALE_DEFAULT$]",
 					"fields": [
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -31,7 +31,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Name"
+								"[$LOCALE_DEFAULT$]": "Name"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -39,24 +39,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -64,10 +64,10 @@
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -80,7 +80,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Short Description"
+								"[$LOCALE_DEFAULT$]": "Short Description"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -88,24 +88,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -113,10 +113,10 @@
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -129,7 +129,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Program Description"
+								"[$LOCALE_DEFAULT$]": "Program Description"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -137,24 +137,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -165,23 +165,23 @@
 							"fieldReference": "VideoThumbnail",
 							"indexType": "text",
 							"label": {
-								"en_US": "Video Thumbnail"
+								"[$LOCALE_DEFAULT$]": "Video Thumbnail"
 							},
 							"localizable": true,
 							"name": "VideoThumbnail",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": "{}"
+								"[$LOCALE_DEFAULT$]": "{}"
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "image",
 							"visibilityExpression": ""
@@ -192,23 +192,23 @@
 							"fieldReference": "Video",
 							"indexType": "text",
 							"label": {
-								"en_US": "Video"
+								"[$LOCALE_DEFAULT$]": "Video"
 							},
 							"localizable": true,
 							"name": "Video",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "rich_text",
 							"visibilityExpression": ""
@@ -219,7 +219,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Features",
 							"label": {
-								"en_US": "Features"
+								"[$LOCALE_DEFAULT$]": "Features"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -228,10 +228,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -244,7 +244,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Number of Lessons"
+										"[$LOCALE_DEFAULT$]": "Number of Lessons"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -252,24 +252,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -277,10 +277,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -293,7 +293,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Quizzes"
+										"[$LOCALE_DEFAULT$]": "Quizzes"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -301,24 +301,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -326,10 +326,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -342,7 +342,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Duration"
+										"[$LOCALE_DEFAULT$]": "Duration"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -350,24 +350,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -375,10 +375,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -391,7 +391,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Max Retakes"
+										"[$LOCALE_DEFAULT$]": "Max Retakes"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -399,24 +399,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -424,10 +424,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -440,7 +440,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Pass Percentage"
+										"[$LOCALE_DEFAULT$]": "Pass Percentage"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -448,24 +448,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -484,7 +484,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module1",
 							"label": {
-								"en_US": "Module 1"
+								"[$LOCALE_DEFAULT$]": "Module 1"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -493,10 +493,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -509,7 +509,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Description"
+										"[$LOCALE_DEFAULT$]": "Module 1 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -517,24 +517,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -542,10 +542,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -558,7 +558,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Name"
+										"[$LOCALE_DEFAULT$]": "Module 1 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -566,24 +566,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -591,10 +591,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -607,7 +607,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Duration"
+										"[$LOCALE_DEFAULT$]": "Module 1 Duration"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -615,24 +615,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -640,10 +640,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -656,7 +656,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 1 Number of Lessons"
+										"[$LOCALE_DEFAULT$]": "Module 1 Number of Lessons"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -664,24 +664,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -700,7 +700,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module2",
 							"label": {
-								"en_US": "Module 2"
+								"[$LOCALE_DEFAULT$]": "Module 2"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -709,10 +709,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -725,7 +725,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Description"
+										"[$LOCALE_DEFAULT$]": "Module 2 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -733,24 +733,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -758,10 +758,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -774,7 +774,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Name"
+										"[$LOCALE_DEFAULT$]": "Module 2 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -782,24 +782,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -807,10 +807,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -823,7 +823,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Duration"
+										"[$LOCALE_DEFAULT$]": "Module 2 Duration"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -831,24 +831,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -856,10 +856,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -872,7 +872,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 2 Number of Lessons"
+										"[$LOCALE_DEFAULT$]": "Module 2 Number of Lessons"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -880,24 +880,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -916,7 +916,7 @@
 							"ddmStructureLayoutId": "",
 							"fieldReference": "Module3",
 							"label": {
-								"en_US": "Module 3"
+								"[$LOCALE_DEFAULT$]": "Module 3"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": false,
@@ -925,10 +925,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -941,7 +941,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Description"
+										"[$LOCALE_DEFAULT$]": "Module 3 Description"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -949,24 +949,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -974,10 +974,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -990,7 +990,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Name"
+										"[$LOCALE_DEFAULT$]": "Module 3 Name"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -998,24 +998,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -1023,10 +1023,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -1039,7 +1039,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Duration"
+										"[$LOCALE_DEFAULT$]": "Module 3 Duration"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -1047,24 +1047,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""
@@ -1072,10 +1072,10 @@
 								{
 									"autocomplete": false,
 									"confirmationErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"confirmationLabel": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"dataSourceType": "",
 									"dataType": "string",
@@ -1088,7 +1088,7 @@
 									"hideField": false,
 									"indexType": "keyword",
 									"label": {
-										"en_US": "Module 3 Number of Lessons"
+										"[$LOCALE_DEFAULT$]": "Module 3 Number of Lessons"
 									},
 									"labelAtStructureLevel": true,
 									"localizable": true,
@@ -1096,24 +1096,24 @@
 									"nativeField": false,
 									"objectFieldName": "",
 									"placeholder": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"predefinedValue": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"readOnly": false,
 									"repeatable": false,
 									"requireConfirmation": false,
 									"required": false,
 									"requiredErrorMessage": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"showLabel": true,
 									"tip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"tooltip": {
-										"en_US": ""
+										"[$LOCALE_DEFAULT$]": ""
 									},
 									"type": "text",
 									"visibilityExpression": ""

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/teacher-structure.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/ddm-structures/teacher-structure.xml
@@ -8,17 +8,17 @@
 			<![CDATA[
 				{
 					"availableLanguageIds": [
-						"en_US"
+						"[$LOCALE_DEFAULT$]"
 					],
-					"defaultLanguageId": "en_US",
+					"defaultLanguageId": "[$LOCALE_DEFAULT$]",
 					"fields": [
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -31,7 +31,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Name"
+								"[$LOCALE_DEFAULT$]": "Name"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -39,24 +39,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""
@@ -67,23 +67,23 @@
 							"fieldReference": "Image",
 							"indexType": "text",
 							"label": {
-								"en_US": "Image"
+								"[$LOCALE_DEFAULT$]": "Image"
 							},
 							"localizable": true,
 							"name": "Image",
 							"objectFieldName": "",
 							"predefinedValue": {
-								"en_US": "{}"
+								"[$LOCALE_DEFAULT$]": "{}"
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "image",
 							"visibilityExpression": ""
@@ -91,10 +91,10 @@
 						{
 							"autocomplete": false,
 							"confirmationErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"confirmationLabel": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"dataSourceType": "",
 							"dataType": "string",
@@ -107,7 +107,7 @@
 							"hideField": false,
 							"indexType": "keyword",
 							"label": {
-								"en_US": "Info"
+								"[$LOCALE_DEFAULT$]": "Info"
 							},
 							"labelAtStructureLevel": true,
 							"localizable": true,
@@ -115,24 +115,24 @@
 							"nativeField": false,
 							"objectFieldName": "",
 							"placeholder": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"predefinedValue": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"readOnly": false,
 							"repeatable": false,
 							"requireConfirmation": false,
 							"required": false,
 							"requiredErrorMessage": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"showLabel": true,
 							"tip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"tooltip": {
-								"en_US": ""
+								"[$LOCALE_DEFAULT$]": ""
 							},
 							"type": "text",
 							"visibilityExpression": ""

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_01.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_01.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Think you're cut out for doing management?]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Think you're cut out for doing management?]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_01.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Monstera from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Monstera from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_02.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_02.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Meet the Steve Jobs of the marketing industry]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Meet the Steve Jobs of the marketing industry]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_02.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by fauxels from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by fauxels from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_03.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_03.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The worst advice we've ever heard about marketing]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The worst advice we've ever heard about marketing]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_03.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Mimi Thian on Unsplash.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Mimi Thian on Unsplash.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_04.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_04.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[5 tools everyone in the design industry should be using]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[5 tools everyone in the design industry should be using]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_04.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by William Fortunato from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by William Fortunato from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_05.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_05.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[When professionals run into problems with design]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[When professionals run into problems with design]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_05.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Fauxels from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Fauxels from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_06.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_06.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Great people doing a great job in the design industry]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Great people doing a great job in the design industry]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_06.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Vlada Karpovich from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Vlada Karpovich from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_07.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_07.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[What the best Management pros do (and you should too)]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[What the best Management pros do (and you should too)]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_07.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Monstera from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Monstera from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_08.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_08.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[ 20 gifts you can give to your marketing boss]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[ 20 gifts you can give to your marketing boss]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_08.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by William Fortunato from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by William Fortunato from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[
 		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_09.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/blog-entries/blog_entry_09.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2D8LdBbz" name="Title" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[25 management tips from top industry experts]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[25 management tips from top industry experts]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="rDvJ4CN6" name="Subtitle" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[The subtitle summarizes the publication in a few short sentences aimed at motivating to continue reading.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="bMNTozJr" name="MainImage" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/blog_09.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="wAbSpc0d" name="ImageAuthor" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Photo by Ivan Samkov from Pexels.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Photo by Ivan Samkov from Pexels.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="f65XxYew" name="Body" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis ultricies lacus sed turpis tincidunt id. Est ante in nibh mauris cursus mattis molestie a iaculis. Ut tortor pretium viverra suspendisse potenti nullam ac tortor. Amet est placerat in egestas erat imperdiet sed euismod nisi. Sagittis nisl rhoncus mattis rhoncus. Consectetur purus ut faucibus pulvinar elementum integer enim. Convallis tellus id interdum velit. Blandit volutpat maecenas volutpat blandit. Facilisis leo vel fringilla est. Aliquam purus sit amet luctus venenatis lectus magna fringilla.</p>
 		<h3>Analyze your audience well</h3>
 		<p>Aliquam malesuada bibendum arcu vitae. Sapien pellentesque habitant morbi tristique senectus. Tempus egestas sed sed risus pretium quam vulputate. Nisl pretium fusce id velit ut. Id semper risus in hendrerit gravida rutrum. Aliquet bibendum enim facilisis gravida neque convallis a cras. Consequat id porta nibh venenatis. Diam in arcu cursus euismod quis viverra nibh cras pulvinar. Eget dolor morbi non arcu risus quis varius quam quisque.</p>
 		<p>Orci eu lobortis elementum nibh tellus molestie nunc non blandit. Lacus vel facilisis volutpat est velit. Curabitur vitae nunc sed velit dignissim sodales. Nibh sit amet commodo nulla. Venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus. Mattis pellentesque id nibh tortor id aliquet lectus. Leo in vitae turpis massa sed elementum tempus egestas. Commodo ullamcorper a lacus vestibulum sed arcu non odio euismod. Ut venenatis tellus in metus vulputate eu scelerisque.</p>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_design.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_design.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="4yJnBIV5" name="CourseName" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Product Design Bootcamp]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Product Design Bootcamp]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="MczeHQtp" name="CourseVideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_design.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Jaz7WIYP" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="yYPMyXOv" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="c8d1TMpg" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Design Fundamentals]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Design Fundamentals]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="U6CTDaeL" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="0hAxBORo" name="Module1VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="HCY5k4eO" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="xYK5O47l" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="luGDcrXu" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Research and Strategy]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Research and Strategy]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="vLB1NckH" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="rortlNxV" name="Module2VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="gJssL0y7" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="iCZAis4U" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="QnjR2RWP" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[User Interface Design]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[User Interface Design]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="VtcTUzve" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="tbnC2EPp" name="Module3VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_management.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_management.xml
@@ -1,50 +1,50 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="4yJnBIV5" name="CourseName" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Project Manager Certificate]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Project Manager Certificate]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="MczeHQtp" name="CourseVideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_management.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Jaz7WIYP" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="yYPMyXOv" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="c8d1TMpg" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Product Strategy]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Product Strategy]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="U6CTDaeL" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="0hAxBORo" name="Module1VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="HCY5k4eO" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="xYK5O47l" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="luGDcrXu" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Agile Product Development]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Agile Product Development]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="vLB1NckH" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="rortlNxV" name="Module2VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="gJssL0y7" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="iCZAis4U" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="QnjR2RWP" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Refining Products]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Refining Products]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="VtcTUzve" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="tbnC2EPp" name="Module3VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_marketing.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/classrooms/classroom_marketing.xml
@@ -1,50 +1,50 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="4yJnBIV5" name="CourseName" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Digital Marketing Bootcamp]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Digital Marketing Bootcamp]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="MczeHQtp" name="CourseVideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_marketing.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Jaz7WIYP" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="yYPMyXOv" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="c8d1TMpg" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Marketing Planning]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Marketing Planning]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="U6CTDaeL" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="0hAxBORo" name="Module1VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="HCY5k4eO" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="xYK5O47l" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="luGDcrXu" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Content Marketing]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Content Marketing]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="vLB1NckH" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="rortlNxV" name="Module2VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="gJssL0y7" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="iCZAis4U" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="QnjR2RWP" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Social Media Marketing]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Social Media Marketing]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="VtcTUzve" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="tbnC2EPp" name="Module3VideoURL" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]]]>
 			</dynamic-content>
 		</dynamic-element>
 	</dynamic-element>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_design.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_design.xml
@@ -1,84 +1,84 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="20NosvcP" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Product Design Bootcamp]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Product Design Bootcamp]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="8HFRNkw7" name="ShortDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="xa29z3C8" name="ProgramDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="1pCS00XC" name="VideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_design.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="UQIv4nRI" name="Video" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p><video controls=""><source src="[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]" type="video/mp4" /></video></p>]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p><video controls=""><source src="[$DOCUMENT_URL:/site-initializer/documents/group/video_design.mp4$]" type="video/mp4" /></video></p>]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="jSnynw83" name="FeaturesFieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="g4XtKzw3" name="Features" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uikm0Vgm" name="NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[9]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[9]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="HtZkz1TZ" name="Quizzes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="kDGj9Ehy" name="Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="dZKl0npa" name="MaxRetakes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="cRGhBAb7" name="PassPercentage" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[90%]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[90%]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="lG30GnjH" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="0yH8J30n" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uhmsaSqS" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="52l34J8D" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Design Fundamentals]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Design Fundamentals]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="jvTFfCuc" name="Module1Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="qYVkHEGy" name="Module1NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Uw4M7Qj0" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="3RgF98i4" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="8j0ae9kk" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="1p8AXQxS" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Research and Strategy]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Research and Strategy]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="DZr5UmkG" name="Module2Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="KhvnhwGK" name="Module2NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="SxTtR5AV" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="um46jj2d" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="6MnRQsKD" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="l17Ounw6" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[User Interface Design]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[User Interface Design]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="CQRGFie1" name="Module3Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="PwjzeQAp" name="Module3NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_management.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_management.xml
@@ -1,86 +1,86 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="20NosvcP" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Project Manager Certification]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Project Manager Certification]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="8HFRNkw7" name="ShortDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="xa29z3C8" name="ProgramDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="1pCS00XC" name="VideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_management.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="UQIv4nRI" name="Video" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>
 <video controls=""><source src="[$DOCUMENT_URL:/site-initializer/documents/group/video_management.mp4$]" type="video/mp4" /></video>
 </p>]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="jSnynw83" name="FeaturesFieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="g4XtKzw3" name="Features" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uikm0Vgm" name="NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[9]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[9]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="HtZkz1TZ" name="Quizzes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="kDGj9Ehy" name="Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="dZKl0npa" name="MaxRetakes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="cRGhBAb7" name="PassPercentage" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[90%]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[90%]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="lG30GnjH" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="0yH8J30n" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uhmsaSqS" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="52l34J8D" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Exploration & Strategy]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Exploration & Strategy]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="jvTFfCuc" name="Module1Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="qYVkHEGy" name="Module1NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Uw4M7Qj0" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="3RgF98i4" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="8j0ae9kk" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="1p8AXQxS" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Agile Product Development]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Agile Product Development]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="DZr5UmkG" name="Module2Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="KhvnhwGK" name="Module2NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="SxTtR5AV" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="um46jj2d" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="6MnRQsKD" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="l17Ounw6" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Refining Products]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Refining Products]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="CQRGFie1" name="Module3Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="PwjzeQAp" name="Module3NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_marketing.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/courses/course_marketing.xml
@@ -1,86 +1,86 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="20NosvcP" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Digital Marketing Bootcamp]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Digital Marketing Bootcamp]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="8HFRNkw7" name="ShortDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[This is a short description to introduce the key aspects of the course.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="xa29z3C8" name="ProgramDescription" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="1pCS00XC" name="VideoThumbnail" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/thumb_video_marketing.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="UQIv4nRI" name="Video" type="rich_text">
-		<dynamic-content language-id="en_US"><![CDATA[<p>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[<p>
 <video controls=""><source src="[$DOCUMENT_URL:/site-initializer/documents/group/video_marketing.mp4$]" type="video/mp4" /></video>
 </p>]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="jSnynw83" name="FeaturesFieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="g4XtKzw3" name="Features" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uikm0Vgm" name="NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[9]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[9]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="HtZkz1TZ" name="Quizzes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="kDGj9Ehy" name="Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="dZKl0npa" name="MaxRetakes" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="cRGhBAb7" name="PassPercentage" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[90%]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[90%]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="lG30GnjH" name="Module1FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="0yH8J30n" name="Module1" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="uhmsaSqS" name="Module1Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="52l34J8D" name="Module1Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Marketing Planning]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Marketing Planning]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="jvTFfCuc" name="Module1Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="qYVkHEGy" name="Module1NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="Uw4M7Qj0" name="Module2FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="3RgF98i4" name="Module2" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="8j0ae9kk" name="Module2Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="1p8AXQxS" name="Module2Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Content Marketing]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Content Marketing]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="DZr5UmkG" name="Module2Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[1 week]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[1 week]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="KhvnhwGK" name="Module2NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[3 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[3 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 	<dynamic-element index-type="" instance-id="SxTtR5AV" name="Module3FieldSet" type="fieldset">
 		<dynamic-element index-type="none" instance-id="um46jj2d" name="Module3" type="fieldset" />
 		<dynamic-element index-type="keyword" instance-id="6MnRQsKD" name="Module3Description" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="l17Ounw6" name="Module3Name" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[Social Media Marketing]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Social Media Marketing]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="CQRGFie1" name="Module3Duration" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[2 weeks]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[2 weeks]]></dynamic-content>
 		</dynamic-element>
 		<dynamic-element index-type="keyword" instance-id="PwjzeQAp" name="Module3NumberOfLessons" type="text">
-			<dynamic-content language-id="en_US"><![CDATA[4 lessons]]></dynamic-content>
+			<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[4 lessons]]></dynamic-content>
 		</dynamic-element>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_brooklyn_simmons.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_brooklyn_simmons.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="rCTyJOHy" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Brooklyn Simmons]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Brooklyn Simmons]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="Nlg7yI6d" name="Image" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/teacher_brooklyn_simmons.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="gypbP4JG" name="Info" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_esther_howard.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_esther_howard.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="GMDwjDEW" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Esther Howard]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Esther Howard]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="17armZGN" name="Image" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/teacher_esther_howard.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="dpR5onzx" name="Info" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_jane_cooper.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_jane_cooper.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="thJgA26D" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Jane Cooper]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Jane Cooper]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="KFMtELi0" name="Image" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/teacher_jane_cooper.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="sAsGecZS" name="Info" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_jerome_bell.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_jerome_bell.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="X2GbcnRS" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Jerome Bell]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Jerome Bell]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="86DZLeoe" name="Image" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/teacher_jerome_bell.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="cx8UANUI" name="Info" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_ralph_edwards.xml
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/journal-articles/teachers/teacher_ralph_edwards.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
-<root available-locales="en_US" default-locale="en_US" version="1.0">
+<root available-locales="[$LOCALE_DEFAULT$]" default-locale="[$LOCALE_DEFAULT$]" version="1.0">
 	<dynamic-element index-type="keyword" instance-id="2toI6lNc" name="Name" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Ralph Edwards]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Ralph Edwards]]></dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="text" instance-id="6khSwWPv" name="Image" type="image">
-		<dynamic-content language-id="en_US">
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]">
 			<![CDATA[[$DOCUMENT_JSON:/site-initializer/documents/group/teacher_ralph_edwards.jpg$]]]>
 		</dynamic-content>
 	</dynamic-element>
 	<dynamic-element index-type="keyword" instance-id="BxzGbSjh" name="Info" type="text">
-		<dynamic-content language-id="en_US"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
+		<dynamic-content language-id="[$LOCALE_DEFAULT$]"><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></dynamic-content>
 	</dynamic-element>
 </root>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/1_home/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/1_home/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/home",
 	"hidden": false,
+	"name": "Home",
 	"name_i18n": {
 		"en_US": "Home"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/account-settings/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/account-settings/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/account-settings",
 	"hidden": false,
+	"name": "Account Settings",
 	"name_i18n": {
 		"en_US": "Account Settings"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/apply/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/apply/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/apply",
 	"hidden": false,
+	"name": "Apply",
 	"name_i18n": {
 		"en_US": "Apply"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/blog/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/blog/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/blog",
 	"hidden": false,
+	"name": "Blog",
 	"name_i18n": {
 		"en_US": "Blog"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/courses/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/courses/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/courses",
 	"hidden": true,
+	"name": "Courses",
 	"name_i18n": {
 		"en_US": "Courses"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/my-learning/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/my-learning/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/my-learning",
 	"hidden": false,
+	"name": "My Learning",
 	"name_i18n": {
 		"en_US": "My Learning"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/notifications/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/notifications/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/notifications",
 	"hidden": false,
+	"name": "Notifications",
 	"name_i18n": {
 		"en_US": "Notifications"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/private/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/private/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/page-private",
 	"hidden": false,
+	"name": "Private",
 	"name_i18n": {
 		"en_US": "Private"
 	},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/sign-in/page.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layouts/sign-in/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/sign-in",
 	"hidden": true,
+	"name": "Sign In",
 	"name_i18n": {
 		"en_US": "Sign In"
 	},


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-22216

# How am I fixing it?

Certain assets already have methods in place to account for a missing locale. For `layout` this is including a `name` parameter to fall back upon. For DDM it is using a replaceable string `LOCALE_DEFAULT`. For Journal I emulated the approach taken by DDM.

# How can you verify that it works?

In `site-initializer-extender-test` run `gw testIntegration --tests *.BundleSiteInitializerTest`