### PR TITLE
LPD-50843 Move change to another publication does not redirect to the Review Changes screen

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -830,7 +830,7 @@ export default function ChangeTrackingRenderView({
 						</div>
 					</>
 				),
-				onClick: () => navigate(moveChangesURL),
+				onClick: () => navigateUtil(moveChangesURL),
 				symbolLeft: 'move-folder',
 			});
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50843

This is caught by ManagePublications#CanMoveChangeBetweenPublications