### PR TITLE
LPD-47041 Convert inline style to aui:style tag to allow for nonce

### DIFF
--- a/portal-web/docroot/html/taglib/portlet/preview/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/preview/page.jsp
@@ -30,13 +30,15 @@ if (Validator.isNull(width)) {
 	</c:if>
 
 	<div class="preview" id="<%= randomNamespace %>">
-		<div style="margin: 3px; width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %>;">
-			<liferay-portlet:runtime
-				persistSettings="<%= false %>"
-				portletName="<%= portletResource %>"
-				queryString="<%= queryString %>"
-			/>
-		</div>
+		<liferay-ui:csp>
+			<div style="margin: 3px !important; width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %> !important;">
+				<liferay-portlet:runtime
+					persistSettings="<%= false %>"
+					portletName="<%= portletResource %>"
+					queryString="<%= queryString %>"
+				/>
+			</div>
+		</liferay-ui:csp>
 	</div>
 </div>
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47041

# How am I fixing it?

Inline styles need to be removed to allow for CSP nonce. As per https://github.com/brianchandotcom/liferay-portal/pull/158057#issuecomment-2614836871 using the `liferay-ui:csp` tag to handle the extraction of the inlined style.