### PR TITLE
LPD-53010 Roles assigned to other sites appear in Site Memberships

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java
@@ -248,7 +248,8 @@ public class UserRolesDisplayContext {
 
 	private List<Role> _getSelectedRoles() throws PortalException {
 		return TransformUtil.transform(
-			UserGroupRoleLocalServiceUtil.getUserGroupRoles(_getUserId()),
+			UserGroupRoleLocalServiceUtil.getUserGroupRoles(
+				_getUserId(), _getGroupId()),
 			userGroupRole -> RoleLocalServiceUtil.fetchRole(
 				userGroupRole.getRoleId()));
 	}

--- a/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
@@ -8,7 +8,8 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
-import {membershipsPagesTest} from '../site-admin-web/fixtures/membershipsPagesTest';
+import getRandomString from '../../utils/getRandomString';
+import {membershipsPagesTest} from './fixtures/membershipsPagesTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -243,5 +244,55 @@ test(
 		await expect(page.getByText(user.name)).not.toBeVisible();
 
 		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
+	}
+);
+
+test(
+	'Filter roles that are assigned to the user based on the current group',
+	{
+		tag: '@LPD-53010',
+	},
+	async ({apiHelpers, membershipsPage, page}) => {
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		const currentSiteId = await page.evaluate(() => {
+			return String(Liferay.ThemeDisplay.getSiteGroupId());
+		});
+
+		const site2 = await apiHelpers.headlessSite.createSite({
+			name: getRandomString(),
+		});
+
+		const siteRole =
+			await apiHelpers.headlessAdminUser.getRoleByName('Site Member');
+
+		await apiHelpers.headlessAdminUser.assignUserToSite(
+			siteRole.id,
+			currentSiteId,
+			user.id
+		);
+
+		await apiHelpers.headlessAdminUser.assignUserToSite(
+			siteRole.id,
+			site2.id,
+			user.id
+		);
+
+		await membershipsPage.goto();
+		await membershipsPage.assignSiteAdministratorRole();
+
+		await page.goto(`/group/${site2.name}/~/control_panel/manage`);
+
+		await membershipsPage.goto();
+		await membershipsPage.openAssignRoles(user.alternateName);
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Assign Roles"]')
+				.getByText('Site Administrator')
+		).toBeVisible();
+
+		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
+		await apiHelpers.headlessSite.deleteSite(site2.id);
 	}
 );

--- a/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
@@ -18,21 +18,7 @@ export class MembershipsPage {
 	}
 
 	async assignAllRolesToUser(userName: String) {
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('menuitem', {
-				exact: true,
-				name: 'Assign Roles',
-			}),
-			timeout: 500,
-			trigger: this.page
-				.locator(
-					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
-						userName +
-						'"]'
-				)
-				.getByLabel('More actions'),
-		});
+		await this.openAssignRoles(userName);
 
 		await this.page.waitForTimeout(500);
 
@@ -92,6 +78,24 @@ export class MembershipsPage {
 	async goto() {
 		await this.productMenuPage.openProductMenuIfClosed();
 		await this.productMenuPage.goToMemberships();
+	}
+
+	async openAssignRoles(userName: String) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Assign Roles',
+			}),
+			timeout: 500,
+			trigger: this.page
+				.locator(
+					'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_users_' +
+						userName +
+						'"]'
+				)
+				.getByLabel('More actions'),
+		});
 	}
 
 	async removeSiteMembershipFromUser(userName: String) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-53010

# How am I fixing it?

This issue is resolved by passing in the current group's ID to filter out the correct roles, rather than all roles the user is assigned across all sites. This matches the logic used in Site Memberships for User Group roles.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-53010'`