### PR TITLE
LPD-51724 Orphaned data in RedirectEntry and RedirectNotFoundEntry tables when deleting site

### DIFF
--- a/modules/apps/redirect/redirect-api/bnd.bnd
+++ b/modules/apps/redirect/redirect-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect API
 Bundle-SymbolicName: com.liferay.redirect.api
-Bundle-Version: 13.0.1
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.google.re2j,\
 	\

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalService.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalService.java
@@ -114,6 +114,8 @@ public interface RedirectEntryLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	public void deleteRedirectEntries(long groupId) throws PortalException;
+
 	/**
 	 * Deletes the redirect entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalServiceUtil.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalServiceUtil.java
@@ -121,6 +121,12 @@ public class RedirectEntryLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static void deleteRedirectEntries(long groupId)
+		throws PortalException {
+
+		getService().deleteRedirectEntries(groupId);
+	}
+
 	/**
 	 * Deletes the redirect entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalServiceWrapper.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectEntryLocalServiceWrapper.java
@@ -126,6 +126,13 @@ public class RedirectEntryLocalServiceWrapper
 		return _redirectEntryLocalService.deletePersistedModel(persistedModel);
 	}
 
+	@Override
+	public void deleteRedirectEntries(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_redirectEntryLocalService.deleteRedirectEntries(groupId);
+	}
+
 	/**
 	 * Deletes the redirect entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalService.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalService.java
@@ -107,6 +107,9 @@ public interface RedirectNotFoundEntryLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	public void deleteRedirectNotFoundEntries(long groupId)
+		throws PortalException;
+
 	/**
 	 * Deletes the redirect not found entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *
@@ -132,10 +135,12 @@ public interface RedirectNotFoundEntryLocalService
 	 *
 	 * @param redirectNotFoundEntry the redirect not found entry
 	 * @return the redirect not found entry that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	public RedirectNotFoundEntry deleteRedirectNotFoundEntry(
-		RedirectNotFoundEntry redirectNotFoundEntry);
+			RedirectNotFoundEntry redirectNotFoundEntry)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalServiceUtil.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalServiceUtil.java
@@ -91,6 +91,12 @@ public class RedirectNotFoundEntryLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static void deleteRedirectNotFoundEntries(long groupId)
+		throws PortalException {
+
+		getService().deleteRedirectNotFoundEntries(groupId);
+	}
+
 	/**
 	 * Deletes the redirect not found entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *
@@ -119,9 +125,11 @@ public class RedirectNotFoundEntryLocalServiceUtil {
 	 *
 	 * @param redirectNotFoundEntry the redirect not found entry
 	 * @return the redirect not found entry that was removed
+	 * @throws PortalException
 	 */
 	public static RedirectNotFoundEntry deleteRedirectNotFoundEntry(
-		RedirectNotFoundEntry redirectNotFoundEntry) {
+			RedirectNotFoundEntry redirectNotFoundEntry)
+		throws PortalException {
 
 		return getService().deleteRedirectNotFoundEntry(redirectNotFoundEntry);
 	}

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalServiceWrapper.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/service/RedirectNotFoundEntryLocalServiceWrapper.java
@@ -96,6 +96,14 @@ public class RedirectNotFoundEntryLocalServiceWrapper
 			persistedModel);
 	}
 
+	@Override
+	public void deleteRedirectNotFoundEntries(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntries(
+			groupId);
+	}
+
 	/**
 	 * Deletes the redirect not found entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *
@@ -125,12 +133,14 @@ public class RedirectNotFoundEntryLocalServiceWrapper
 	 *
 	 * @param redirectNotFoundEntry the redirect not found entry
 	 * @return the redirect not found entry that was removed
+	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.redirect.model.RedirectNotFoundEntry
-		deleteRedirectNotFoundEntry(
-			com.liferay.redirect.model.RedirectNotFoundEntry
-				redirectNotFoundEntry) {
+			deleteRedirectNotFoundEntry(
+				com.liferay.redirect.model.RedirectNotFoundEntry
+					redirectNotFoundEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntry(
 			redirectNotFoundEntry);

--- a/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/service/packageinfo
+++ b/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/model/listener/GroupModelListener.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.redirect.internal.model.listener;
+
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.redirect.service.RedirectNotFoundEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = ModelListener.class)
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onAfterRemove(Group group) throws ModelListenerException {
+		try {
+			_redirectEntryLocalService.deleteRedirectEntries(
+				group.getGroupId());
+
+			_redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntries(
+				group.getGroupId());
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Reference
+	private RedirectEntryLocalService _redirectEntryLocalService;
+
+	@Reference
+	private RedirectNotFoundEntryLocalService
+		_redirectNotFoundEntryLocalService;
+
+}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/base/RedirectNotFoundEntryLocalServiceBaseImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/base/RedirectNotFoundEntryLocalServiceBaseImpl.java
@@ -129,11 +129,13 @@ public abstract class RedirectNotFoundEntryLocalServiceBaseImpl
 	 *
 	 * @param redirectNotFoundEntry the redirect not found entry
 	 * @return the redirect not found entry that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	public RedirectNotFoundEntry deleteRedirectNotFoundEntry(
-		RedirectNotFoundEntry redirectNotFoundEntry) {
+			RedirectNotFoundEntry redirectNotFoundEntry)
+		throws PortalException {
 
 		return redirectNotFoundEntryPersistence.remove(redirectNotFoundEntry);
 	}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
@@ -154,6 +154,15 @@ public class RedirectEntryLocalServiceImpl
 		return redirectEntry;
 	}
 
+	@Override
+	public void deleteRedirectEntries(long groupId) throws PortalException {
+		for (RedirectEntry redirectEntry :
+				redirectEntryPersistence.findByGroupId(groupId)) {
+
+			redirectEntryLocalService.deleteRedirectEntry(redirectEntry);
+		}
+	}
+
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	public RedirectEntry deleteRedirectEntry(long redirectEntryId)

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectNotFoundEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectNotFoundEntryLocalServiceImpl.java
@@ -80,6 +80,18 @@ public class RedirectNotFoundEntryLocalServiceImpl
 		return redirectNotFoundEntry;
 	}
 
+	@Override
+	public void deleteRedirectNotFoundEntries(long groupId)
+		throws PortalException {
+
+		for (RedirectNotFoundEntry redirectNotFoundEntry :
+				redirectNotFoundEntryPersistence.findByGroupId(groupId)) {
+
+			redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntry(
+				redirectNotFoundEntry);
+		}
+	}
+
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	public RedirectNotFoundEntry deleteRedirectNotFoundEntry(

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectNotFoundEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectNotFoundEntryLocalServiceImpl.java
@@ -80,6 +80,20 @@ public class RedirectNotFoundEntryLocalServiceImpl
 		return redirectNotFoundEntry;
 	}
 
+	@Indexable(type = IndexableType.DELETE)
+	@Override
+	public RedirectNotFoundEntry deleteRedirectNotFoundEntry(
+			RedirectNotFoundEntry redirectNotFoundEntry)
+		throws PortalException {
+
+		_viewCountManager.deleteViewCount(
+			redirectNotFoundEntry.getCompanyId(),
+			_portal.getClassNameId(RedirectNotFoundEntry.class),
+			redirectNotFoundEntry.getRedirectNotFoundEntryId());
+
+		return super.deleteRedirectNotFoundEntry(redirectNotFoundEntry);
+	}
+
 	@Override
 	public RedirectNotFoundEntry fetchRedirectNotFoundEntry(
 		long groupId, String url) {

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/internal/model/listener/test/GroupModelListenerTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.redirect.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.view.count.ViewCountManager;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.redirect.model.RedirectEntry;
+import com.liferay.redirect.model.RedirectNotFoundEntry;
+import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.redirect.service.RedirectNotFoundEntryLocalService;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class GroupModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testOnAfterRemove() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		RedirectEntry redirectEntry =
+			_redirectEntryLocalService.addRedirectEntry(
+				group.getGroupId(), RandomTestUtil.randomString(), null, false,
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		RedirectNotFoundEntry redirectNotFoundEntry =
+			_redirectNotFoundEntryLocalService.addOrUpdateRedirectNotFoundEntry(
+				group, RandomTestUtil.randomString());
+
+		Assert.assertNotNull(
+			_redirectEntryLocalService.fetchRedirectEntry(
+				redirectEntry.getRedirectEntryId()));
+		Assert.assertNotNull(
+			_redirectNotFoundEntryLocalService.fetchRedirectNotFoundEntry(
+				redirectNotFoundEntry.getRedirectNotFoundEntryId()));
+		Assert.assertEquals(
+			1,
+			_viewCountManager.getViewCount(
+				group.getCompanyId(),
+				_portal.getClassNameId(RedirectNotFoundEntry.class),
+				redirectNotFoundEntry.getRedirectNotFoundEntryId()));
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertNull(
+			_redirectEntryLocalService.fetchRedirectEntry(
+				redirectEntry.getRedirectEntryId()));
+		Assert.assertNull(
+			_redirectNotFoundEntryLocalService.fetchRedirectNotFoundEntry(
+				redirectNotFoundEntry.getRedirectNotFoundEntryId()));
+		Assert.assertEquals(
+			0,
+			_viewCountManager.getViewCount(
+				group.getCompanyId(),
+				_portal.getClassNameId(RedirectNotFoundEntry.class),
+				redirectNotFoundEntry.getRedirectNotFoundEntryId()));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private RedirectEntryLocalService _redirectEntryLocalService;
+
+	@Inject
+	private RedirectNotFoundEntryLocalService
+		_redirectNotFoundEntryLocalService;
+
+	@Inject
+	private ViewCountManager _viewCountManager;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51724

# How am I fixing it?

When a site was deleted it's redirect/not found entries were not removed from the database, leaving behind orphaned entries. This pull adds in a new `GroupModelListener` to clean up these entries when the group is deleted.

Along with that I noticed when a `RedirectNotFoundEntry` was added an entry was also added to the `ViewCountEntry` table. However, upon deletion, the `ViewCountEntry` entry was not also deleted. This is handled in 20ea0f45172a948fa241f67bb8b04b2cd5e9d543.

# How can you verify that it works?

In `redirect-test` run `gw testIntegration --tests *.GroupModelListenerTest`