### PR TITLE
LPD-50844 LayoutFriendlyURLEntryUpgradeProcess fails when different locales have the same friendly URL

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/LayoutFriendlyURLEntryUpgradeProcess.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/LayoutFriendlyURLEntryUpgradeProcess.java
@@ -8,6 +8,7 @@ package com.liferay.friendly.url.internal.upgrade.v3_4_1;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.model.FriendlyURLEntryMapping;
+import com.liferay.friendly.url.model.impl.FriendlyURLEntryLocalizationModelImpl;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -26,6 +27,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +48,10 @@ public class LayoutFriendlyURLEntryUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		dropIndexes(
+			Arrays.asList("IX_8AB5CAE", "IX_C753170C"),
+			FriendlyURLEntryLocalizationModelImpl.TABLE_NAME);
+
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			Map<Long, String> defaultLanguageIds = new ConcurrentHashMap<>();
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
@@ -6,6 +6,7 @@
 package com.liferay.friendly.url.internal.upgrade.v3_4_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
@@ -16,21 +17,30 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.dao.orm.FinderCache;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.model.impl.LayoutFriendlyURLImpl;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -43,6 +53,7 @@ import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Timestamp;
 
 import java.util.List;
 
@@ -92,6 +103,70 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 		_deleteFriendlyURLEntries(draftLayout2, layout2);
 
 		_assertUpgrade(draftLayout1, draftLayout2, layout1, layout2);
+	}
+
+	@Test
+	public void testUpgradeDuplicateFriendlyURLEntryLocalization()
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
+		Layout layout = null;
+
+		try {
+			String name = RandomTestUtil.randomString();
+
+			layout = LayoutTestUtil.addTypePortletLayout(
+				_group.getGroupId(), false,
+				HashMapBuilder.put(
+					LocaleUtil.US, name
+				).build(),
+				HashMapBuilder.put(
+					LocaleUtil.US,
+					_friendlyURLNormalizer.normalizeWithEncoding(
+						StringPool.SLASH + name)
+				).build());
+
+			_insertLayoutFriendlyURLEntry(
+				layout,
+				_friendlyURLNormalizer.normalizeWithEncoding(
+					StringPool.SLASH + name),
+				LanguageUtil.getLanguageId(LocaleUtil.SPAIN));
+
+			db.runSQL(
+				"create unique index IX_8AB5CAE on " +
+					"FriendlyURLEntryLocalization (groupId, classNameId, " +
+						"urlTitle[$COLUMN_LENGTH:255$])");
+			db.runSQL(
+				"create unique index IX_C753170C on " +
+					"FriendlyURLEntryLocalization (groupId, classNameId, " +
+						"urlTitle[$COLUMN_LENGTH:255$], ctCollectionId)");
+
+			_entityCache.clearCache(LayoutFriendlyURLImpl.class);
+			_finderCache.clearCache(LayoutFriendlyURLImpl.class);
+
+			_assertUpgrade(layout);
+		}
+		finally {
+			if (dbInspector.hasIndex(
+					"FriendlyURLEntryLocalization", "IX_8AB5CAE")) {
+
+				db.runSQL(
+					"drop index IX_8AB5CAE on FriendlyURLEntryLocalization");
+			}
+
+			if (dbInspector.hasIndex(
+					"FriendlyURLEntryLocalization", "IX_C753170C")) {
+
+				db.runSQL(
+					"drop index IX_C753170C on FriendlyURLEntryLocalization");
+			}
+
+			if (layout != null) {
+				_layoutLocalService.deleteLayout(layout);
+			}
+		}
 	}
 
 	@Test
@@ -400,6 +475,42 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 		return 0;
 	}
 
+	private void _insertLayoutFriendlyURLEntry(
+			Layout layout, String friendlyURL, String languageId)
+		throws Exception {
+
+		Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"insert into LayoutFriendlyURL (mvccVersion, ",
+					"ctCollectionId, uuid_, layoutFriendlyURLId, groupId, ",
+					"companyId, userId, userName, createDate, modifiedDate, ",
+					"plid, privateLayout, friendlyURL, languageId, ",
+					"lastPublishDate) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ",
+					"?, ?, ?, ?, ?)"))) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setString(3, PortalUUIDUtil.generate());
+			preparedStatement.setLong(4, _counterLocalService.increment());
+			preparedStatement.setLong(5, _group.getGroupId());
+			preparedStatement.setLong(6, _group.getCompanyId());
+			preparedStatement.setLong(7, TestPropsValues.getUserId());
+			preparedStatement.setString(8, null);
+			preparedStatement.setTimestamp(9, timestamp);
+			preparedStatement.setTimestamp(10, timestamp);
+			preparedStatement.setLong(11, layout.getPlid());
+			preparedStatement.setBoolean(12, layout.isPrivateLayout());
+			preparedStatement.setString(13, friendlyURL);
+			preparedStatement.setString(14, languageId);
+			preparedStatement.setTimestamp(15, null);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
 	private void _runSQL(String sql) throws Exception {
 		DB db = DBManagerUtil.getDB();
 
@@ -436,6 +547,15 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@Inject
+	private FinderCache _finderCache;
+
+	@Inject
 	private FriendlyURLEntryLocalizationPersistence
 		_friendlyURLEntryLocalizationPersistence;
 
@@ -451,6 +571,12 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private MultiVMPool _multiVMPool;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_0_0/ObjectFieldUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_0_0/ObjectFieldUpgradeProcess.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.Collections;
+
 /**
  * @author Pedro Leite
  */
@@ -60,11 +62,7 @@ public class ObjectFieldUpgradeProcess extends UpgradeProcess {
 				String indexName = IndexMetadataFactoryUtil.createIndexName(
 					dbTableName, columnNames);
 
-				if (hasIndex(dbTableName, indexName)) {
-					runSQL(
-						StringBundler.concat(
-							"drop index ", indexName, " on ", dbTableName));
-				}
+				dropIndexes(Collections.singletonList(indexName), dbTableName);
 			}
 		}
 	}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -462,6 +462,17 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	}
 
 	@Test
+	public void testDropIndexes() throws Exception {
+		_addIndex(new String[] {"typeVarchar", "typeBoolean"});
+
+		Assert.assertTrue(hasIndex(_TABLE_NAME, _INDEX_NAME));
+
+		dropIndexes(Collections.singletonList(_INDEX_NAME), _TABLE_NAME);
+
+		Assert.assertFalse(hasIndex(_TABLE_NAME, _INDEX_NAME));
+	}
+
+	@Test
 	public void testDropNonexistentTable() throws Exception {
 		dropTable("nonexistentTable");
 	}

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_2/SamlPeerBindingUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_2/SamlPeerBindingUpgradeProcess.java
@@ -5,11 +5,10 @@
 
 package com.liferay.saml.persistence.internal.upgrade.v3_0_2;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.saml.persistence.model.impl.SamlPeerBindingImpl;
+
+import java.util.Arrays;
 
 /**
  * @author Stian Sigvartsen
@@ -18,30 +17,9 @@ public class SamlPeerBindingUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		_dropIndex(SamlPeerBindingImpl.TABLE_NAME, "IX_E642E1AE");
-
-		_dropIndex(SamlPeerBindingImpl.TABLE_NAME, "IX_81ACF542");
-
-		_dropIndex(SamlPeerBindingImpl.TABLE_NAME, "IX_BC82BDFC");
+		dropIndexes(
+			Arrays.asList("IX_E642E1AE", "IX_81ACF542", "IX_BC82BDFC"),
+			SamlPeerBindingImpl.TABLE_NAME);
 	}
-
-	private void _dropIndex(String tableName, String indexName)
-		throws Exception {
-
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				String.format(
-					"Dropping index %s from table %s", indexName, tableName));
-		}
-
-		if (hasIndex(tableName, indexName)) {
-			runSQL(
-				StringBundler.concat(
-					"drop index ", indexName, " on ", tableName));
-		}
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		SamlPeerBindingUpgradeProcess.class);
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -316,6 +316,29 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
+	public void dropIndexes(
+			Connection connection, List<String> indexNames, String tableName)
+		throws Exception {
+
+		DBInspector dbInspector = new DBInspector(connection);
+
+		for (String indexName : indexNames) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					String.format(
+						"Dropping index %s from table %s", indexName,
+						tableName));
+			}
+
+			if (dbInspector.hasIndex(tableName, indexName)) {
+				runSQL(
+					StringBundler.concat(
+						"drop index ", indexName, " on ", tableName));
+			}
+		}
+	}
+
+	@Override
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException {

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSQLServer.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSQLServer.java
@@ -19,6 +19,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -223,9 +224,8 @@ public class UpgradeSQLServer extends UpgradeProcess {
 							primaryKeyColumnNames, ")"));
 				}
 				else {
-					runSQL(
-						StringBundler.concat(
-							"drop index ", indexName, " on ", tableName));
+					dropIndexes(
+						Collections.singletonList(indexName), tableName);
 				}
 			}
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -294,6 +294,14 @@ public abstract class BaseDBProcess implements DBProcess {
 		return dbInspector.hasTable(tableName);
 	}
 
+	protected void dropIndexes(List<String> indexNames, String tableName)
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+
+		db.dropIndexes(connection, indexNames, tableName);
+	}
+
 	protected List<IndexMetadata> dropIndexes(
 			String tableName, String columnName)
 		throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -68,6 +68,10 @@ public interface DB {
 			Connection connection, String tableName, String newTableName)
 		throws Exception;
 
+	public void dropIndexes(
+			Connection connection, List<String> indexNames, String tableName)
+		throws Exception;
+
 	public List<IndexMetadata> dropIndexes(
 			Connection connection, String tableName, String columnName)
 		throws IOException, SQLException;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 20.0.0
+version 20.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 14.1.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50844

# How am I fixing it?

In the past we had two unique indexes on the `FriendlyURLEntryLocalization` table. Now, they have been changed and are no longer unique. When upgrading, the indexes are only modified after all of the upgrade processes have finished. In this case, we are trying to add records that violate the unique index but would be allowed with our current indexes.

To fix this issue I decided to drop the indexes prior to running the affected upgrade process. This allows the upgrade to complete successfully and once it does the correct indexes are then created.

The test manually inserts a record into the `LayoutFriendlyURL` table because if the service APIs are used then it will also populate the `FriendlyURLEntryLocalization`, which renders the test useless.

If there are any foreseen issues with the changes please let me know what would be a better alternative to pursue.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.LayoutFriendlyURLEntryUpgradeProcessTest`
In `portal-dao-test` run `gw testIntegration --tests *.BaseDBProcessTest`