### PR TITLE
LPD-46100 Update site navigation menu ERCs in Masterclass and Team Extranet templates (see LPD-43431)

### DIFF
--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/display-page-templates/classroom/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/display-page-templates/classroom/page-definition.json
@@ -1142,6 +1142,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU2",
 												"siteNavigationMenuName": "Private Area Navigation",
 												"siteNavigationMenuType": "-1"
 											},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/main-1/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/main-1/page-definition.json
@@ -349,6 +349,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU1",
 												"siteNavigationMenuName": "Main Navigation",
 												"siteNavigationMenuType": "-1"
 											},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/main-2/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/main-2/page-definition.json
@@ -65,6 +65,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU1",
 												"siteNavigationMenuName": "Main Navigation",
 												"siteNavigationMenuType": "-1"
 											},
@@ -347,6 +348,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU1",
 												"siteNavigationMenuName": "Main Navigation",
 												"siteNavigationMenuType": "-1"
 											},

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/private-area/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/layout-page-templates/master-pages/private-area/page-definition.json
@@ -136,6 +136,7 @@
 													"expandedLevels": "auto",
 													"rootMenuItemLevel": "0",
 													"rootMenuItemType": "absolute",
+													"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU2",
 													"siteNavigationMenuName": "Private Area Navigation",
 													"siteNavigationMenuType": "-1"
 												},
@@ -495,6 +496,7 @@
 																"expandedLevels": "auto",
 																"rootMenuItemLevel": "0",
 																"rootMenuItemType": "absolute",
+																"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU2",
 																"siteNavigationMenuName": "Private Area Navigation",
 																"siteNavigationMenuType": "-1"
 															},

--- a/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/layout-page-templates/master-pages/master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/layout-page-templates/master-pages/master/page-definition.json
@@ -40,6 +40,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU1",
 												"siteNavigationMenuName": "Main Navigation",
 												"siteNavigationMenuType": "-1"
 											},
@@ -361,6 +362,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU1",
 												"siteNavigationMenuName": "Main Navigation",
 												"siteNavigationMenuType": "-1"
 											},
@@ -375,6 +377,7 @@
 												"expandedLevels": "auto",
 												"rootMenuItemLevel": "0",
 												"rootMenuItemType": "absolute",
+												"siteNavigationMenuExternalReferenceCode": "SITENAVIGATIONMENU2",
 												"siteNavigationMenuName": "Privacy Navigation",
 												"siteNavigationMenuType": "-1"
 											},


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46100

# How am I fixing it?

In https://liferay.atlassian.net/browse/LPD-43431 the site initializer framework was updated to use ERC for site navigation menus. These changes add the ERC to the Masterclass and Team Extranet templates to work with this new change.

The templates were only partially updated in LPD-43431.