### PR TITLE
LPD-44715 Move listeners to the React component

### DIFF
--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
@@ -149,10 +149,6 @@ renderResponse.setTitle(editRedirectEntryDisplayContext.getTitle());
 	context='<%=
 		HashMapBuilder.<String, Object>put(
 			"getRedirectEntryChainCauseURL", editRedirectEntryDisplayContext.getRedirectEntryChainCauseURL()
-		).put(
-			"initialDestinationURL", editRedirectEntryDisplayContext.getDestinationURL()
-		).put(
-			"initialIsPermanent", editRedirectEntryDisplayContext.isRedirectEntryPermanent()
 		).build()
 	%>'
 	module="{editRedirectEntry} from redirect-web"

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/DestinationUrlInput.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/DestinationUrlInput.js
@@ -8,7 +8,7 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 const REGEX_URL =
 	/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(https?:\/\/|www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))((.*):(\d*)\/?(.*))?)/;
@@ -37,6 +37,41 @@ const DestinationUrlInput = ({
 	const isAbsoluteUrl = (url) => {
 		return REGEX_URL && REGEX_URL.test(url);
 	};
+
+	useEffect(() => {
+		const destinationURLInput = document.getElementById(
+			`${namespace}destinationURL`
+		);
+		const initialDestinationURL = destinationURLInput.value;
+		const permanentSelect = document.getElementById(
+			`${namespace}permanent`
+		);
+		const typeInfoAlert = document.getElementById(
+			`${namespace}typeInfoAlert`
+		);
+
+		const _showTypeInfoAlert = () => {
+			typeInfoAlert.classList.toggle(
+				'hide',
+				permanentSelect.value === 'true' &&
+					destinationURLInput.value === initialDestinationURL
+			);
+		};
+
+		if (typeInfoAlert && permanentSelect.value === 'true') {
+			destinationURLInput.addEventListener('input', _showTypeInfoAlert);
+			permanentSelect.addEventListener('input', _showTypeInfoAlert);
+		}
+
+		return () => {
+			destinationURLInput?.removeEventListener(
+				'input',
+				_showTypeInfoAlert
+			);
+
+			permanentSelect?.removeEventListener('input', _showTypeInfoAlert);
+		};
+	}, [namespace]);
 
 	return (
 		<ClayForm.Group

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
@@ -5,32 +5,9 @@
 
 import {createResourceURL, fetch, openToast, postForm} from 'frontend-js-web';
 
-export default function ({
-	getRedirectEntryChainCauseURL,
-	initialDestinationURL,
-	initialIsPermanent,
-	namespace,
-}) {
+export default function ({getRedirectEntryChainCauseURL, namespace}) {
 	const form = document[`${namespace}fm`];
 	form.addEventListener('submit', saveRedirectEntry);
-	const typeInfoAlert = document.getElementById(`${namespace}typeInfoAlert`);
-	const destinationURLInput = document.getElementById(
-		`${namespace}destinationURL`
-	);
-	const permanentSelect = document.getElementById(`${namespace}permanent`);
-
-	if (typeInfoAlert && initialIsPermanent) {
-		destinationURLInput.addEventListener('input', showTypeInfoAlert);
-		permanentSelect.addEventListener('input', showTypeInfoAlert);
-	}
-
-	function showTypeInfoAlert() {
-		typeInfoAlert.classList.toggle(
-			'hide',
-			permanentSelect.value === 'true' &&
-				destinationURLInput.value === initialDestinationURL
-		);
-	}
 
 	function saveRedirectEntry() {
 		const destinationURL = form.elements[`${namespace}destinationURL`];


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44715

# How am I fixing it?

The listener was being attached prior to the React component being rendered. This moves the listener logic inside of the React component to ensure it will attach successfully.

# How can you verify that it works?

In the root folder run

`ant -f build-test.xml run-selenium-test -Dtest.class=Redirect#CanEditEntry`
`ant -f build-test.xml run-selenium-test -Dtest.class=Redirect#CanAccessUpdatedPermanentEntry`