### PR TITLE
LPD-48005 Fix EditSiteURLMVCActionCommandTest

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/admin/web/internal/portlet/action/test/EditSiteURLMVCActionCommandTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/admin/web/internal/portlet/action/test/EditSiteURLMVCActionCommandTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -78,7 +79,8 @@ public class EditSiteURLMVCActionCommandTest {
 		String redirect = (String)mockLiferayPortletActionRequest.getAttribute(
 			WebKeys.REDIRECT);
 
-		Assert.assertTrue(redirect.contains(groupFriendlyURL));
+		Assert.assertTrue(
+			redirect.contains(StringUtil.toLowerCase(groupFriendlyURL)));
 		Assert.assertTrue(redirect.contains(themeDisplay.getPortalURL()));
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48005

# How am I fixing it?

The redirect returns a URL with a friendly URL converted to lower case. The test has been updated to match.

# How can you verify that it works?

In `site-test` run `gw testIntegration --tests *.EditSiteURLMVCActionCommandTest`