### PR TITLE
LPD-50734 Cannot remove user's membership after assigning a role to them

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups.jsp
@@ -73,14 +73,18 @@ Role role = userGroupsDisplayContext.getRole();
 	<aui:input name="tabs1" type="hidden" value="user-groups" />
 </aui:form>
 
-<portlet:actionURL name="addUserGroupGroupRole" var="addUserGroupGroupRoleURL" />
+<portlet:actionURL name="addUserGroupGroupRole" var="addUserGroupGroupRoleURL">
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
 
 <aui:form action="<%= addUserGroupGroupRoleURL %>" cssClass="hide" name="addUserGroupGroupRoleFm">
 	<aui:input name="tabs1" type="hidden" value="user-groups" />
 	<aui:input name="userGroupId" type="hidden" />
 </aui:form>
 
-<portlet:actionURL name="unassignUserGroupGroupRole" var="unassignUserGroupGroupRoleURL" />
+<portlet:actionURL name="unassignUserGroupGroupRole" var="unassignUserGroupGroupRoleURL">
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
 
 <aui:form action="<%= unassignUserGroupGroupRoleURL %>" cssClass="hide" name="unassignUserGroupGroupRoleFm">
 	<aui:input name="tabs1" type="hidden" value="user-groups" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -215,10 +215,13 @@ Team team = usersDisplayContext.getTeam();
 </aui:form>
 
 <aui:form cssClass="hide" method="post" name="editUserGroupRoleFm">
+	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 	<aui:input name="tabs1" type="hidden" value="users" />
 </aui:form>
 
-<portlet:actionURL name="unassignUserGroupRole" var="unassignUserGroupRoleURL" />
+<portlet:actionURL name="unassignUserGroupRole" var="unassignUserGroupRoleURL">
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
 
 <aui:form action="<%= unassignUserGroupRoleURL %>" cssClass="hide" name="unassignUserGroupRoleFm">
 	<aui:input name="tabs1" type="hidden" value="users" />

--- a/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
@@ -214,3 +214,34 @@ test(
 		);
 	}
 );
+
+test(
+	'Able to remove membership after assigning role to user',
+	{
+		tag: '@LPD-50734',
+	},
+	async ({apiHelpers, membershipsPage, page}) => {
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		const siteId = await page.evaluate(() => {
+			return String(Liferay.ThemeDisplay.getSiteGroupId());
+		});
+
+		const siteRole =
+			await apiHelpers.headlessAdminUser.getRoleByName('Site Member');
+
+		await apiHelpers.headlessAdminUser.assignUserToSite(
+			siteRole.id,
+			siteId,
+			user.id
+		);
+
+		await membershipsPage.goto();
+		await membershipsPage.assignAllRolesToUser(user.alternateName);
+		await membershipsPage.removeSiteMembershipFromUser(user.alternateName);
+
+		await expect(page.getByText(user.name)).not.toBeVisible();
+
+		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
+	}
+);

--- a/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
@@ -94,6 +94,24 @@ export class MembershipsPage {
 		await this.productMenuPage.goToMemberships();
 	}
 
+	async removeSiteMembershipFromUser(userName: String) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Remove Membership',
+			}),
+			timeout: 500,
+			trigger: this.page
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
+						userName +
+						'"]'
+				)
+				.getByLabel('More actions'),
+		});
+	}
+
 	async removeSiteAdministratorRole() {
 		this.page.once('dialog', (dialog) => {
 			dialog.accept();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50734

# How am I fixing it?

When a user performed many actions in a row the previous actions were being stored in the URL. This caused any previous action performed to be executed again. After setting the redirect the action is cleared out and only one action is performed per request.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-50734'`