### PR TITLE
LPD-47041 Convert inline style to aui:style tag to allow for nonce

### DIFF
--- a/portal-web/docroot/html/taglib/portlet/preview/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/preview/page.jsp
@@ -30,7 +30,7 @@ if (Validator.isNull(width)) {
 	</c:if>
 
 	<div class="preview" id="<%= randomNamespace %>">
-		<div style="margin: 3px; width: <%= Validator.isNotNull(previewWidth) ? ((GetterUtil.getInteger(previewWidth) + 20) + "px") : "100%" %>;">
+		<div>
 			<liferay-portlet:runtime
 				persistSettings="<%= false %>"
 				portletName="<%= portletResource %>"
@@ -54,6 +54,8 @@ if (Validator.isNull(width)) {
 			var item = children[i];
 
 			item.style.cursor = 'default';
+			item.style.margin = '3px';
+			item.style.width = <%= previewWidth %> ? parseInt('<%= HtmlUtil.escape(previewWidth) %>', 10) + 20 + 'px' : '100%';
 
 			item.onclick = emptyFnFalse;
 			item.onmouseover = emptyFnFalse;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47041

# How am I fixing it?

Inline styles need to be removed to allow for CSP nonce. As per https://github.com/brianchandotcom/liferay-portal/pull/158057#issuecomment-2614836871 I tried using the `<liferay-ui:csp>` tag to handle the extraction of the inlined style. However, this didn't work due to the precedence of the CSS styles.

I reached out to Ivan and Juanjo and they concluded that using the `<liferay-ui:csp>` tag should be the last resort to fix these types of issues. They offered the solution I am sending in here, where the style is added through the `<aui:script>` tag. This is valid as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src

Brian, if this isn't what you're looking for our options are:

- The original solution of using the `<aui:style>` tag
- Using `<liferay-ui:csp>` with the addition of `!important` to the style so that it takes precedence
- A different option that hasn't been proposed yet

Please let me know your thoughts.