### PR TITLE
LPD-52590 Allow parent navItem be selected when child is selected

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/vertical-navigation/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/vertical-navigation/index.html
@@ -53,7 +53,7 @@
 				[#assign navItemCSSClass = "${navItemCSSClass} open" /]
 			[/#if]
 
-			[#if !navItem.isChildSelected() && navItem.isSelected()]
+			[#if navItem.isChildSelected() || navItem.isSelected()]
 				[#assign
 					activeKey = navItem.getLayoutId()
 					navLinkCSSClass = "${navLinkCSSClass} active"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52590

My fix contradicts the previous logic so I'm not sure if this will break anything the original developer had in mind.
I did test the other sections in CMS and I didn't see anything getting selected that shouldn't.

Should we have someone from the Content Management team to double check this change?