### PR TITLE
LPD-44049 Update path in order to find drag handler for page to be moved

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagesadmin/PagesAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagesadmin/PagesAdmin.path
@@ -94,7 +94,7 @@
 </tr>
 <tr>
 	<td>LIST_GROUP_ITEM_DRAG_HANDLER</td>
-	<td>//div[contains(@class,'miller-columns')]//li[contains(.,'${key_pageName}')]/div[contains(@class,'drag-handler')]</td>
+	<td>//div[contains(@class,'miller-columns')]//li[contains(.,'${key_pageName}')]//div[contains(@class,'drag-handler')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44049

# How am I fixing it?

The path needs to be updated in order to find the drag handler.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=NavigationMenuWidget#ConfigureDisplayTemplateOfNavigationMenuWidget`