### PR TITLE
LPD-46726 Fix test failure in site-navigation-admin-web/itemAddition.spec.ts

### DIFF
--- a/modules/test/playwright/tests/site-navigation-admin-web/itemAddition.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/itemAddition.spec.ts
@@ -81,6 +81,8 @@ test(
 		await page.mouse.move(targetRect.x, targetRect.y + 1);
 		await page.mouse.up();
 
+		await page.waitForTimeout(300);
+
 		const cardTitles = await page.locator('.card-title').allTextContents();
 
 		await expect(cardTitles[2]).toBe('Parent 3');


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46726

Resent from: https://github.com/liferay-site-management/liferay-portal/pull/1728
Just changed the commit/branch name.

The problem was that, when the test switch the "Parent 3" with the "Parent 2", the constant that is created after that to save the current state was getting the state before the switch, so I just put a wait so the new state can be updated.