### PR TITLE
LPD-47162 Embedded widgets in fragments was deprecated in LPD-40535 so enable this functionality to allow the test to run

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -102,6 +102,21 @@ definition {
 	test ExportImportSiteWithEmbeddedWCDInFragment {
 		property portal.acceptance = "true";
 
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Instance Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Feature Flags",
+			configurationName = "Deprecation",
+			configurationScope = "Virtual Instance Scope");
+
+		Check.checkToggleSwitch(
+			locator1 = "FeatureFlag#TOGGLE_ROW",
+			title_row = "Embedded Widgets in Fragments",
+			toggle_state = "Disabled");
+
 		task ("Add a fragment collection in site") {
 			JSONFragment.addFragmentCollection(
 				groupName = "Test Site Name",
@@ -128,6 +143,10 @@ definition {
 			WaitForVisible(locator1 = "FragmentEditor#CHANGES_SAVED_MESSAGE");
 
 			PortletEntry.publish();
+
+			Click(
+				key_text = "Publish",
+				locator1 = "Modal#MODAL_FOOTER_BUTTON");
 		}
 
 		task ("Add a Content page and add a web content") {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47162

# How am I fixing it?

Embedded widgets in fragments was deprecated in LPD-40535 so enable this functionality to allow the test to run

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=SitesExportImport#ExportImportSiteWithEmbeddedWCDInFragment`