### PR TITLE
LPD-50258 Can't add parent page in Menu Display using Pages Hierarchy

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/display/context/SiteNavigationMenuDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/display/context/SiteNavigationMenuDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -202,18 +203,38 @@ public class SiteNavigationMenuDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		SiteNavigationMenuItem siteNavigationMenuItem =
-			SiteNavigationMenuItemLocalServiceUtil.
-				fetchSiteNavigationMenuItemByExternalReferenceCode(
-					rootMenuItemExternalReferenceCode,
-					_getSiteNavigationMenuGroupId());
+		if (isSiteNavigationMenuSelected()) {
+			SiteNavigationMenuItem siteNavigationMenuItem =
+				SiteNavigationMenuItemLocalServiceUtil.
+					fetchSiteNavigationMenuItemByExternalReferenceCode(
+						rootMenuItemExternalReferenceCode,
+						_getSiteNavigationMenuGroupId());
 
-		if (siteNavigationMenuItem == null) {
-			return StringPool.BLANK;
+			if (siteNavigationMenuItem == null) {
+				return StringPool.BLANK;
+			}
+
+			_rootMenuItemId = String.valueOf(
+				siteNavigationMenuItem.getSiteNavigationMenuItemId());
 		}
+		else {
+			Layout rootLayout =
+				LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+					rootMenuItemExternalReferenceCode,
+					_themeDisplay.getScopeGroupId(), false);
 
-		_rootMenuItemId = String.valueOf(
-			siteNavigationMenuItem.getSiteNavigationMenuItemId());
+			if (rootLayout == null) {
+				rootLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+					rootMenuItemExternalReferenceCode,
+					_themeDisplay.getScopeGroupId(), true);
+			}
+
+			if (rootLayout == null) {
+				return StringPool.BLANK;
+			}
+
+			_rootMenuItemId = rootMenuItemExternalReferenceCode;
+		}
 
 		return _rootMenuItemId;
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/portlet/action/SiteNavigationMenuConfigurationAction.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/portlet/action/SiteNavigationMenuConfigurationAction.java
@@ -10,8 +10,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -97,7 +99,7 @@ public class SiteNavigationMenuConfigurationAction
 		try {
 			portletPreferences.reset("included-layouts");
 
-			_updateRootMenuItemPreferences(portletPreferences);
+			_updateRootMenuItemPreferences(portletPreferences, portletRequest);
 			_updateSiteNavigationMenuPreferences(
 				portletPreferences, portletRequest);
 		}
@@ -117,34 +119,64 @@ public class SiteNavigationMenuConfigurationAction
 	protected SiteNavigationMenuService siteNavigationMenuService;
 
 	private void _updateRootMenuItemPreferences(
-			PortletPreferences portletPreferences)
+			PortletPreferences portletPreferences,
+			PortletRequest portletRequest)
 		throws ReadOnlyException {
 
-		long rootMenuItemId = GetterUtil.getLong(
-			portletPreferences.getValue("rootMenuItemId", null));
-		String rootMenuItemType = portletPreferences.getValue(
-			"rootMenuItemType", StringPool.BLANK);
+		long siteNavigationMenuId = GetterUtil.getLong(
+			portletPreferences.getValue("siteNavigationMenuId", null));
 
-		if ((rootMenuItemId == 0) ||
-			!Objects.equals(rootMenuItemType, "select")) {
+		if (siteNavigationMenuId > 0) {
+			long rootMenuItemId = GetterUtil.getLong(
+				portletPreferences.getValue("rootMenuItemId", null));
+			String rootMenuItemType = portletPreferences.getValue(
+				"rootMenuItemType", StringPool.BLANK);
+
+			if ((rootMenuItemId == 0) ||
+				!Objects.equals(rootMenuItemType, "select")) {
+
+				portletPreferences.reset("rootMenuItemExternalReferenceCode");
+				portletPreferences.reset("rootMenuItemId");
+			}
+
+			SiteNavigationMenuItem siteNavigationMenuItem =
+				siteNavigationMenuItemLocalService.fetchSiteNavigationMenuItem(
+					rootMenuItemId);
+
+			if (siteNavigationMenuItem != null) {
+				portletPreferences.setValue(
+					"rootMenuItemExternalReferenceCode",
+					siteNavigationMenuItem.getExternalReferenceCode());
+
+				return;
+			}
 
 			portletPreferences.reset("rootMenuItemExternalReferenceCode");
-			portletPreferences.reset("rootMenuItemId");
 		}
+		else {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)portletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
 
-		SiteNavigationMenuItem siteNavigationMenuItem =
-			siteNavigationMenuItemLocalService.fetchSiteNavigationMenuItem(
-				rootMenuItemId);
+			String rootMenuItemId = portletPreferences.getValue(
+				"rootMenuItemId", null);
 
-		if (siteNavigationMenuItem != null) {
-			portletPreferences.setValue(
-				"rootMenuItemExternalReferenceCode",
-				siteNavigationMenuItem.getExternalReferenceCode());
+			Layout rootLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
+				rootMenuItemId, themeDisplay.getScopeGroupId(), false);
 
-			return;
+			if (rootLayout == null) {
+				rootLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
+					rootMenuItemId, themeDisplay.getScopeGroupId(), true);
+			}
+
+			if (rootLayout != null) {
+				portletPreferences.setValue(
+					"rootMenuItemExternalReferenceCode", rootLayout.getUuid());
+			}
+			else {
+				portletPreferences.reset("rootMenuItemExternalReferenceCode");
+			}
 		}
-
-		portletPreferences.reset("rootMenuItemExternalReferenceCode");
 	}
 
 	private void _updateSiteNavigationMenuPreferences(
@@ -201,6 +233,9 @@ public class SiteNavigationMenuConfigurationAction
 
 	@Reference
 	private ItemSelector _itemSelector;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private PortletDisplayTemplate _portletDisplayTemplate;

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -129,14 +129,27 @@ SiteNavigationMenuConfigurationDisplayContext siteNavigationMenuConfigurationDis
 									<%
 									String rootMenuItemName = siteNavigationMenuDisplayContext.getSiteNavigationMenuName();
 
-									SiteNavigationMenuItem siteNavigationMenuItem = SiteNavigationMenuItemLocalServiceUtil.fetchSiteNavigationMenuItem(GetterUtil.getLong(siteNavigationMenuDisplayContext.getRootMenuItemId()));
+									if (siteNavigationMenuDisplayContext.isSiteNavigationMenuSelected()) {
+										SiteNavigationMenuItem siteNavigationMenuItem = SiteNavigationMenuItemLocalServiceUtil.fetchSiteNavigationMenuItem(GetterUtil.getLong(siteNavigationMenuDisplayContext.getRootMenuItemId()));
 
-									if (siteNavigationMenuItem != null) {
-										SiteNavigationMenuItemTypeRegistry siteNavigationMenuItemTypeRegistry = (SiteNavigationMenuItemTypeRegistry)request.getAttribute(SiteNavigationMenuWebKeys.SITE_NAVIGATION_MENU_ITEM_TYPE_REGISTRY);
+										if (siteNavigationMenuItem != null) {
+											SiteNavigationMenuItemTypeRegistry siteNavigationMenuItemTypeRegistry = (SiteNavigationMenuItemTypeRegistry)request.getAttribute(SiteNavigationMenuWebKeys.SITE_NAVIGATION_MENU_ITEM_TYPE_REGISTRY);
 
-										SiteNavigationMenuItemType siteNavigationMenuItemType = siteNavigationMenuItemTypeRegistry.getSiteNavigationMenuItemType(siteNavigationMenuItem.getType());
+											SiteNavigationMenuItemType siteNavigationMenuItemType = siteNavigationMenuItemTypeRegistry.getSiteNavigationMenuItemType(siteNavigationMenuItem.getType());
 
-										rootMenuItemName = siteNavigationMenuItemType.getTitle(siteNavigationMenuItem, locale);
+											rootMenuItemName = siteNavigationMenuItemType.getTitle(siteNavigationMenuItem, locale);
+										}
+									}
+									else {
+										Layout rootLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(siteNavigationMenuDisplayContext.getRootMenuItemId(), themeDisplay.getScopeGroupId(), false);
+
+										if (rootLayout == null) {
+											rootLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(siteNavigationMenuDisplayContext.getRootMenuItemId(), themeDisplay.getScopeGroupId(), true);
+										}
+
+										if (rootLayout != null) {
+											rootMenuItemName = rootLayout.getName(locale);
+										}
 									}
 									%>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -20,6 +20,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.item.selector.constants.ItemSelectorPortletKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.model.Layout" %><%@
+page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.theme.NavItem" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/test/java/com/liferay/site/navigation/menu/web/internal/display/context/SiteNavigationMenuDisplayContextTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/test/java/com/liferay/site/navigation/menu/web/internal/display/context/SiteNavigationMenuDisplayContextTest.java
@@ -173,11 +173,25 @@ public class SiteNavigationMenuDisplayContextTest {
 		_setUpSiteNavigationMenuItemLocalServiceUtil(
 			_group.getGroupId(), rootMenuItemId);
 
+		long siteNavigationMenuId = RandomTestUtil.randomLong();
+
+		_setUpSiteNavigationMenuLocalServiceUtil(
+			_group.getGroupId(), siteNavigationMenuId);
+
 		String rootMenuItemExternalReferenceCode =
 			RandomTestUtil.randomString();
 
 		_setUpSiteNavigationMenuPortletInstanceConfigurationRootMenuItem(
 			rootMenuItemExternalReferenceCode, null);
+
+		String siteNavigationMenuExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_setUpSiteNavigationMenuPortletInstanceConfigurationSiteNavigationMenu(
+			siteNavigationMenuExternalReferenceCode, null);
+
+		_setUpSiteNavigationMenuPortletInstanceConfigurationSiteNavigationMenuType(
+			-1);
 
 		SiteNavigationMenuDisplayContext siteNavigationMenuDisplayContext =
 			new SiteNavigationMenuDisplayContext(_httpServletRequest);
@@ -205,12 +219,27 @@ public class SiteNavigationMenuDisplayContextTest {
 		_setUpSiteNavigationMenuItemLocalServiceUtil(
 			group.getGroupId(), rootMenuItemId);
 
+		long siteNavigationMenuId = RandomTestUtil.randomLong();
+
+		_setUpSiteNavigationMenuLocalServiceUtil(
+			_group.getGroupId(), siteNavigationMenuId);
+
 		String rootMenuItemExternalReferenceCode =
 			RandomTestUtil.randomString();
 
 		_setUpSiteNavigationMenuPortletInstanceConfigurationRootMenuItem(
 			rootMenuItemExternalReferenceCode,
 			group.getExternalReferenceCode());
+
+		String siteNavigationMenuExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_setUpSiteNavigationMenuPortletInstanceConfigurationSiteNavigationMenu(
+			siteNavigationMenuExternalReferenceCode,
+			group.getExternalReferenceCode());
+
+		_setUpSiteNavigationMenuPortletInstanceConfigurationSiteNavigationMenuType(
+			-1);
 
 		SiteNavigationMenuDisplayContext siteNavigationMenuDisplayContext =
 			new SiteNavigationMenuDisplayContext(_httpServletRequest);

--- a/modules/apps/site-navigation/site-navigation-menu-web/test.properties
+++ b/modules/apps/site-navigation/site-navigation-menu-web/test.properties
@@ -1,0 +1,22 @@
+##
+## Test Suites
+##
+
+    modified.files.includes[relevant][site-navigation-menu-web-rule]=**
+    relevant.rule.names=site-navigation-menu-web-rule
+
+    test.batch.names[relevant][site-navigation-menu-web-rule]=\
+        playwright-js-tomcat90-mysql57
+
+    #
+    # Relevant
+    #
+
+    playwright.projects.includes[playwright-js-tomcat90-mysql57][relevant][site-navigation-menu-web-rule]=\
+        site-navigation-menu-web
+
+##
+## Testray
+##
+
+    testray.main.component.name=Navigation Menus

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -117,6 +117,7 @@ import {config as siteCmsSiteInitializerConfig} from './tests/site-cms-site-init
 import {config as siteNavigationAdminWebConfig} from './tests/site-navigation-admin-web/config';
 import {config as siteNavigationBreadcrumbWebConfig} from './tests/site-navigation-breadcrumb-web/config';
 import {config as siteNavigationLanguageWebConfig} from './tests/site-navigation-language-web/config';
+import {config as siteNavigationMenuWebConfig} from './tests/site-navigation-menu-web/config';
 import {config as stableConfig} from './tests/stable/config';
 import {config as stagingConfig} from './tests/staging-configuration-web/config';
 import {config as stylebookWebConfig} from './tests/style-book-web/config';
@@ -246,6 +247,7 @@ export default defineConfig({
 		siteNavigationAdminWebConfig,
 		siteNavigationBreadcrumbWebConfig,
 		siteNavigationLanguageWebConfig,
+		siteNavigationMenuWebConfig,
 		stableConfig,
 		stagingConfig,
 		stylebookWebConfig,

--- a/modules/test/playwright/tests/site-navigation-menu-web/config.ts
+++ b/modules/test/playwright/tests/site-navigation-menu-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'site-navigation-menu-web',
+	testDir: 'tests/site-navigation-menu-web',
+};

--- a/modules/test/playwright/tests/site-navigation-menu-web/navigationMenu.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-menu-web/navigationMenu.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {pageViewModePagesTest} from '../../fixtures/pageViewModePagesTest';
+import getRandomString from '../../utils/getRandomString';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageViewModePagesTest
+);
+
+test(
+	'Select page as root menu item for Navigation Menu widget',
+	{
+		tag: '@LPD-50258',
+	},
+	async ({apiHelpers, page, site, widgetPagePage}) => {
+		const parentLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
+
+		const childLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			parentLayoutId: parentLayout.layoutId,
+			title: getRandomString(),
+		});
+
+		await page.goto(
+			`/web${site.friendlyUrlPath}${parentLayout.friendlyURL}`
+		);
+
+		await widgetPagePage.clickOnAction('Menu Display', 'Configuration');
+
+		const configurationIFrame = page.frameLocator(
+			'iframe[title*="Menu Display"]'
+		);
+
+		await configurationIFrame
+			.getByLabel('Start with Menu Items In')
+			.selectOption('Select Parent');
+
+		await configurationIFrame
+			.getByRole('button', {name: 'Menu Item'})
+			.click();
+
+		await configurationIFrame
+			.frameLocator('iframe[title="Select Site Navigation Menu Item"]')
+			.getByText('Pages Hierarchy')
+			.click();
+		await configurationIFrame
+			.frameLocator('iframe[title="Select Site Navigation Menu Item"]')
+			.getByText(parentLayout.nameCurrentValue)
+			.click();
+
+		await widgetPagePage.saveAndClose('Menu Display');
+
+		await expect(
+			page.getByRole('menuitem', {name: childLayout.nameCurrentValue})
+		).toBeVisible();
+
+		await widgetPagePage.clickOnAction('Menu Display', 'Configuration');
+
+		await expect(
+			configurationIFrame.getByText(parentLayout.nameCurrentValue)
+		).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/site-navigation-menu-web/test.properties
+++ b/modules/test/playwright/tests/site-navigation-menu-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Navigation Menus

--- a/test.properties
+++ b/test.properties
@@ -7459,7 +7459,8 @@
     playwright.projects.includes[playwright-js-tomcat90-postgresql155][site-management]=\
         site-admin-web,\
         site-navigation-admin-web,\
-        site-navigation-breadcrumb-web
+        site-navigation-breadcrumb-web,\
+        site-navigation-menu-web
 
     site.management.testing.modules=\
         apps/click-to-chat/**,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50258

# How am I fixing it?

When ERC was added to the Menu Display widget configuration the ability to set the root item as a layout page was lost. It was assumed that the root item would always be a `NavigationMenuItem`.

The changes made in this pull emulate the logic used in `NavItemUtil._getNavItems`, which is the logic that renders the navigation menu within the widget. The logic there works properly we just needed to send the right information to it.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-50258'`