### PR TITLE
LPD-47041 Convert inline style to aui:style tag to allow for nonce

### DIFF
--- a/portal-web/docroot/html/taglib/portlet/preview/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/preview/page.jsp
@@ -30,7 +30,14 @@ if (Validator.isNull(width)) {
 	</c:if>
 
 	<div class="preview" id="<%= randomNamespace %>">
-		<div style="margin: 3px; width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %>;">
+		<aui:style type="text/css">
+			.taglib-portlet-preview-pane {
+				margin: 3px !important;
+				width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %> !important;
+			}
+		</aui:style>
+
+		<div class="taglib-portlet-preview-pane">
 			<liferay-portlet:runtime
 				persistSettings="<%= false %>"
 				portletName="<%= portletResource %>"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47041

# How am I fixing it?

Inline styles need to be removed to allow for CSP nonce. This converts the inlined style to an aui:style tag, which has the nonce built in.