### PR TITLE
LPD-53428 Add timeout to fix flaky test in memberships.spec.ts

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/memberships.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {membershipsPagesTest} from './fixtures/membershipsPagesTest';
 
 export const test = mergeTests(
@@ -90,7 +91,15 @@ test(
 
 		await page.getByRole('link', {name: 'User Groups'}).click();
 
+		await expect(
+			page.getByText(
+				' No user group was found that is a member of this site.'
+			)
+		).toBeVisible();
+
 		await page.getByRole('button', {name: 'Add'}).click();
+
+		await page.waitForTimeout(500);
 
 		await page
 			.frameLocator('iframe[title="Assign User Groups to This Site"]')
@@ -99,7 +108,7 @@ test(
 
 		await page.getByRole('button', {name: 'Done'}).click();
 
-		await page.waitForTimeout(500);
+		await waitForAlert(page);
 
 		await membershipsPage.assignSiteAdministratorRole();
 		await membershipsPage.filterBySiteAdministratorRole();

--- a/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/pages/MembershipsPage.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page} from '@playwright/test';
+import {Page, expect} from '@playwright/test';
 
 import {ProductMenuPage} from '../../../pages/product-navigation-control-menu-web/ProductMenuPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class MembershipsPage {
 	readonly page: Page;
@@ -28,6 +29,8 @@ export class MembershipsPage {
 			.check();
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
+
+		await waitForAlert(this.page);
 	}
 
 	async assignAllUsersSiteMembership() {
@@ -41,6 +44,8 @@ export class MembershipsPage {
 			.check();
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
+
+		await waitForAlert(this.page);
 	}
 
 	async assignSiteAdministratorRole() {
@@ -59,6 +64,8 @@ export class MembershipsPage {
 			.click();
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
+
+		await waitForAlert(this.page);
 	}
 
 	async filterBySiteAdministratorRole() {
@@ -73,6 +80,10 @@ export class MembershipsPage {
 			.frameLocator('iframe[title="Select Role"]')
 			.getByText('Site Administrator')
 			.click();
+
+		await expect(
+			this.page.getByRole('heading', {name: 'Search Results'})
+		).toBeVisible();
 	}
 
 	async goto() {
@@ -114,6 +125,8 @@ export class MembershipsPage {
 				)
 				.getByLabel('More actions'),
 		});
+
+		await waitForAlert(this.page);
 	}
 
 	async removeSiteAdministratorRole() {
@@ -129,6 +142,8 @@ export class MembershipsPage {
 			timeout: 500,
 			trigger: this.page.getByLabel('Select All Items on the Page'),
 		});
+
+		await waitForAlert(this.page);
 	}
 
 	async unassignAllRolesFromUser(userName: String) {
@@ -156,5 +171,7 @@ export class MembershipsPage {
 			.check();
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
+
+		await waitForAlert(this.page);
 	}
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-53428

# How am I fixing it?

This test has been consistently flaky. Adding a timeout to hopefully alleviate these issues moving forward.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'Bulk removal of roles from user groups'`