### PR TITLE
LPD-46458 The image is some times located in a separate 'style' tag that is not considered visible

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/contentpage/ContentPages.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/contentpage/ContentPages.macro
@@ -195,7 +195,7 @@ definition {
 			var position = 1;
 		}
 
-		AssertVisible(
+		AssertElementPresent(
 			image = ${image},
 			index = ${position},
 			locator1 = "Fragment#FRAGMENT_BACKGROUND_IMAGE");

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
@@ -366,7 +366,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_BACKGROUND_IMAGE</td>
-	<td>xpath=(//div[contains(@style,'background-image')])[${index}][contains(@style,'${image}')]</td>
+	<td>xpath=(//div[contains(@style,'background-image')])[${index}][contains(@style,'${image}')] | //div/style[contains(text(),'${image}')]</td>
 	<td></td>
 </tr>
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46458

# How am I fixing it?

The image is being styled in a separate `style` element rather than inline on the `div` itself.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=NavigationMenusWithStaging#AddDisplayPageTypeNavigationMenuItems`