### PR TITLE
LPD-48608 Add the user and path info to the request to avoid exceptions in other LogoutAction classes

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
+++ b/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
@@ -6,6 +6,7 @@
 package com.liferay.click.to.chat.web.internal.events.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -103,6 +104,7 @@ public class LogoutPreActionTest {
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setUser(TestPropsValues.getUser());
 
 		_mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -111,6 +113,8 @@ public class LogoutPreActionTest {
 			new Cookie("intercom-id-test", RandomTestUtil.randomString()),
 			new Cookie("intercom-session-test", RandomTestUtil.randomString()),
 			new Cookie("test-cookie", RandomTestUtil.randomString()));
+
+		_mockHttpServletRequest.setPathInfo(StringPool.BLANK);
 	}
 
 	@Inject


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48608

# How am I fixing it?

The tests were passing but there is missing attributes on the request object causing issues in other `LogoutAction` classes. Such as missing `pathInfo` in `PunchOutTokenLogoutAction` and the lack of a user in Analytics Reports `LogoutPreAction` both causing NPEs. This caused the `PortalLogAssertorTest` to fail.

# How can you verify that it works?

In `click-to-chat-test` run `gw testIntegration --tests *.LogoutPreActionTest` and ensure there are no errors logged in the portal.