### PR TITLE
LPD-46461 Clean up Site Management test routine

### DIFF
--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/site-initializer-liferay-marketplace-test/src/testFunctional/tests/MP2CustomerDashboard.testcase
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/site-initializer-liferay-marketplace-test/src/testFunctional/tests/MP2CustomerDashboard.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-liferay-marketplace";

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/site-initializer-liferay-marketplace-test/src/testFunctional/tests/MP2PublisherDashboard.testcase
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/site-initializer-liferay-marketplace-test/src/testFunctional/tests/MP2PublisherDashboard.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-liferay-marketplace";

--- a/modules/apps/site-initializer/site-initializer-masterclass/site-initializer-masterclass-test/src/testFunctional/tests/Masterclass.testcase
+++ b/modules/apps/site-initializer/site-initializer-masterclass/site-initializer-masterclass-test/src/testFunctional/tests/Masterclass.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPApplicationFilterSearch.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPApplicationFilterSearch.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPApplicationsStatus.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPApplicationsStatus.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPClaimsDetails.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPClaimsDetails.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPContactInfo.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPContactInfo.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPCoverages.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPCoverages.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPDashboardTasks.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPDashboardTasks.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPDriverInfo.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPDriverInfo.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPIncompleteApplication.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPIncompleteApplication.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPLayoutPage.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPLayoutPage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPPolicies.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPPolicies.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPRecentApplications.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPRecentApplications.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPReview.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPReview.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPSignInPage.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPSignInPage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPSite.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPSite.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPTypeOfInsurance.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPTypeOfInsurance.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPUnderwritingTrigger.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAPUnderwritingTrigger.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAccountAvatarFunctionality.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-ap/site-initializer-raylife-ap-test/src/testFunctional/tests/RaylifeAccountAvatarFunctionality.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "feature.flag.LPS-165493=true";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBasicsPageMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBasicsPageMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-raylife-d2c";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBusiness.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBusiness.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBusinessInfoMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeBusinessInfoMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCongratsScreenMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCongratsScreenMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeContactInfo.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeContactInfo.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeContactPage.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeContactPage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCreateAccount.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCreateAccount.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCreateAccountMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeCreateAccountMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeD2CContinuousUpgrade.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeD2CContinuousUpgrade.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property app.server.types = "tomcat";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeDocuSignIntegration.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeDocuSignIntegration.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeEmployeeInfoMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeEmployeeInfoMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeEmployees.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeEmployees.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeHomePage.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeHomePage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIndustry.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIndustry.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIndustryMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIndustryMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIntoModalsMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeIntoModalsMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeKnockoutMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeKnockoutMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLandingMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLandingMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLoadingPage.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLoadingPage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLoadingPageMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeLoadingPageMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeMenuLinksMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeMenuLinksMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeNavigation.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeNavigation.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeNavigationProgressBarMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeNavigationProgressBarMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethod.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethod.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethodMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethodMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePolicyDeclaration.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePolicyDeclaration.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePricingInstallments.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePricingInstallments.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProduct.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProduct.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProductSelectionPageMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProductSelectionPageMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProperty.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeProperty.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePropertyInfoMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePropertyInfoMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteComparison.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteComparison.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteComparisonMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteComparisonMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteProfile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeQuoteProfile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeRetrieveEmail.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeRetrieveEmail.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-raylife-d2c";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeRetrieveQuote.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeRetrieveQuote.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-raylife-d2c";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSaveExit.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSaveExit.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSite.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSite.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property osgi.modules.includes = "site-initializer-raylife-d2c";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSummarySection.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeSummarySection.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeUploadDocuments.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeUploadDocuments.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeUploadDocumentsMobile.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifeUploadDocumentsMobile.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property portal.release = "false";

--- a/modules/apps/site-initializer/site-initializer-team-extranet/site-initializer-team-extranet-test/src/testFunctional/tests/TeamExtranet.testcase
+++ b/modules/apps/site-initializer/site-initializer-team-extranet/site-initializer-team-extranet-test/src/testFunctional/tests/TeamExtranet.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property ci.retries.disabled = "true";

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPHomePage.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPHomePage.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganization.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganization.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationForm.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationForm.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationListing.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationListing.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationStatus.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPOrganizationStatus.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPReport.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPReport.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequest.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequest.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestForm.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestForm.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestListing.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestListing.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestStatus.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/tests/EVPRequestStatus.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/friendlyurl/FriendlyURLService.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-publications"
+@component-name = "portal-site-management"
 definition {
 
 	property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property database.types = "mysql, postgresql";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnlineCoverBugs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnlineCoverBugs.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-site-management"
+@component-name = "portal-solutions"
 definition {
 
 	property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";

--- a/test.properties
+++ b/test.properties
@@ -8353,7 +8353,7 @@
 
     modules.includes.public[modules-semantic-versioning][site-management]=${site.management.testing.modules}
 
-    playwright.projects.includes[playwright-js-tomcat90-mysql57][site-management]=\
+    playwright.projects.includes[playwright-js-tomcat90-postgresql155][site-management]=\
         site-admin-web,\
         site-navigation-admin-web,\
         site-navigation-breadcrumb-web
@@ -8384,7 +8384,7 @@
     test.batch.dist.app.servers[site-management]=tomcat
 
     test.batch.names[site-management]=\
-        functional-tomcat90-mysql57,\
+        functional-tomcat90-postgresql155,\
         functional-upgrade-tomcat90-db2111,\
         functional-upgrade-tomcat90-mariadb102,\
         functional-upgrade-tomcat90-mysql57,\
@@ -8394,13 +8394,13 @@
         functional-upgrade-tomcat90-postgresql163,\
         functional-upgrade-tomcat90-sqlserver2017,\
         js-unit,\
-        modules-integration-mysql57,\
+        modules-integration-postgresql155,\
         modules-semantic-versioning,\
         modules-unit,\
-        playwright-js-tomcat90-mysql57,\
+        playwright-js-tomcat90-postgresql155,\
         semantic-versioning
 
-    test.batch.run.property.query[functional-tomcat90-mysql57][site-management]=\
+    test.batch.run.property.query[functional-tomcat90-postgresql155][site-management]=\
         (testray.main.component.name == "Breadcrumb Widget") OR \
         (testray.main.component.name == "Click to Chat") OR \
         (testray.main.component.name == "Friendly URL Service") OR \

--- a/test.properties
+++ b/test.properties
@@ -8398,8 +8398,7 @@
         modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat90-mysql57,\
-        semantic-versioning,\
-        service-builder
+        semantic-versioning
 
     test.batch.run.property.query[functional-tomcat90-mysql57][site-management]=\
         (testray.main.component.name == "Breadcrumb Widget") OR \

--- a/test.properties
+++ b/test.properties
@@ -8389,9 +8389,7 @@
         functional-upgrade-tomcat90-mariadb102,\
         functional-upgrade-tomcat90-mysql57,\
         functional-upgrade-tomcat90-oracle193,\
-        functional-upgrade-tomcat90-postgresql144,\
-        functional-upgrade-tomcat90-postgresql153,\
-        functional-upgrade-tomcat90-postgresql163,\
+        functional-upgrade-tomcat90-postgresql155,\
         functional-upgrade-tomcat90-sqlserver2017,\
         js-unit,\
         modules-integration-postgresql155,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46461

# How am I fixing it?

The changes to the site template tests don't affect our routine as they were already being run under the correct team's routine. This update makes it clearer who owns these tests.

The changes to our routine results in 19 less tests being executed and limited data is showing that the test routine is finishing 30 minutes faster than previously.