### PR TITLE
LPD-50655 Navigation Menu configuration preview is not styled properly

### DIFF
--- a/portal-web/docroot/html/taglib/portlet/preview/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/preview/page.jsp
@@ -30,7 +30,7 @@ if (Validator.isNull(width)) {
 	</c:if>
 
 	<div class="preview" id="<%= randomNamespace %>">
-		<div>
+		<div id="<%= randomNamespace %>previewContainer">
 			<liferay-portlet:runtime
 				persistSettings="<%= false %>"
 				portletName="<%= portletResource %>"
@@ -44,6 +44,13 @@ if (Validator.isNull(width)) {
 	var randomElement = document.getElementById('<%= randomNamespace %>');
 
 	if (randomElement) {
+		var previewContainer = document.getElementById('<%= randomNamespace %>previewContainer');
+
+		if (previewContainer) {
+			previewContainer.style.margin = '3px';
+			previewContainer.style.width = <%= previewWidth %> ? parseInt('<%= HtmlUtil.escape(previewWidth) %>', 10) + 20 + 'px' : '100%';
+		}
+
 		var children = randomElement.getElementsByTagName('*');
 
 		var emptyFnFalse = function () {
@@ -54,8 +61,6 @@ if (Validator.isNull(width)) {
 			var item = children[i];
 
 			item.style.cursor = 'default';
-			item.style.margin = '3px';
-			item.style.width = <%= previewWidth %> ? parseInt('<%= HtmlUtil.escape(previewWidth) %>', 10) + 20 + 'px' : '100%';
 
 			item.onclick = emptyFnFalse;
 			item.onmouseover = emptyFnFalse;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50655

# How am I fixing it?

The CSS was erroneously being applied to all children elements rather than the first child div container.

Before:

![LPD-50655_before](https://github.com/user-attachments/assets/132e9f3f-aaac-400a-8331-4c393598d15c)

After:

![LPD-50655_after](https://github.com/user-attachments/assets/1f6aff75-271a-434e-8745-f3bbd5c61571)