### PR TITLE
LPD-49575 Site Initializer does not properly update when there are account relationships

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/account-group-assignments.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/account-group-assignments.json
@@ -10,5 +10,11 @@
 		"accounts": [
 			"TESTACCOUNT2"
 		]
+	},
+	{
+		"accountGroupExternalReferenceCode": "TESTACCOUNTGROUP2",
+		"accounts": [
+			"TESTACCOUNT2"
+		]
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/accounts-organizations.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/accounts-organizations.json
@@ -10,5 +10,11 @@
 		"organizations": [
 			"TESTORGANIZATION2"
 		]
+	},
+	{
+		"accountExternalReferenceCode": "TESTACCOUNT2",
+		"organizations": [
+			"TESTORGANIZATION2"
+		]
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
-import com.liferay.account.model.AccountEntryModel;
 import com.liferay.account.model.AccountGroup;
+import com.liferay.account.model.AccountGroupRel;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.account.service.AccountGroupLocalService;
@@ -151,7 +151,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
-import com.liferay.portal.kernel.model.OrganizationModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Theme;
@@ -618,10 +617,20 @@ public class BundleSiteInitializer implements SiteInitializer {
 				continue;
 			}
 
-			_accountGroupRelService.addAccountGroupRels(
-				accountGroup.getAccountGroupId(), AccountEntry.class.getName(),
-				ListUtil.toLongArray(
-					accountEntries, AccountEntryModel::getAccountEntryId));
+			for (AccountEntry accountEntry : accountEntries) {
+				AccountGroupRel accountGroupRel =
+					_accountGroupRelService.fetchAccountGroupRel(
+						accountGroup.getAccountGroupId(),
+						AccountEntry.class.getName(),
+						accountEntry.getAccountEntryId());
+
+				if (accountGroupRel == null) {
+					_accountGroupRelService.addAccountGroupRel(
+						accountGroup.getAccountGroupId(),
+						AccountEntry.class.getName(),
+						accountEntry.getAccountEntryId());
+				}
+			}
 		}
 	}
 
@@ -692,18 +701,19 @@ public class BundleSiteInitializer implements SiteInitializer {
 				continue;
 			}
 
-			List<com.liferay.portal.kernel.model.Organization> organizations =
-				new ArrayList<>();
+			List<Long> organizationIds = new ArrayList<>();
 
 			for (int j = 0; j < organizationJSONArray.length(); j++) {
-				organizations.add(
+				com.liferay.portal.kernel.model.Organization organization =
 					_organizationLocalService.
 						getOrganizationByExternalReferenceCode(
 							organizationJSONArray.getString(j),
-							serviceContext.getCompanyId()));
+							serviceContext.getCompanyId());
+
+				organizationIds.add(organization.getOrganizationId());
 			}
 
-			if (ListUtil.isEmpty(organizations)) {
+			if (ListUtil.isEmpty(organizationIds)) {
 				continue;
 			}
 
@@ -717,11 +727,16 @@ public class BundleSiteInitializer implements SiteInitializer {
 				continue;
 			}
 
-			_accountEntryOrganizationRelLocalService.
-				addAccountEntryOrganizationRels(
-					accountEntry.getAccountEntryId(),
-					ListUtil.toLongArray(
-						organizations, OrganizationModel::getOrganizationId));
+			for (Long organizationId : organizationIds) {
+				if (!_accountEntryOrganizationRelLocalService.
+						hasAccountEntryOrganizationRel(
+							accountEntry.getAccountEntryId(), organizationId)) {
+
+					_accountEntryOrganizationRelLocalService.
+						addAccountEntryOrganizationRel(
+							accountEntry.getAccountEntryId(), organizationId);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-49575

# How am I fixing it?

When creating relationships with accounts it never took into consideration whether or not the relationship already existed. Logic has been added to only add the relationship if it does not yet exist.

# How can you verify that it works?

In `site-initializer-extender-test` run `gw testIntegration --tests *.BundleSiteInitializerTest`