### PR TITLE
LPD-43724 Get the workflow task from production when the publication has been published

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
@@ -210,6 +210,16 @@ public class WorkflowTaskUserNotificationHandler
 			long ctCollectionId = jsonObject.getLong(
 				WorkflowConstants.CONTEXT_CT_COLLECTION_ID);
 
+			CTCollection ctCollection =
+				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+
+			if ((ctCollection != null) &&
+				(ctCollection.getStatus() ==
+					WorkflowConstants.STATUS_APPROVED)) {
+
+				ctCollectionId = CTConstants.CT_COLLECTION_ID_PRODUCTION;
+			}
+
 			WorkflowTask workflowTask = _fetchWorkflowTask(
 				ctCollectionId, workflowTaskId);
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.workflow.task.web.internal.notifications;
 
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
@@ -65,6 +66,7 @@ public class WorkflowTaskUserNotificationHandlerTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_setUpCTCollectionLocalService();
 		_setUpUserNotificationEventLocalService();
 		_setUpWorkflowTaskManagerUtil();
 		_setUpWorkflowTaskPermission();
@@ -235,6 +237,12 @@ public class WorkflowTaskUserNotificationHandlerTest {
 			}
 
 		};
+	}
+
+	private static void _setUpCTCollectionLocalService() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskUserNotificationHandler, "_ctCollectionLocalService",
+			ProxyFactory.newDummyInstance(CTCollectionLocalService.class));
 	}
 
 	private static void _setUpUserNotificationEventLocalService()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-43724

Notifications for published publication were being deleted because we were attempting to get the workflow task using the ctCollectionId. But after publishing the publication, the workflow task is not under production.