### PR TITLE
LPD-44567 Resolve test failures in FriendlyURLService.testcase

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
@@ -291,7 +291,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		Navigator.openSpecificURL(url = "${portalURL}/es/web/test-site-name/-/prueba");
 
@@ -317,7 +317,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openToEditWCInSite(
 			groupName = "Test Site Name",
@@ -337,7 +337,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "prueba");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		Navigator.openSpecificURL(url = "${portalURL}/es/web/test-site-name/-/prueba");
 
@@ -465,15 +465,19 @@ definition {
 
 		AssetPublisherPortlet.configureDisplaySettings(displaySettings = "Set as the Default Asset Publisher for This Page");
 
-		JSONWebcontent.addWebContent(
-			content = "Web Content Content",
+		WebContentNavigator.openToAddBasicArticle(
 			groupName = "Test Site Name",
-			title = "Web Content Article");
+			siteURLKey = "test-site-name");
+
+		WebContent.addWithFriendlyURL(
+			friendlyURL = "web-content-article",
+			webContentContent = "Web Content Content",
+			webContentTitle = "Web Content Article");
 
 		WebContentNavigator.openToEditWCInSite(
 			groupName = "Test Site Name",
 			siteURLKey = "test-site-name",
-			version = "1.1",
+			urlTitle = "web-content-article",
 			webContentTitle = "Web Content Article");
 
 		WebContent.editDisplayPage(
@@ -482,7 +486,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "friendlyUrl");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openToEditWCInSite(
 			groupName = "Test Site Name",
@@ -493,7 +497,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "web-content-article");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		Navigator.openSpecificURL(url = "${portalURL}/web/test-site-name/-/web-content-article");
 
@@ -716,7 +720,7 @@ definition {
 			pageName = "Test Source Page",
 			pageType = "Pages");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		Navigator.openSpecificURL(url = "${portalURL}/web/test-site-name/-/friendlyUrl");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44567

# How am I fixing it?

Publishing a Web Content article now involves more steps so the functional tests have been updated to accommodate this.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=FriendlyURLService#CanReAddSameFriendlyURLForDifferentLanguageInWebContentAfterRemoveTheTranslation`