### PR TITLE
LPD-44979 Allow for getting the navigation menu item's display icon

### DIFF
--- a/modules/apps/site-navigation/site-navigation-api/bnd.bnd
+++ b/modules/apps/site-navigation/site-navigation-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site Navigation API
 Bundle-SymbolicName: com.liferay.site.navigation.api
-Bundle-Version: 10.0.1
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.site.navigation.constants,\
 	com.liferay.site.navigation.exception,\

--- a/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/type/SiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/type/SiteNavigationMenuItemType.java
@@ -67,6 +67,16 @@ public interface SiteNavigationMenuItemType {
 		throw new UnsupportedOperationException();
 	}
 
+	public default String getDisplayIcon(
+		SiteNavigationMenuItem siteNavigationMenuItem) {
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.fastLoad(
+			siteNavigationMenuItem.getTypeSettings()
+		).build();
+
+		return unicodeProperties.getProperty("displayIcon", StringPool.BLANK);
+	}
+
 	public default String getIcon() {
 		return "magic";
 	}

--- a/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/type/packageinfo
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/type/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -50,7 +54,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_justified.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -50,7 +54,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_justified.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -50,7 +54,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -51,7 +55,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -51,7 +55,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank.ftl
@@ -22,7 +22,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -63,7 +67,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank.ftl
@@ -42,10 +42,7 @@
 
 						<#assign nav_item_caret>
 							<span class="lfr-nav-child-toggle">
-								<@liferay_aui.icon
-									image="angle-down"
-									markupView="lexicon"
-								/>
+								<@clay["icon"] symbol="angle-down" />
 							</span>
 						</#assign>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_blank_justified.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -54,7 +58,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_default.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_default.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -50,7 +54,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_default.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_default.ftl
@@ -34,9 +34,15 @@
 					/>
 
 					<#if showChildrenNavItems>
+						<#assign nav_item_attr_has_popup = "aria-haspopup='true'" />
+
+						<#assign nav_item_caret>
+							<span class="lfr-nav-child-toggle">
+								<@clay["icon"] symbol="angle-down" />
+							</span>
+						</#assign>
+
 						<#assign
-							nav_item_attr_has_popup = "aria-haspopup='true'"
-							nav_item_caret = '<span class="lfr-nav-child-toggle"><i class="icon-caret-down"></i></span>'
 							nav_item_css_class = "${nav_item_css_class} dropdown"
 							nav_item_link_css_class = "${nav_item_link_css_class} dropdown-toggle"
 						/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_links.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_links.ftl
@@ -18,7 +18,11 @@
 			<#assign navItems = entries />
 
 			<#list navItems as navItem>
-				<#assign showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren() />
+				<#assign
+					displayIcon = navItem.getDisplayIcon()
+
+					showChildrenNavItems = (displayDepth != 1) && navItem.hasBrowsableChildren()
+				/>
 
 				<#if navItem.isBrowsable() || showChildrenNavItems>
 					<#assign
@@ -60,7 +64,15 @@
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
 						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()}>
-							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
+							<span class="text-truncate">
+								<#if validator.isNull(displayIcon)>
+									<@liferay_theme["layout-icon"] layout=navItem.getLayout() />
+								<#else>
+									<@clay["icon"] symbol="${displayIcon}" />
+								</#if>
+
+								${navItem.getName()} ${nav_item_caret}
+							</span>
 						</a>
 
 						<#if showChildrenNavItems>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_links.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_navbar_links.ftl
@@ -38,11 +38,7 @@
 
 						<#assign nav_item_caret>
 							<span class="lfr-nav-child-toggle">
-								<@liferay_aui.icon
-									image="angle-down"
-									markupView="lexicon"
-									menuItem=false
-								/>
+								<@clay["icon"] symbol="angle-down" />
 							</span>
 						</#assign>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_split_button_dropdowns.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/display/template/dependencies/portlet_display_template_split_button_dropdowns.ftl
@@ -47,10 +47,7 @@
 
 						<#if showChildrenNavItems>
 							<button aria-expanded="false" aria-haspopup="true" class="${nav_item_css_class} btn btn-secondary c-px-2 dropdown-toggle" data-toggle="liferay-dropdown" type="button">
-								<@liferay_aui.icon
-									image="angle-down"
-									markupView="lexicon"
-								/>
+								<@clay["icon"] symbol="angle-down" />
 
 								<span class='sr-only'>${toggle_text}</span>
 							</button>

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItemImpl.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItemImpl.java
@@ -84,6 +84,12 @@ public class SiteNavigationMenuNavItemImpl
 	}
 
 	@Override
+	public String getDisplayIcon() {
+		return _siteNavigationMenuItemType.getDisplayIcon(
+			_siteNavigationMenuItem);
+	}
+
+	@Override
 	public Map<String, Serializable> getExpandoAttributes() {
 		Map<String, Serializable> expandoAttributes =
 			super.getExpandoAttributes();

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/NavItem.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/NavItem.java
@@ -169,6 +169,10 @@ public class NavItem implements Serializable {
 		return _children;
 	}
 
+	public String getDisplayIcon() throws Exception {
+		return StringPool.BLANK;
+	}
+
 	public Map<String, Serializable> getExpandoAttributes() {
 		if (_layout != null) {
 			ExpandoBridge expandoBridge = _layout.getExpandoBridge();

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.1.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44979

# How am I fixing it?

This is the foundation for displaying user selected icons in navigation menus. I am open to suggestions about the API name.

The current default templates for navigation menus have also been updated to optionally display the selected icon.

# How can you verify that it works?

Presently, there is no way to set an icon on a navigation menu item. That will be implemented in https://liferay.atlassian.net/browse/LPD-44030 by the Platform Experience team. These current changes were asked to be submitted so that when the icon selector is ready we already have a head start on the implementation.

Once the icon selector is ready functional tests will be added to ensure the functionality of selecting and displaying an icon.