### PR TITLE
LPD-53785 Fix failing test NavigationMenuWidget#ViewCustomFieldOfNavigationMenu

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/navigationmenu/NavigationMenuWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/navigationmenu/NavigationMenuWidget.testcase
@@ -942,7 +942,7 @@ definition {
 <#if entries?has_content>
 	<#list entries as navItem>
 		<#assign customFields = navItem.getExpandoAttributes()/>
-		${customFields["subtitle"]}
+		${customFields["Subtitle"]}
 			''';
 
 			WidgetTemplates.openWidgetTemplatesAdmin(siteURLKey = "test-site-name");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-53785

# How am I fixing it?

The keys for custom fields have become case sensitive it seems, so the test is updated to accommodate this.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=NavigationMenuWidget#ViewCustomFieldOfNavigationMenu`