### PR TITLE
LPD-45308 Update expiration dates to be far into the future to avoid issues

### DIFF
--- a/modules/apps/redirect/redirect-test/src/testFunctional/tests/Redirect.testcase
+++ b/modules/apps/redirect/redirect-test/src/testFunctional/tests/Redirect.testcase
@@ -790,7 +790,7 @@ definition {
 
 		JSONRedirect.addRedirect(
 			destinationURL = "${portalURL}/web/test-site-name/test-destination-page",
-			expirationDate = "2024-12-31",
+			expirationDate = "2099-12-31",
 			groupName = "Test Site Name",
 			permanent = "true",
 			sourceURL = "test-source-page");
@@ -1061,7 +1061,7 @@ definition {
 
 		JSONRedirect.updateEntry(
 			destinationURL = "${portalURL}/web/test-site-name/test-destination-page",
-			expirationDate = "2024-12-31",
+			expirationDate = "2099-12-31",
 			groupName = "Test Site Name",
 			permanent = "true",
 			sourceURL = "test-source-page");
@@ -1070,7 +1070,7 @@ definition {
 
 		Redirect.viewEntry(
 			destinationURL = "${portalURL}/web/test-site-name/test-destination-page",
-			expirationDate = "12/31/24",
+			expirationDate = "12/31/99",
 			redirectType = "Permanent",
 			sourceURL = "${portalURL}/web/test-site-name/test-source-page");
 	}
@@ -1304,7 +1304,7 @@ definition {
 
 		JSONRedirect.updateEntry(
 			destinationURL = "${portalURL}/web/test-site-name/test-destination-page",
-			expirationDate = "2024-12-31",
+			expirationDate = "2099-12-31",
 			groupName = "Test Site Name",
 			sourceURL = "test-source-page");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45308

# How am I fixing it?

The expiration dates were set for 2024 and are now causing issues that we're in 2025.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=Redirect#CanResetExpiredEntry`