### PR TITLE
LPD-51686 Permissions Table for Vocabularies

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -17209,6 +17209,7 @@ site-id=Site ID
 site-id-help=The identifier of the current site.
 site-initializer-extender-synchronize-help-x=This operation is irreversible and will synchronize the current site with {0}.
 site-map-display-context-help=Provides helper methods to retrieve the Site Map widget configuration.
+site-member=Site Member
 site-members=Site Members
 site-members-can-mention-each-other=Site Members Can Mention Each Other
 site-membership-preference=Site Membership Preference

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
@@ -1,0 +1,347 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Body, Cell, Head, Row, Table, Text} from '@clayui/core';
+import {ClayCheckbox, ClaySelect} from '@clayui/form';
+import React, {useMemo, useState} from 'react';
+
+export enum ActionId {
+	AddCategory = 'ADD_CATEGORY',
+	Delete = 'DELETE',
+	Download = 'DOWNLOAD',
+	Permissions = 'PERMISSIONS',
+	Update = 'UPDATE',
+	View = 'VIEW',
+}
+
+export enum Role {
+	Guest = 'Guest',
+	OrganizationUser = 'Organization User',
+	Owner = 'Owner',
+	PowerUser = 'Power User',
+	SiteMember = 'Site Member',
+	User = 'User',
+}
+
+type ActionLabels = {
+	[key in ActionId]: string;
+};
+
+const ACTION_LABELS: ActionLabels = {
+	[ActionId.AddCategory]: Liferay.Language.get('add-category'),
+	[ActionId.Delete]: Liferay.Language.get('delete'),
+	[ActionId.Download]: Liferay.Language.get('download'),
+	[ActionId.Permissions]: Liferay.Language.get('permissions'),
+	[ActionId.Update]: Liferay.Language.get('update'),
+	[ActionId.View]: Liferay.Language.get('view'),
+};
+
+type RoleLabels = {
+	[key in Role]: string;
+};
+
+const ROLE_LABELS: RoleLabels = {
+	[Role.Guest]: Liferay.Language.get('guest'),
+	[Role.OrganizationUser]: Liferay.Language.get('organization-members'),
+	[Role.PowerUser]: Liferay.Language.get('power-users'),
+	[Role.SiteMember]: Liferay.Language.get('site-members'),
+	[Role.User]: Liferay.Language.get('user'),
+	[Role.Owner]: Liferay.Language.get('owner'),
+};
+interface PermissionItem {
+	actionIds: ActionId[];
+	roleName: Role;
+}
+
+/**
+ * Returns a new permissions object with the particular actionId at
+ * a certain index toggled. Called when clicking on a checkbox in the
+ * permissions table.
+ *
+ * @param permissions
+ * @param actionId
+ * @param index
+ * @returns PermissionItem[]
+ */
+const toggleActionIdAtIndex = (
+	permissions: PermissionItem[],
+	actionId: ActionId,
+	index: number
+) => {
+	const newPermissions = permissions.slice();
+
+	newPermissions[index].actionIds = permissions[index].actionIds.includes(
+		actionId
+	)
+		? permissions[index].actionIds.filter((item) => item !== actionId)
+		: [...permissions[index].actionIds, actionId];
+
+	return newPermissions;
+};
+
+/**
+ * Returns a new permissions object with all the actionIds enabled
+ * for the listed roles, while the rest of the roles have the actionIds
+ * disabled. Called when selecting from the 'Viewable By' dropdown.
+ *
+ * @param permissions
+ * @param roles
+ * @param actionIdsToEnable
+ * @returns PermissionItem[]
+ */
+const enableActionIdsForRoles = (
+	permissions: PermissionItem[],
+	roles: Role[],
+	actionIdsToEnable: ActionId[]
+) => {
+	return permissions.map(({actionIds, roleName}) => {
+		const actionIdsNotEnabled = actionIdsToEnable.filter(
+			(id) => !actionIds.includes(id)
+		);
+
+		return {
+			actionIds: roles.includes(roleName)
+				? [...actionIds, ...actionIdsNotEnabled]
+				: actionIds.filter((item) => !actionIdsToEnable.includes(item)),
+			roleName,
+		};
+	});
+};
+
+function PermissionsTable({
+
+	/*
+	 * Classname to apply extra styles to the table.
+	 */
+	className,
+
+	/*
+	 * Default group role that is between Guest and Owner, featured
+	 * in the Viewable By options and should be included as one of the roles
+	 * in defaultPermissions (example: organization member, power user,
+	 * site member).
+	 */
+	defaultGroupRole = Role.SiteMember,
+
+	/*
+	 * Default state for permissions.
+	 */
+	defaultPermissions = [
+		{
+			actionIds: [ActionId.View],
+			roleName: Role.Guest,
+		},
+		{
+			actionIds: [ActionId.View],
+			roleName: Role.SiteMember,
+		},
+	],
+
+	/*
+	 * Checkboxes to be disabled for the guest role.
+	 */
+	guestUnsupportedActions = [ActionId.Update],
+
+	/*
+	 * Callback for when permissions gets changed.
+	 */
+	onChange = () => {},
+
+	/*
+	 * Actions to be listed as the row/column entries.
+	 */
+	supportedActions = [
+		ActionId.Delete,
+		ActionId.Permissions,
+		ActionId.Update,
+		ActionId.View,
+	],
+	...otherProps
+}: {
+	className: string;
+	defaultGroupRole: Role;
+	defaultPermissions: PermissionItem[];
+	guestUnsupportedActions: ActionId[];
+	onChange: Function;
+	supportedActions: ActionId[];
+}) {
+	const [permissions, setPermissions] =
+		useState<PermissionItem[]>(defaultPermissions);
+	const [viewableBy, setViewableBy] = useState<Role>(
+		defaultPermissions.every(({actionIds}: {actionIds: ActionId[]}) =>
+			actionIds.includes(ActionId.View)
+		) // Guest -> all permissions enabled
+			? Role.Guest
+			: defaultPermissions.every(
+						({actionIds}: {actionIds: ActionId[]}) =>
+							!actionIds.includes(ActionId.View)
+				  ) // Owner -> no permissions enabled
+				? Role.Owner
+				: defaultGroupRole // Group -> group permissions enabled
+	);
+
+	const allRoles: Role[] = useMemo(() => {
+		return defaultPermissions.map(({roleName}) => roleName);
+	}, [defaultPermissions]);
+
+	const viewableByOptions = [
+		{
+			label: `${Liferay.Language.get('anyone')} (${Liferay.Util.sub(Liferay.Language.get('x-role'), ROLE_LABELS[Role.Guest])})`,
+			value: Role.Guest,
+		},
+		{
+			label: ROLE_LABELS[defaultGroupRole],
+			value: defaultGroupRole,
+		},
+		{
+			label: ROLE_LABELS[Role.Owner],
+			value: Role.Owner,
+		},
+	];
+
+	const _handleChangePermissions = (newPermissions: PermissionItem[]) => {
+		setPermissions(newPermissions);
+		onChange(newPermissions);
+	};
+
+	const _handleChangeAction = (index: number, action: ActionId) => {
+		_handleChangePermissions(
+			toggleActionIdAtIndex(permissions, action, index)
+		);
+	};
+
+	const _handleChangeViewableBy = (event: any) => {
+		setViewableBy(event.target.value as Role);
+
+		const actionIdsToUpdate = supportedActions.includes(ActionId.Download)
+			? [ActionId.View, ActionId.Download]
+			: [ActionId.View];
+
+		const rolesToEnable =
+			event.target.value === Role.Guest
+				? allRoles
+				: event.target.value === Role.Owner
+					? []
+					: [defaultGroupRole];
+
+		_handleChangePermissions(
+			enableActionIdsForRoles(
+				permissions,
+				rolesToEnable,
+				actionIdsToUpdate
+			)
+		);
+	};
+
+	const _isActionChecked = (action: ActionId, index: number) => {
+		return permissions[index].actionIds.includes(action);
+	};
+
+	const _isActionDisabled = (action: ActionId, role: Role) => {
+		if (action === ActionId.View) {
+			return true;
+		}
+
+		if (role === Role.Guest) {
+			return guestUnsupportedActions.includes(action);
+		}
+
+		return false;
+	};
+
+	return (
+		<>
+			<p>
+				<label htmlFor="viewableBy">
+					{supportedActions.includes(ActionId.Download)
+						? Liferay.Language.get('viewable-and-downloadable-by')
+						: Liferay.Language.get('viewable-by')}
+				</label>
+
+				<ClaySelect
+					aria-label={Liferay.Language.get('viewable-by')}
+					id="viewableBy"
+					onChange={_handleChangeViewableBy}
+					value={viewableBy}
+				>
+					{viewableByOptions.map((item) => (
+						<ClaySelect.Option
+							key={item.value}
+							label={item.label}
+							value={item.value}
+						/>
+					))}
+				</ClaySelect>
+			</p>
+
+			<Table
+				className={className}
+				columnsVisibility={false}
+				striped={false}
+				{...otherProps}
+			>
+				<Head
+					items={[
+						{
+							id: 'role',
+							name: Liferay.Language.get('role'),
+						},
+						...supportedActions.map((action: ActionId) => ({
+							id: action,
+							name: ACTION_LABELS[action] || action,
+						})),
+					]}
+				>
+					{(column) => (
+						<Cell key={`action_header_${column.id}`}>
+							{column.name}
+						</Cell>
+					)}
+				</Head>
+
+				<Body>
+					{permissions.map((item: PermissionItem, index) => (
+						<Row key={item.roleName}>
+							<Cell>
+								<Text size={3} weight="semi-bold">
+									{item.roleName}
+								</Text>
+							</Cell>
+
+							{supportedActions.map((action: ActionId) => (
+								<Cell
+									key={`${item.roleName.replace(' ', '')}-${action}`}
+								>
+									<ClayCheckbox
+										aria-label={Liferay.Util.sub(
+											'give-x-permission-to-users-with-the-x-role',
+											[
+												ACTION_LABELS[action],
+												item.roleName,
+											]
+										)}
+										checked={_isActionChecked(
+											action,
+											index
+										)}
+										disabled={_isActionDisabled(
+											action,
+											item.roleName
+										)}
+										onChange={() =>
+											_handleChangeAction(index, action)
+										}
+									/>
+								</Cell>
+							))}
+						</Row>
+					))}
+				</Body>
+			</Table>
+		</>
+	);
+}
+
+export default PermissionsTable;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
@@ -7,52 +7,9 @@ import {Body, Cell, Head, Row, Table, Text} from '@clayui/core';
 import {ClayCheckbox, ClaySelect} from '@clayui/form';
 import React, {useMemo, useState} from 'react';
 
-export enum ActionId {
-	AddCategory = 'ADD_CATEGORY',
-	Delete = 'DELETE',
-	Download = 'DOWNLOAD',
-	Permissions = 'PERMISSIONS',
-	Update = 'UPDATE',
-	View = 'VIEW',
-}
-
-export enum Role {
-	Guest = 'Guest',
-	OrganizationUser = 'Organization User',
-	Owner = 'Owner',
-	PowerUser = 'Power User',
-	SiteMember = 'Site Member',
-	User = 'User',
-}
-
-type ActionLabels = {
-	[key in ActionId]: string;
-};
-
-const ACTION_LABELS: ActionLabels = {
-	[ActionId.AddCategory]: Liferay.Language.get('add-category'),
-	[ActionId.Delete]: Liferay.Language.get('delete'),
-	[ActionId.Download]: Liferay.Language.get('download'),
-	[ActionId.Permissions]: Liferay.Language.get('permissions'),
-	[ActionId.Update]: Liferay.Language.get('update'),
-	[ActionId.View]: Liferay.Language.get('view'),
-};
-
-type RoleLabels = {
-	[key in Role]: string;
-};
-
-const ROLE_LABELS: RoleLabels = {
-	[Role.Guest]: Liferay.Language.get('guest'),
-	[Role.OrganizationUser]: Liferay.Language.get('organization-members'),
-	[Role.PowerUser]: Liferay.Language.get('power-users'),
-	[Role.SiteMember]: Liferay.Language.get('site-members'),
-	[Role.User]: Liferay.Language.get('user'),
-	[Role.Owner]: Liferay.Language.get('owner'),
-};
 interface PermissionItem {
-	actionIds: ActionId[];
-	roleName: Role;
+	actionIds: string[];
+	roleName: string;
 }
 
 /**
@@ -67,7 +24,7 @@ interface PermissionItem {
  */
 const toggleActionIdAtIndex = (
 	permissions: PermissionItem[],
-	actionId: ActionId,
+	actionId: string,
 	index: number
 ) => {
 	const newPermissions = permissions.slice();
@@ -87,14 +44,14 @@ const toggleActionIdAtIndex = (
  * disabled. Called when selecting from the 'Viewable By' dropdown.
  *
  * @param permissions
- * @param roles
+ * @param roleNames
  * @param actionIdsToEnable
  * @returns PermissionItem[]
  */
 const enableActionIdsForRoles = (
 	permissions: PermissionItem[],
-	roles: Role[],
-	actionIdsToEnable: ActionId[]
+	roleNamesToEnable: string[],
+	actionIdsToEnable: string[]
 ) => {
 	return permissions.map(({actionIds, roleName}) => {
 		const actionIdsNotEnabled = actionIdsToEnable.filter(
@@ -102,7 +59,7 @@ const enableActionIdsForRoles = (
 		);
 
 		return {
-			actionIds: roles.includes(roleName)
+			actionIds: roleNamesToEnable.includes(roleName)
 				? [...actionIds, ...actionIdsNotEnabled]
 				: actionIds.filter((item) => !actionIdsToEnable.includes(item)),
 			roleName,
@@ -113,6 +70,19 @@ const enableActionIdsForRoles = (
 function PermissionsTable({
 
 	/*
+	 * Actions to be listed as the row/column entries.
+	 */
+	actions = [
+		{
+			id: 'DELETE',
+			label: Liferay.Language.get('delete'),
+		},
+		{id: 'PERMISSIONS', label: Liferay.Language.get('permissions')},
+		{id: 'UPDATE', label: Liferay.Language.get('update')},
+		{id: 'VIEW', label: Liferay.Language.get('view')},
+	],
+
+	/*
 	 * Classname to apply extra styles to the table.
 	 */
 	className,
@@ -120,29 +90,29 @@ function PermissionsTable({
 	/*
 	 * Default group role that is between Guest and Owner, featured
 	 * in the Viewable By options and should be included as one of the roles
-	 * in defaultPermissions (example: organization member, power user,
-	 * site member).
+	 * in "roles" (example: Organization Member, Power User,
+	 * Site Member).
 	 */
-	defaultGroupRole = Role.SiteMember,
+	defaultGroupRole = 'Site Member',
 
 	/*
 	 * Default state for permissions.
 	 */
 	defaultPermissions = [
 		{
-			actionIds: [ActionId.View],
-			roleName: Role.Guest,
+			actionIds: ['VIEW'],
+			roleName: 'Guest',
 		},
 		{
-			actionIds: [ActionId.View],
-			roleName: Role.SiteMember,
+			actionIds: ['VIEW'],
+			roleName: 'Site Member',
 		},
 	],
 
 	/*
 	 * Checkboxes to be disabled for the guest role.
 	 */
-	guestUnsupportedActions = [ActionId.Update],
+	guestUnsupportedActionIds = ['UPDATE'],
 
 	/*
 	 * Callback for when permissions gets changed.
@@ -150,54 +120,68 @@ function PermissionsTable({
 	onChange = () => {},
 
 	/*
-	 * Actions to be listed as the row/column entries.
+	 * Roles to be listed as the row/column entries.
 	 */
-	supportedActions = [
-		ActionId.Delete,
-		ActionId.Permissions,
-		ActionId.Update,
-		ActionId.View,
+	roles = [
+		{id: 'Guest', label: Liferay.Language.get('guest')},
+		{
+			id: 'Site Member',
+			label: Liferay.Language.get('site-member'),
+		},
 	],
 	...otherProps
 }: {
+	actions: {id: string; label: string}[];
 	className: string;
-	defaultGroupRole: Role;
+	defaultGroupRole: string;
 	defaultPermissions: PermissionItem[];
-	guestUnsupportedActions: ActionId[];
+	guestUnsupportedActionIds: string[];
 	onChange: Function;
-	supportedActions: ActionId[];
+	roles: {id: string; label: string}[];
 }) {
+	const initialPermissions = useMemo(
+		() =>
+			roles.map(({id}) => ({
+				actionIds:
+					defaultPermissions.find(({roleName}) => id === roleName)
+						?.actionIds || [],
+				roleName: id,
+			})),
+		[roles, defaultPermissions]
+	);
+	const supportedActionIds: string[] = useMemo(
+		() => actions.map(({id}) => id),
+		[actions]
+	);
+	const supportedRoleNames: string[] = useMemo(
+		() => roles.map(({id}) => id),
+		[roles]
+	);
+
 	const [permissions, setPermissions] =
-		useState<PermissionItem[]>(defaultPermissions);
-	const [viewableBy, setViewableBy] = useState<Role>(
-		defaultPermissions.every(({actionIds}: {actionIds: ActionId[]}) =>
-			actionIds.includes(ActionId.View)
-		) // Guest -> all permissions enabled
-			? Role.Guest
-			: defaultPermissions.every(
-						({actionIds}: {actionIds: ActionId[]}) =>
-							!actionIds.includes(ActionId.View)
+		useState<PermissionItem[]>(initialPermissions);
+	const [viewableBy, setViewableBy] = useState<string>(
+		initialPermissions.every(({actionIds}) => actionIds.includes('VIEW')) // Guest -> all permissions enabled
+			? 'Guest'
+			: initialPermissions.every(
+						({actionIds}) => !actionIds.includes('VIEW')
 				  ) // Owner -> no permissions enabled
-				? Role.Owner
+				? 'Owner'
 				: defaultGroupRole // Group -> group permissions enabled
 	);
 
-	const allRoles: Role[] = useMemo(() => {
-		return defaultPermissions.map(({roleName}) => roleName);
-	}, [defaultPermissions]);
-
 	const viewableByOptions = [
 		{
-			label: `${Liferay.Language.get('anyone')} (${Liferay.Util.sub(Liferay.Language.get('x-role'), ROLE_LABELS[Role.Guest])})`,
-			value: Role.Guest,
+			label: `${Liferay.Language.get('anyone')} (${Liferay.Util.sub(Liferay.Language.get('x-role'), Liferay.Language.get('guest'))})`,
+			value: 'Guest',
 		},
 		{
-			label: ROLE_LABELS[defaultGroupRole],
+			label: roles.find(({id}) => id === defaultGroupRole)?.label,
 			value: defaultGroupRole,
 		},
 		{
-			label: ROLE_LABELS[Role.Owner],
-			value: Role.Owner,
+			label: Liferay.Language.get('Owner'),
+			value: 'Owner',
 		},
 	];
 
@@ -206,46 +190,46 @@ function PermissionsTable({
 		onChange(newPermissions);
 	};
 
-	const _handleChangeAction = (index: number, action: ActionId) => {
+	const _handleChangeAction = (actionId: string, index: number) => {
 		_handleChangePermissions(
-			toggleActionIdAtIndex(permissions, action, index)
+			toggleActionIdAtIndex(permissions, actionId, index)
 		);
 	};
 
 	const _handleChangeViewableBy = (event: any) => {
-		setViewableBy(event.target.value as Role);
+		setViewableBy(event.target.value);
 
-		const actionIdsToUpdate = supportedActions.includes(ActionId.Download)
-			? [ActionId.View, ActionId.Download]
-			: [ActionId.View];
+		const actionIdsToEnable = supportedActionIds.includes('DOWNLOAD')
+			? ['VIEW', 'DOWNLOAD']
+			: ['VIEW'];
 
-		const rolesToEnable =
-			event.target.value === Role.Guest
-				? allRoles
-				: event.target.value === Role.Owner
+		const roleNamesToEnable =
+			event.target.value === 'Guest'
+				? supportedRoleNames
+				: event.target.value === 'Owner'
 					? []
 					: [defaultGroupRole];
 
 		_handleChangePermissions(
 			enableActionIdsForRoles(
 				permissions,
-				rolesToEnable,
-				actionIdsToUpdate
+				roleNamesToEnable,
+				actionIdsToEnable
 			)
 		);
 	};
 
-	const _isActionChecked = (action: ActionId, index: number) => {
-		return permissions[index].actionIds.includes(action);
+	const _isActionChecked = (actionId: string, index: number) => {
+		return permissions[index].actionIds.includes(actionId);
 	};
 
-	const _isActionDisabled = (action: ActionId, role: Role) => {
-		if (action === ActionId.View) {
+	const _isActionDisabled = (actionId: string, roleName: string) => {
+		if (actionId === 'VIEW') {
 			return true;
 		}
 
-		if (role === Role.Guest) {
-			return guestUnsupportedActions.includes(action);
+		if (roleName === 'Guest') {
+			return guestUnsupportedActionIds.includes(actionId);
 		}
 
 		return false;
@@ -255,7 +239,7 @@ function PermissionsTable({
 		<>
 			<p>
 				<label htmlFor="viewableBy">
-					{supportedActions.includes(ActionId.Download)
+					{supportedActionIds.includes('DOWNLOAD')
 						? Liferay.Language.get('viewable-and-downloadable-by')
 						: Liferay.Language.get('viewable-by')}
 				</label>
@@ -286,52 +270,46 @@ function PermissionsTable({
 					items={[
 						{
 							id: 'role',
-							name: Liferay.Language.get('role'),
+							label: Liferay.Language.get('role'),
 						},
-						...supportedActions.map((action: ActionId) => ({
-							id: action,
-							name: ACTION_LABELS[action] || action,
-						})),
+						...actions,
 					]}
 				>
 					{(column) => (
 						<Cell key={`action_header_${column.id}`}>
-							{column.name}
+							{column.label}
 						</Cell>
 					)}
 				</Head>
 
 				<Body>
-					{permissions.map((item: PermissionItem, index) => (
-						<Row key={item.roleName}>
+					{roles.map(({id: roleName, label: roleLabel}, index) => (
+						<Row key={roleName}>
 							<Cell>
 								<Text size={3} weight="semi-bold">
-									{item.roleName}
+									{roleLabel}
 								</Text>
 							</Cell>
 
-							{supportedActions.map((action: ActionId) => (
+							{actions.map(({id: actionId}) => (
 								<Cell
-									key={`${item.roleName.replace(' ', '')}-${action}`}
+									key={`${roleName.replace(' ', '')}-${actionId}`}
 								>
 									<ClayCheckbox
 										aria-label={Liferay.Util.sub(
 											'give-x-permission-to-users-with-the-x-role',
-											[
-												ACTION_LABELS[action],
-												item.roleName,
-											]
+											[actionId, roleName]
 										)}
 										checked={_isActionChecked(
-											action,
+											actionId,
 											index
 										)}
 										disabled={_isActionDisabled(
-											action,
-											item.roleName
+											actionId,
+											roleName
 										)}
 										onChange={() =>
-											_handleChangeAction(index, action)
+											_handleChangeAction(actionId, index)
 										}
 									/>
 								</Cell>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
@@ -7,7 +7,17 @@ import {Body, Cell, Head, Row, Table, Text} from '@clayui/core';
 import {ClayCheckbox, ClaySelect} from '@clayui/form';
 import React, {useMemo, useState} from 'react';
 
-interface PermissionItem {
+interface IActionItem {
+	id: string;
+	label: string;
+}
+
+interface IRoleItem {
+	label: string;
+	name: string;
+}
+
+export interface IPermissionItem {
 	actionIds: string[];
 	roleName: string;
 }
@@ -20,13 +30,13 @@ interface PermissionItem {
  * @param permissions
  * @param actionId
  * @param index
- * @returns PermissionItem[]
+ * @returns IPermissionItem[]
  */
 const toggleActionIdAtIndex = (
-	permissions: PermissionItem[],
+	permissions: IPermissionItem[],
 	actionId: string,
 	index: number
-): PermissionItem[] => {
+): IPermissionItem[] => {
 	const newPermissions = permissions.slice();
 
 	newPermissions[index].actionIds = permissions[index].actionIds.includes(
@@ -46,13 +56,13 @@ const toggleActionIdAtIndex = (
  * @param permissions
  * @param roleNames
  * @param actionIdsToEnable
- * @returns PermissionItem[]
+ * @returns IPermissionItem[]
  */
 const enableActionIdsForRoles = (
-	permissions: PermissionItem[],
+	permissions: IPermissionItem[],
 	roleNamesToEnable: string[],
 	actionIdsToEnable: string[]
-): PermissionItem[] => {
+): IPermissionItem[] => {
 	return permissions.map(({actionIds, roleName}) => {
 		const actionIdsNotEnabled = actionIdsToEnable.filter(
 			(id) => !actionIds.includes(id)
@@ -77,9 +87,18 @@ function PermissionsTable({
 			id: 'DELETE',
 			label: Liferay.Language.get('delete'),
 		},
-		{id: 'PERMISSIONS', label: Liferay.Language.get('permissions')},
-		{id: 'UPDATE', label: Liferay.Language.get('update')},
-		{id: 'VIEW', label: Liferay.Language.get('view')},
+		{
+			id: 'PERMISSIONS',
+			label: Liferay.Language.get('permissions'),
+		},
+		{
+			id: 'UPDATE',
+			label: Liferay.Language.get('update'),
+		},
+		{
+			id: 'VIEW',
+			label: Liferay.Language.get('view'),
+		},
 	],
 
 	/*
@@ -96,7 +115,7 @@ function PermissionsTable({
 	defaultGroupRole = 'Site Member',
 
 	/*
-	 * Default state for permissions.
+	 * Default state for permissions. Sets the checkboxes initially selected.
 	 */
 	defaultPermissions = [
 		{
@@ -120,38 +139,45 @@ function PermissionsTable({
 	onChange = () => {},
 
 	/*
-	 * Orientation of the table (default is horizontal).
+	 * Configures whether actions or roles are displayed horizontally in the
+	 * table header.
+	 * `false` = Horizontal display, Actions are listed in the table header.
+	 * `true` = Vertical display: Roles are listed in the table header.
 	 */
 	reverse = false,
 
 	/*
 	 * Roles to be listed as the row/column entries.
+	 * `name` is used to compare with `roleName` for equality.
 	 */
 	roles = [
-		{id: 'Guest', label: Liferay.Language.get('guest')},
 		{
-			id: 'Site Member',
+			label: Liferay.Language.get('guest'),
+			name: 'Guest',
+		},
+		{
 			label: Liferay.Language.get('site-member'),
+			name: 'Site Member',
 		},
 	],
 	...otherProps
 }: {
-	actions: {id: string; label: string}[];
-	className: string;
-	defaultGroupRole: string;
-	defaultPermissions: PermissionItem[];
-	guestUnsupportedActionIds: string[];
-	onChange: Function;
-	reverse: boolean;
-	roles: {id: string; label: string}[];
+	actions?: IActionItem[];
+	className?: string;
+	defaultGroupRole?: string;
+	defaultPermissions?: IPermissionItem[];
+	guestUnsupportedActionIds?: string[];
+	onChange?: Function;
+	reverse?: boolean;
+	roles?: IRoleItem[];
 }) {
 	const initialPermissions = useMemo(
 		() =>
-			roles.map(({id}) => ({
+			roles.map(({name}) => ({
 				actionIds:
-					defaultPermissions.find(({roleName}) => id === roleName)
+					defaultPermissions.find(({roleName}) => name === roleName)
 						?.actionIds || [],
-				roleName: id,
+				roleName: name,
 			})),
 		[roles, defaultPermissions]
 	);
@@ -160,12 +186,12 @@ function PermissionsTable({
 		[actions]
 	);
 	const supportedRoleNames: string[] = useMemo(
-		() => roles.map(({id}) => id),
+		() => roles.map(({name}) => name),
 		[roles]
 	);
 
 	const [permissions, setPermissions] =
-		useState<PermissionItem[]>(initialPermissions);
+		useState<IPermissionItem[]>(initialPermissions);
 	const [viewableBy, setViewableBy] = useState<string>(
 		initialPermissions.every(({actionIds}) => actionIds.includes('VIEW')) // All "view" permissions enabled -> Guest
 			? 'Guest'
@@ -182,7 +208,7 @@ function PermissionsTable({
 			value: 'Guest',
 		},
 		{
-			label: roles.find(({id}) => id === defaultGroupRole)?.label,
+			label: roles.find(({name}) => name === defaultGroupRole)?.label,
 			value: defaultGroupRole,
 		},
 		{
@@ -191,7 +217,7 @@ function PermissionsTable({
 		},
 	];
 
-	const _handleChangePermissions = (newPermissions: PermissionItem[]) => {
+	const _handleChangePermissions = (newPermissions: IPermissionItem[]) => {
 		setPermissions(newPermissions);
 		onChange(newPermissions);
 	};
@@ -272,112 +298,122 @@ function PermissionsTable({
 				striped={false}
 				{...otherProps}
 			>
-				<Head
-					items={
-						reverse
-							? [
-									{
-										id: 'action',
-										label: Liferay.Language.get('action'),
-									},
-									...roles,
-								]
-							: [
-									{
-										id: 'role',
-										label: Liferay.Language.get('role'),
-									},
-									...actions,
-								]
-					}
-				>
-					{(column) => (
-						<Cell key={`action_header_${column.id}`}>
-							{column.label}
-						</Cell>
-					)}
-				</Head>
-
 				{reverse ? (
-					<Body>
-						{actions.map(({id: actionId, label: actionLabel}) => (
-							<Row key={actionId}>
-								<Cell>
-									<Text size={3} weight="semi-bold">
-										{actionLabel}
-									</Text>
-								</Cell>
+					<>
+						<Head
+							items={[
+								{
+									label: Liferay.Language.get('action'),
+									name: 'action',
+								},
+								...roles,
+							]}
+						>
+							{(column) => (
+								<Cell key={column.name}>{column.label}</Cell>
+							)}
+						</Head>
 
-								{roles.map(({id: roleName}, index) => (
-									<Cell
-										key={`${roleName.replace(' ', '')}-${actionId}`}
-									>
-										<ClayCheckbox
-											aria-label={Liferay.Util.sub(
-												'give-x-permission-to-users-with-the-x-role',
-												[actionId, roleName]
-											)}
-											checked={_isActionChecked(
-												actionId,
-												index
-											)}
-											disabled={_isActionDisabled(
-												actionId,
-												roleName
-											)}
-											onChange={() =>
-												_handleChangeAction(
-													actionId,
-													index
-												)
-											}
-										/>
-									</Cell>
-								))}
-							</Row>
-						))}
-					</Body>
+						<Body>
+							{actions.map(
+								({id: actionId, label: actionLabel}) => (
+									<Row key={actionId}>
+										<Cell>
+											<Text size={3} weight="semi-bold">
+												{actionLabel}
+											</Text>
+										</Cell>
+
+										{roles.map(
+											({name: roleName}, index) => (
+												<Cell
+													key={`${roleName.replace(' ', '')}-${actionId}`}
+												>
+													<ClayCheckbox
+														aria-label={Liferay.Util.sub(
+															'give-x-permission-to-users-with-the-x-role',
+															[actionId, roleName]
+														)}
+														checked={_isActionChecked(
+															actionId,
+															index
+														)}
+														disabled={_isActionDisabled(
+															actionId,
+															roleName
+														)}
+														onChange={() =>
+															_handleChangeAction(
+																actionId,
+																index
+															)
+														}
+													/>
+												</Cell>
+											)
+										)}
+									</Row>
+								)
+							)}
+						</Body>
+					</>
 				) : (
-					<Body>
-						{roles.map(
-							({id: roleName, label: roleLabel}, index) => (
-								<Row key={roleName}>
-									<Cell>
-										<Text size={3} weight="semi-bold">
-											{roleLabel}
-										</Text>
-									</Cell>
+					<>
+						<Head
+							items={[
+								{
+									id: 'role',
+									label: Liferay.Language.get('role'),
+								},
+								...actions,
+							]}
+						>
+							{(column) => (
+								<Cell key={column.id}>{column.label}</Cell>
+							)}
+						</Head>
 
-									{actions.map(({id: actionId}) => (
-										<Cell
-											key={`${roleName.replace(' ', '')}-${actionId}`}
-										>
-											<ClayCheckbox
-												aria-label={Liferay.Util.sub(
-													'give-x-permission-to-users-with-the-x-role',
-													[actionId, roleName]
-												)}
-												checked={_isActionChecked(
-													actionId,
-													index
-												)}
-												disabled={_isActionDisabled(
-													actionId,
-													roleName
-												)}
-												onChange={() =>
-													_handleChangeAction(
+						<Body>
+							{roles.map(
+								({label: roleLabel, name: roleName}, index) => (
+									<Row key={roleName}>
+										<Cell>
+											<Text size={3} weight="semi-bold">
+												{roleLabel}
+											</Text>
+										</Cell>
+
+										{actions.map(({id: actionId}) => (
+											<Cell
+												key={`${roleName.replace(' ', '')}-${actionId}`}
+											>
+												<ClayCheckbox
+													aria-label={Liferay.Util.sub(
+														'give-x-permission-to-users-with-the-x-role',
+														[actionId, roleName]
+													)}
+													checked={_isActionChecked(
 														actionId,
 														index
-													)
-												}
-											/>
-										</Cell>
-									))}
-								</Row>
-							)
-						)}
-					</Body>
+													)}
+													disabled={_isActionDisabled(
+														actionId,
+														roleName
+													)}
+													onChange={() =>
+														_handleChangeAction(
+															actionId,
+															index
+														)
+													}
+												/>
+											</Cell>
+										))}
+									</Row>
+								)
+							)}
+						</Body>
+					</>
 				)}
 			</Table>
 		</>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
@@ -26,7 +26,7 @@ const toggleActionIdAtIndex = (
 	permissions: PermissionItem[],
 	actionId: string,
 	index: number
-) => {
+): PermissionItem[] => {
 	const newPermissions = permissions.slice();
 
 	newPermissions[index].actionIds = permissions[index].actionIds.includes(
@@ -52,7 +52,7 @@ const enableActionIdsForRoles = (
 	permissions: PermissionItem[],
 	roleNamesToEnable: string[],
 	actionIdsToEnable: string[]
-) => {
+): PermissionItem[] => {
 	return permissions.map(({actionIds, roleName}) => {
 		const actionIdsNotEnabled = actionIdsToEnable.filter(
 			(id) => !actionIds.includes(id)
@@ -167,13 +167,13 @@ function PermissionsTable({
 	const [permissions, setPermissions] =
 		useState<PermissionItem[]>(initialPermissions);
 	const [viewableBy, setViewableBy] = useState<string>(
-		initialPermissions.every(({actionIds}) => actionIds.includes('VIEW')) // Guest -> all permissions enabled
+		initialPermissions.every(({actionIds}) => actionIds.includes('VIEW')) // All "view" permissions enabled -> Guest
 			? 'Guest'
 			: initialPermissions.every(
 						({actionIds}) => !actionIds.includes('VIEW')
-				  ) // Owner -> no permissions enabled
+				  ) // No "view" permissions enabled -> Owner
 				? 'Owner'
-				: defaultGroupRole // Group -> group permissions enabled
+				: defaultGroupRole // Some "view" permissions enabled -> Default Group Role
 	);
 
 	const viewableByOptions = [

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/forms/PermissionsTable.tsx
@@ -120,6 +120,11 @@ function PermissionsTable({
 	onChange = () => {},
 
 	/*
+	 * Orientation of the table (default is horizontal).
+	 */
+	reverse = false,
+
+	/*
 	 * Roles to be listed as the row/column entries.
 	 */
 	roles = [
@@ -137,6 +142,7 @@ function PermissionsTable({
 	defaultPermissions: PermissionItem[];
 	guestUnsupportedActionIds: string[];
 	onChange: Function;
+	reverse: boolean;
 	roles: {id: string; label: string}[];
 }) {
 	const initialPermissions = useMemo(
@@ -267,13 +273,23 @@ function PermissionsTable({
 				{...otherProps}
 			>
 				<Head
-					items={[
-						{
-							id: 'role',
-							label: Liferay.Language.get('role'),
-						},
-						...actions,
-					]}
+					items={
+						reverse
+							? [
+									{
+										id: 'action',
+										label: Liferay.Language.get('action'),
+									},
+									...roles,
+								]
+							: [
+									{
+										id: 'role',
+										label: Liferay.Language.get('role'),
+									},
+									...actions,
+								]
+					}
 				>
 					{(column) => (
 						<Cell key={`action_header_${column.id}`}>
@@ -282,41 +298,87 @@ function PermissionsTable({
 					)}
 				</Head>
 
-				<Body>
-					{roles.map(({id: roleName, label: roleLabel}, index) => (
-						<Row key={roleName}>
-							<Cell>
-								<Text size={3} weight="semi-bold">
-									{roleLabel}
-								</Text>
-							</Cell>
-
-							{actions.map(({id: actionId}) => (
-								<Cell
-									key={`${roleName.replace(' ', '')}-${actionId}`}
-								>
-									<ClayCheckbox
-										aria-label={Liferay.Util.sub(
-											'give-x-permission-to-users-with-the-x-role',
-											[actionId, roleName]
-										)}
-										checked={_isActionChecked(
-											actionId,
-											index
-										)}
-										disabled={_isActionDisabled(
-											actionId,
-											roleName
-										)}
-										onChange={() =>
-											_handleChangeAction(actionId, index)
-										}
-									/>
+				{reverse ? (
+					<Body>
+						{actions.map(({id: actionId, label: actionLabel}) => (
+							<Row key={actionId}>
+								<Cell>
+									<Text size={3} weight="semi-bold">
+										{actionLabel}
+									</Text>
 								</Cell>
-							))}
-						</Row>
-					))}
-				</Body>
+
+								{roles.map(({id: roleName}, index) => (
+									<Cell
+										key={`${roleName.replace(' ', '')}-${actionId}`}
+									>
+										<ClayCheckbox
+											aria-label={Liferay.Util.sub(
+												'give-x-permission-to-users-with-the-x-role',
+												[actionId, roleName]
+											)}
+											checked={_isActionChecked(
+												actionId,
+												index
+											)}
+											disabled={_isActionDisabled(
+												actionId,
+												roleName
+											)}
+											onChange={() =>
+												_handleChangeAction(
+													actionId,
+													index
+												)
+											}
+										/>
+									</Cell>
+								))}
+							</Row>
+						))}
+					</Body>
+				) : (
+					<Body>
+						{roles.map(
+							({id: roleName, label: roleLabel}, index) => (
+								<Row key={roleName}>
+									<Cell>
+										<Text size={3} weight="semi-bold">
+											{roleLabel}
+										</Text>
+									</Cell>
+
+									{actions.map(({id: actionId}) => (
+										<Cell
+											key={`${roleName.replace(' ', '')}-${actionId}`}
+										>
+											<ClayCheckbox
+												aria-label={Liferay.Util.sub(
+													'give-x-permission-to-users-with-the-x-role',
+													[actionId, roleName]
+												)}
+												checked={_isActionChecked(
+													actionId,
+													index
+												)}
+												disabled={_isActionDisabled(
+													actionId,
+													roleName
+												)}
+												onChange={() =>
+													_handleChangeAction(
+														actionId,
+														index
+													)
+												}
+											/>
+										</Cell>
+									))}
+								</Row>
+							)
+						)}
+					</Body>
+				)}
 			</Table>
 		</>
 	);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-51686 - Permissions Table for Vocabularies on CMS 2.0

- Parent components can keep track of the change of permissions by passing in `onChange` callback
- `defaultPermissions` are formatted with `actionIds` and `roleName` permission objects (see example)
- Properties `actions` and `roles` determine the rows and columns
- Appearance can be altered by adding `className` or including extra props that are meant for table (like `striped`)
- Table can be in the vertical layout when `reverse` is set to true

Example of usage (updated):

```
<PermissionsTable
	actions={[
		{
			id: "DELETE",
			label: Liferay.Language.get("delete"),
		},
		{id: "VIEW", label: Liferay.Language.get("view")},
		{id: "DOWNLOAD", label: Liferay.Language.get("download")},
		{id: "PERMISSIONS", label: Liferay.Language.get("permissions")},
		{id: "UPDATE", label: Liferay.Language.get("update")},
	]}
	defaultGroupRole={"Site Member"}
	defaultPermissions={[
		{
			actionIds: ["VIEW"],
			roleName: "Guest",
		},
		{
			actionIds: ["VIEW", "UPDATE"],
			roleName: "Site Member",
		},
	]}
	onChange={setPermissions}
	guestUnsupportedActionIds={["UPDATE"]}
	striped={true}
	reverse={true}
	roles={[
		{id: "Guest", label: Liferay.Language.get("guest")},
		{
			id: "Site Member",
			label: Liferay.Language.get("site-member"),
		},
		{
			id: "Custom Role",
			label: Liferay.Language.get("custom-role"),
		},
	]}
/>
```
Creates this example:
![Screenshot 2025-04-02 at 2 59 21 PM](https://github.com/user-attachments/assets/db26a977-8003-4921-9603-314f88921cb1)


Default looks like:
<img width="875" alt="Screenshot 2025-04-01 at 1 32 46 PM" src="https://github.com/user-attachments/assets/585d4967-d575-40b3-bbe4-cd3965b23d58" />
