### PR TITLE
LPD-52989 Test failures in Site Management module due to LPD-51577 pagination update

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -53,7 +53,7 @@ test(
 	async ({apiHelpers, page, selectSiteInitializerPage, sitesPage}) => {
 		const layoutSetPrototypes = [];
 
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 21; i++) {
 			const layoutSetPrototype: LayoutSetPrototype =
 				await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
 					{
@@ -68,12 +68,8 @@ test(
 
 		await sitesPage.customSiteTemplatesItem.click();
 
-		await page.getByLabel('Items per Page').click();
-
-		await page.getByRole('option', {name: '4  Entries per Page'}).click();
-
 		await expect(
-			page.getByText('Showing 1 to 4 of 5 entries.')
+			page.getByText('Showing 1 to 20 of 21 entries.')
 		).toBeVisible();
 
 		await expect(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SiteMemberships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SiteMemberships.testcase
@@ -726,6 +726,8 @@ definition {
 	@description = "View pagination in site memberships admin."
 	@priority = 3
 	test SiteMembershipsPagination {
+		property custom.properties = "search.container.page.delta.values=4,20,40,60";
+
 		task ("Add 10 users") {
 			for (var screenName : list "userfn1,userfn2,userfn3,userfn4,userfn5,userfn6,userfn7,userfn8,userfn9,userfn10") {
 				JSONUser.addUser(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/mysites/MySites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/mysites/MySites.testcase
@@ -54,9 +54,9 @@ definition {
 
 			Pagination.viewResults(results = "Showing 1 to 20 of 25 entries.");
 
-			Pagination.changePagination(itemsPerPage = 4);
+			Pagination.changePagination(itemsPerPage = 40);
 
-			Pagination.viewResults(results = "Showing 1 to 4 of 25 entries.");
+			Pagination.viewResults(results = "Showing 1 to 25 of 25 entries.");
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52989

# How am I fixing it?

The default pagination options have changed requiring an update in some of our tests.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-39408'`
In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=SiteMemberships#SiteMembershipsPagination`
In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=MySites#DisplayMySitesPagination`