### PR TITLE
LPD-50844 LayoutFriendlyURLEntryUpgradeProcess fails when different locales have the same friendly URL

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/LayoutFriendlyURLEntryUpgradeProcess.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/LayoutFriendlyURLEntryUpgradeProcess.java
@@ -8,6 +8,7 @@ package com.liferay.friendly.url.internal.upgrade.v3_4_1;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.model.FriendlyURLEntryMapping;
+import com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -46,6 +47,12 @@ public class LayoutFriendlyURLEntryUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		_dropIndex(
+			FriendlyURLEntryLocalizationModelImpl.TABLE_NAME, "IX_8AB5CAE");
+
+		_dropIndex(
+			FriendlyURLEntryLocalizationModelImpl.TABLE_NAME, "IX_C753170C");
+
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			Map<Long, String> defaultLanguageIds = new ConcurrentHashMap<>();
 
@@ -261,6 +268,22 @@ public class LayoutFriendlyURLEntryUpgradeProcess extends UpgradeProcess {
 			preparedStatement.setLong(7, friendlyURLEntryId);
 
 			preparedStatement.executeUpdate();
+		}
+	}
+
+	private void _dropIndex(String tableName, String indexName)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				String.format(
+					"Dropping index %s from table %s", indexName, tableName));
+		}
+
+		if (hasIndex(tableName, indexName)) {
+			runSQL(
+				StringBundler.concat(
+					"drop index ", indexName, " on ", tableName));
 		}
 	}
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
@@ -6,6 +6,7 @@
 package com.liferay.friendly.url.internal.upgrade.v3_4_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
@@ -16,21 +17,30 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.dao.orm.FinderCache;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.model.impl.LayoutFriendlyURLImpl;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -43,6 +53,7 @@ import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Timestamp;
 
 import java.util.List;
 
@@ -92,6 +103,70 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 		_deleteFriendlyURLEntries(draftLayout2, layout2);
 
 		_assertUpgrade(draftLayout1, draftLayout2, layout1, layout2);
+	}
+
+	@Test
+	public void testUpgradeDuplicateFriendlyURLEntryLocalization()
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
+		Layout layout = null;
+
+		try {
+			String name = RandomTestUtil.randomString();
+
+			layout = LayoutTestUtil.addTypePortletLayout(
+				_group.getGroupId(), false,
+				HashMapBuilder.put(
+					LocaleUtil.US, name
+				).build(),
+				HashMapBuilder.put(
+					LocaleUtil.US,
+					_friendlyURLNormalizer.normalizeWithEncoding(
+						StringPool.SLASH + name)
+				).build());
+
+			_insertLayoutFriendlyURLEntry(
+				layout,
+				_friendlyURLNormalizer.normalizeWithEncoding(
+					StringPool.SLASH + name),
+				LanguageUtil.getLanguageId(LocaleUtil.SPAIN));
+
+			db.runSQL(
+				"create unique index IX_8AB5CAE on " +
+					"FriendlyURLEntryLocalization (groupId, classNameId, " +
+						"urlTitle[$COLUMN_LENGTH:255$])");
+			db.runSQL(
+				"create unique index IX_C753170C on " +
+					"FriendlyURLEntryLocalization (groupId, classNameId, " +
+						"urlTitle[$COLUMN_LENGTH:255$], ctCollectionId)");
+
+			_entityCache.clearCache(LayoutFriendlyURLImpl.class);
+			_finderCache.clearCache(LayoutFriendlyURLImpl.class);
+
+			_assertUpgrade(layout);
+		}
+		finally {
+			if (dbInspector.hasIndex(
+					"FriendlyURLEntryLocalization", "IX_8AB5CAE")) {
+
+				db.runSQL(
+					"drop index IX_8AB5CAE on FriendlyURLEntryLocalization");
+			}
+
+			if (dbInspector.hasIndex(
+					"FriendlyURLEntryLocalization", "IX_C753170C")) {
+
+				db.runSQL(
+					"drop index IX_C753170C on FriendlyURLEntryLocalization");
+			}
+
+			if (layout != null) {
+				_layoutLocalService.deleteLayout(layout);
+			}
+		}
 	}
 
 	@Test
@@ -400,6 +475,42 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 		return 0;
 	}
 
+	private void _insertLayoutFriendlyURLEntry(
+			Layout layout, String friendlyURL, String languageId)
+		throws Exception {
+
+		Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"insert into LayoutFriendlyURL (mvccVersion, ",
+					"ctCollectionId, uuid_, layoutFriendlyURLId, groupId, ",
+					"companyId, userId, userName, createDate, modifiedDate, ",
+					"plid, privateLayout, friendlyURL, languageId, ",
+					"lastPublishDate) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ",
+					"?, ?, ?, ?, ?)"))) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setString(3, PortalUUIDUtil.generate());
+			preparedStatement.setLong(4, _counterLocalService.increment());
+			preparedStatement.setLong(5, _group.getGroupId());
+			preparedStatement.setLong(6, _group.getCompanyId());
+			preparedStatement.setLong(7, TestPropsValues.getUserId());
+			preparedStatement.setString(8, null);
+			preparedStatement.setTimestamp(9, timestamp);
+			preparedStatement.setTimestamp(10, timestamp);
+			preparedStatement.setLong(11, layout.getPlid());
+			preparedStatement.setBoolean(12, layout.isPrivateLayout());
+			preparedStatement.setString(13, friendlyURL);
+			preparedStatement.setString(14, languageId);
+			preparedStatement.setTimestamp(15, null);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
 	private void _runSQL(String sql) throws Exception {
 		DB db = DBManagerUtil.getDB();
 
@@ -436,6 +547,15 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@Inject
+	private FinderCache _finderCache;
+
+	@Inject
 	private FriendlyURLEntryLocalizationPersistence
 		_friendlyURLEntryLocalizationPersistence;
 
@@ -451,6 +571,12 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private MultiVMPool _multiVMPool;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50844

# How am I fixing it?

In the past we had two unique indexes on the `FriendlyURLEntryLocalization` table. Now, they have been changed and are no longer unique. When upgrading, the indexes are only modified after all of the upgrade processes have finished. In this case, we are trying to add records that violate the unique index but would be allowed with our current indexes.

To fix this issue I decided to drop the indexes prior to running the affected upgrade process. This allows the upgrade to complete successfully and once it does the correct indexes are then created.

The test manually inserts a record into the `LayoutFriendlyURL` table because if the service APIs are used then it will also populate the `FriendlyURLEntryLocalization`, which renders the test useless.

If there are any foreseen issues with the changes please let me know what would be a better alternative to pursue.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.LayoutFriendlyURLEntryUpgradeProcessTest`