### PR TITLE
LPD-44946 Ensure the correct display style is being fetched. Additionally, the 'option' value might not be a string so make the check more robust to confirm it is an expected value

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/index.js
@@ -24,13 +24,11 @@ export function NavigationMenuConfiguration({
 }) {
 	const form = document.getElementById(`${namespace}fm`);
 
-	const displayStyle = document.getElementById(
-		`${namespace}preferences--displayStyle--`
-	);
-
 	const resetPreview = (option) => {
 		const displayDepthSelect = getFormElement(form, 'displayDepth');
-		const displayStyleValue = option || displayStyle.value;
+		const displayStyle = document.getElementById(
+			`${namespace}preferences--displayStyle--`
+		);
 		const expandedLevelsSelect = getFormElement(form, 'expandedLevels');
 		const rootMenuItemIdInput = getFormElement(form, 'rootMenuItemId');
 		const rootMenuItemLevelSelect = getFormElement(
@@ -46,6 +44,15 @@ export function NavigationMenuConfiguration({
 			form,
 			'siteNavigationMenuType'
 		);
+
+		let displayStyleValue = null;
+
+		if (typeof option === 'string' || option instanceof String) {
+			displayStyleValue = option;
+		}
+		else {
+			displayStyleValue = displayStyle.value;
+		}
 
 		let data = {
 			preview: true,


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44946

# How am I fixing it?

The display style is a React component which is not ready at the time this Javascript is executed. The declaration is moved inside the function to fetch the element when needed. Also, the `option` parameter was being used even when it wasn't a valid parameter.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=NavigationMenuWidget#ViewWarningMessageInPreviewWindowWhenNoNavigationAvailable`