### PR TITLE
LPD-53456 Technical Task | Filter associated navigation menus exports based on creation/modification date range

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 52.0.1
+Bundle-Version: 53.0.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
@@ -74,7 +74,10 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public Page<NavigationMenu> getSiteNavigationMenusPage(
-			Long siteId, Pagination pagination)
+			Long siteId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
 	public NavigationMenu postSiteNavigationMenu(
@@ -86,8 +89,10 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public Response postSiteNavigationMenusPageExportBatch(
-			Long siteId, String callbackURL, String contentType,
-			String fieldNames)
+			Long siteId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
 		throws Exception;
 
 	public NavigationMenu putNavigationMenu(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 20.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
@@ -94,11 +94,13 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public Page<NavigationMenu> getSiteNavigationMenusPage(
-			Long siteId, Pagination pagination)
+			Long siteId, String search, String filterString,
+			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSiteNavigationMenusPageHttpResponse(
-			Long siteId, Pagination pagination)
+			Long siteId, String search, String filterString,
+			Pagination pagination, String sortString)
 		throws Exception;
 
 	public NavigationMenu postSiteNavigationMenu(
@@ -118,13 +120,14 @@ public interface NavigationMenuResource {
 		throws Exception;
 
 	public void postSiteNavigationMenusPageExportBatch(
-			Long siteId, String callbackURL, String contentType,
-			String fieldNames)
+			Long siteId, String search, String filterString, String sortString,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postSiteNavigationMenusPageExportBatchHttpResponse(
-				Long siteId, String callbackURL, String contentType,
+				Long siteId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 		throws Exception;
 
@@ -1033,11 +1036,13 @@ public interface NavigationMenuResource {
 		}
 
 		public Page<NavigationMenu> getSiteNavigationMenusPage(
-				Long siteId, Pagination pagination)
+				Long siteId, String search, String filterString,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSiteNavigationMenusPageHttpResponse(siteId, pagination);
+				getSiteNavigationMenusPageHttpResponse(
+					siteId, search, filterString, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -1099,7 +1104,8 @@ public interface NavigationMenuResource {
 		}
 
 		public HttpInvoker.HttpResponse getSiteNavigationMenusPageHttpResponse(
-				Long siteId, Pagination pagination)
+				Long siteId, String search, String filterString,
+				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1123,11 +1129,23 @@ public interface NavigationMenuResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
 			if (pagination != null) {
 				httpInvoker.parameter(
 					"page", String.valueOf(pagination.getPage()));
 				httpInvoker.parameter(
 					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
 			}
 
 			httpInvoker.path(
@@ -1357,13 +1375,15 @@ public interface NavigationMenuResource {
 		}
 
 		public void postSiteNavigationMenusPageExportBatch(
-				Long siteId, String callbackURL, String contentType,
+				Long siteId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
 				String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSiteNavigationMenusPageExportBatchHttpResponse(
-					siteId, callbackURL, contentType, fieldNames);
+					siteId, search, filterString, sortString, callbackURL,
+					contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -1415,7 +1435,8 @@ public interface NavigationMenuResource {
 
 		public HttpInvoker.HttpResponse
 				postSiteNavigationMenusPageExportBatchHttpResponse(
-					Long siteId, String callbackURL, String contentType,
+					Long siteId, String search, String filterString,
+					String sortString, String callbackURL, String contentType,
 					String fieldNames)
 			throws Exception {
 
@@ -1441,6 +1462,18 @@ public interface NavigationMenuResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
 
 			if (callbackURL != null) {
 				httpInvoker.parameter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -15619,6 +15619,10 @@ paths:
                     schema:
                         type: string
                 -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
                     name: nestedFields
                     schema:
                         type: integer
@@ -15632,6 +15636,14 @@ paths:
                         type: integer
                 -   in: query
                     name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
                     schema:
                         type: string
             responses:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -4658,6 +4658,9 @@ public class Mutation {
 	@GraphQLField
 	public Response createSiteNavigationMenusPageExportBatch(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("sort") String sortsString,
 			@GraphQLName("callbackURL") String callbackURL,
 			@GraphQLName("contentType") String contentType,
 			@GraphQLName("fieldNames") String fieldNames)
@@ -4668,8 +4671,11 @@ public class Mutation {
 			this::_populateResourceContext,
 			navigationMenuResource ->
 				navigationMenuResource.postSiteNavigationMenusPageExportBatch(
-					Long.valueOf(siteKey), callbackURL, contentType,
-					fieldNames));
+					Long.valueOf(siteKey), search,
+					_filterBiFunction.apply(
+						navigationMenuResource, filterString),
+					_sortsBiFunction.apply(navigationMenuResource, sortsString),
+					callbackURL, contentType, fieldNames));
 	}
 
 	@GraphQLField(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -3225,13 +3225,16 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {navigationMenus(page: ___, pageSize: ___, siteKey: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {navigationMenus(filter: ___, page: ___, pageSize: ___, search: ___, siteKey: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public NavigationMenuPage navigationMenus(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -3239,7 +3242,12 @@ public class Query {
 			this::_populateResourceContext,
 			navigationMenuResource -> new NavigationMenuPage(
 				navigationMenuResource.getSiteNavigationMenusPage(
-					Long.valueOf(siteKey), Pagination.of(page, pageSize))));
+					Long.valueOf(siteKey), search,
+					_filterBiFunction.apply(
+						navigationMenuResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(
+						navigationMenuResource, sortsString))));
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/NavigationMenuEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/NavigationMenuEntityModel.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.odata.entity.v1_0;
+
+import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+
+import java.util.Map;
+
+/**
+ * @author Joao Victor Alves
+ */
+public class NavigationMenuEntityModel implements EntityModel {
+
+	public NavigationMenuEntityModel() {
+		_entityFieldsMap = EntityFieldsMapFactory.create(
+			new DateTimeEntityField(
+				"dateCreated",
+				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
+				locale -> Field.CREATE_DATE),
+			new DateTimeEntityField(
+				"dateModified",
+				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
+				locale -> Field.MODIFIED_DATE));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -464,6 +464,10 @@ public abstract class BaseNavigationMenuResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "nestedFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -477,6 +481,14 @@ public abstract class BaseNavigationMenuResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
 			)
 		}
 	)
@@ -494,7 +506,14 @@ public abstract class BaseNavigationMenuResourceImpl
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("siteId")
 			Long siteId,
-			@javax.ws.rs.core.Context Pagination pagination)
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("search")
+			String search,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@javax.ws.rs.core.Context Pagination pagination,
+			@javax.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -604,6 +623,18 @@ public abstract class BaseNavigationMenuResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "callbackURL"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -631,6 +662,13 @@ public abstract class BaseNavigationMenuResourceImpl
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("siteId")
 			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("search")
+			String search,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@javax.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("callbackURL")
 			String callbackURL,
@@ -1101,7 +1139,8 @@ public abstract class BaseNavigationMenuResourceImpl
 
 		if (parameters.containsKey("siteId")) {
 			return getSiteNavigationMenusPage(
-				(Long)parameters.get("siteId"), pagination);
+				(Long)parameters.get("siteId"), search, filter, pagination,
+				sorts);
 		}
 		else {
 			throw new NotSupportedException(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.delivery.dto.v1_0.NavigationMenu;
 import com.liferay.headless.delivery.dto.v1_0.NavigationMenuItem;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
+import com.liferay.headless.delivery.internal.odata.entity.v1_0.NavigationMenuEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.NavigationMenuResource;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -17,6 +18,9 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -33,6 +37,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.custom.field.CustomFieldsUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -45,6 +50,7 @@ import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.JaxRsLinkUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.site.navigation.constants.SiteNavigationActionKeys;
 import com.liferay.site.navigation.constants.SiteNavigationConstants;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
@@ -63,6 +69,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import javax.ws.rs.core.MultivaluedMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -92,6 +100,11 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 	}
 
 	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
 	public NavigationMenu getNavigationMenu(Long navigationMenuId)
 		throws Exception {
 
@@ -113,9 +126,11 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 
 	@Override
 	public Page<NavigationMenu> getSiteNavigationMenusPage(
-		Long siteId, Pagination pagination) {
+			Long siteId, String search, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
 
-		return Page.of(
+		return SearchUtil.search(
 			HashMapBuilder.put(
 				"create",
 				addAction(
@@ -139,13 +154,19 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 					ActionKeys.UPDATE, "putNavigationMenuBatch",
 					SiteNavigationConstants.RESOURCE_NAME, null)
 			).build(),
-			transform(
-				_siteNavigationMenuService.getSiteNavigationMenus(
-					siteId, pagination.getStartPosition(),
-					pagination.getEndPosition(), null),
-				this::_toNavigationMenu),
-			pagination,
-			_siteNavigationMenuService.getSiteNavigationMenusCount(siteId));
+			booleanQuery -> {
+			},
+			filter, SiteNavigationMenu.class.getName(), search, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+				searchContext.setGroupIds(new long[] {siteId});
+			},
+			sorts,
+			document -> _toNavigationMenu(
+				_siteNavigationMenuService.fetchSiteNavigationMenu(
+					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
 	}
 
 	@Override
@@ -896,6 +917,9 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 				siteNavigationMenuItem.getSiteNavigationMenuItemId(), true);
 		}
 	}
+
+	private static final EntityModel _entityModel =
+		new NavigationMenuEntityModel();
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -24,6 +24,7 @@ import com.liferay.headless.delivery.client.permission.Permission;
 import com.liferay.headless.delivery.client.resource.v1_0.NavigationMenuResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.NavigationMenuSerDes;
 import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -53,6 +54,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.rule.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -951,7 +953,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 		Page<NavigationMenu> page =
 			navigationMenuResource.getSiteNavigationMenusPage(
-				siteId, Pagination.of(1, 10));
+				siteId, null, null, Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
@@ -961,7 +963,8 @@ public abstract class BaseNavigationMenuResourceTestCase {
 					irrelevantSiteId, randomIrrelevantNavigationMenu());
 
 			page = navigationMenuResource.getSiteNavigationMenusPage(
-				irrelevantSiteId, Pagination.of(1, (int)totalCount + 1));
+				irrelevantSiteId, null, null,
+				Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -983,7 +986,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				siteId, randomNavigationMenu());
 
 		page = navigationMenuResource.getSiteNavigationMenusPage(
-			siteId, Pagination.of(1, 10));
+			siteId, null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -1016,13 +1019,109 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteNavigationMenusPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
+
+		NavigationMenu navigationMenu1 = randomNavigationMenu();
+
+		navigationMenu1 = testGetSiteNavigationMenusPage_addNavigationMenu(
+			siteId, navigationMenu1);
+
+		for (EntityField entityField : entityFields) {
+			Page<NavigationMenu> page =
+				navigationMenuResource.getSiteNavigationMenusPage(
+					siteId, null,
+					getFilterString(entityField, "between", navigationMenu1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(navigationMenu1),
+				(List<NavigationMenu>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithFilter("eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithFilterStringContains()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithFilter("eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetSiteNavigationMenusPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
+
+		NavigationMenu navigationMenu1 =
+			testGetSiteNavigationMenusPage_addNavigationMenu(
+				siteId, randomNavigationMenu());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		NavigationMenu navigationMenu2 =
+			testGetSiteNavigationMenusPage_addNavigationMenu(
+				siteId, randomNavigationMenu());
+
+		for (EntityField entityField : entityFields) {
+			Page<NavigationMenu> page =
+				navigationMenuResource.getSiteNavigationMenusPage(
+					siteId, null,
+					getFilterString(entityField, operator, navigationMenu1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(navigationMenu1),
+				(List<NavigationMenu>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteNavigationMenusPageWithPagination()
 		throws Exception {
 
 		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
 
 		Page<NavigationMenu> navigationMenusPage =
-			navigationMenuResource.getSiteNavigationMenusPage(siteId, null);
+			navigationMenuResource.getSiteNavigationMenusPage(
+				siteId, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			navigationMenusPage.getTotalCount());
@@ -1046,10 +1145,11 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<NavigationMenu> page1 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId,
+					siteId, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
-						pageSizeLimit));
+						pageSizeLimit),
+					null);
 
 			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
 
@@ -1058,20 +1158,22 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 			Page<NavigationMenu> page2 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId,
+					siteId, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
-						pageSizeLimit));
+						pageSizeLimit),
+					null);
 
 			assertContains(
 				navigationMenu2, (List<NavigationMenu>)page2.getItems());
 
 			Page<NavigationMenu> page3 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId,
+					siteId, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
-						pageSizeLimit));
+						pageSizeLimit),
+					null);
 
 			assertContains(
 				navigationMenu3, (List<NavigationMenu>)page3.getItems());
@@ -1079,7 +1181,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		else {
 			Page<NavigationMenu> page1 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId, Pagination.of(1, totalCount + 2));
+					siteId, null, null, Pagination.of(1, totalCount + 2), null);
 
 			List<NavigationMenu> navigationMenus1 =
 				(List<NavigationMenu>)page1.getItems();
@@ -1090,7 +1192,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 			Page<NavigationMenu> page2 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId, Pagination.of(2, totalCount + 2));
+					siteId, null, null, Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -1102,7 +1204,8 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 			Page<NavigationMenu> page3 =
 				navigationMenuResource.getSiteNavigationMenusPage(
-					siteId, Pagination.of(1, (int)totalCount + 3));
+					siteId, null, null, Pagination.of(1, (int)totalCount + 3),
+					null);
 
 			assertContains(
 				navigationMenu1, (List<NavigationMenu>)page3.getItems());
@@ -1110,6 +1213,158 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				navigationMenu2, (List<NavigationMenu>)page3.getItems());
 			assertContains(
 				navigationMenu3, (List<NavigationMenu>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithSortDateTime()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, navigationMenu1, navigationMenu2) -> {
+				BeanTestUtil.setProperty(
+					navigationMenu1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, navigationMenu1, navigationMenu2) -> {
+				BeanTestUtil.setProperty(
+					navigationMenu1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					navigationMenu2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithSortInteger()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, navigationMenu1, navigationMenu2) -> {
+				BeanTestUtil.setProperty(
+					navigationMenu1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					navigationMenu2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetSiteNavigationMenusPageWithSortString()
+		throws Exception {
+
+		testGetSiteNavigationMenusPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, navigationMenu1, navigationMenu2) -> {
+				Class<?> clazz = navigationMenu1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						navigationMenu1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						navigationMenu2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						navigationMenu1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						navigationMenu2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						navigationMenu1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						navigationMenu2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetSiteNavigationMenusPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, NavigationMenu, NavigationMenu, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
+
+		NavigationMenu navigationMenu1 = randomNavigationMenu();
+		NavigationMenu navigationMenu2 = randomNavigationMenu();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, navigationMenu1, navigationMenu2);
+		}
+
+		navigationMenu1 = testGetSiteNavigationMenusPage_addNavigationMenu(
+			siteId, navigationMenu1);
+
+		navigationMenu2 = testGetSiteNavigationMenusPage_addNavigationMenu(
+			siteId, navigationMenu2);
+
+		Page<NavigationMenu> page =
+			navigationMenuResource.getSiteNavigationMenusPage(
+				siteId, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<NavigationMenu> ascPage =
+				navigationMenuResource.getSiteNavigationMenusPage(
+					siteId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				navigationMenu1, (List<NavigationMenu>)ascPage.getItems());
+			assertContains(
+				navigationMenu2, (List<NavigationMenu>)ascPage.getItems());
+
+			Page<NavigationMenu> descPage =
+				navigationMenuResource.getSiteNavigationMenusPage(
+					siteId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				navigationMenu2, (List<NavigationMenu>)descPage.getItems());
+			assertContains(
+				navigationMenu1, (List<NavigationMenu>)descPage.getItems());
 		}
 	}
 
@@ -1433,6 +1688,9 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		return navigationMenuResource.postSiteNavigationMenu(
 			testGroup.getGroupId(), randomNavigationMenu());
 	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	protected void appendGraphQLFieldValue(StringBuilder sb, Object value)
 		throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -988,7 +988,7 @@ public class NavigationMenuResourceTest
 
 		Page<NavigationMenu> page =
 			navigationMenuResource.getSiteNavigationMenusPage(
-				testGroup.getGroupId(), Pagination.of(1, 10));
+				testGroup.getGroupId(), null, null, Pagination.of(1, 10), null);
 
 		Assert.assertEquals(1, page.getTotalCount());
 		assertValid(page);

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 104.0.1
+Bundle-Version: 104.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -380,6 +380,10 @@ public interface ObjectRelationshipLocalService
 	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
 		long objectDefinitionId2);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
+		long objectDefinitionId2, String type);
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -498,6 +498,14 @@ public class ObjectRelationshipLocalServiceUtil {
 			objectDefinitionId2);
 	}
 
+	public static List<ObjectRelationship>
+		getObjectRelationshipsByObjectDefinitionId2(
+			long objectDefinitionId2, String type) {
+
+		return getService().getObjectRelationshipsByObjectDefinitionId2(
+			objectDefinitionId2, type);
+	}
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -579,6 +579,16 @@ public class ObjectRelationshipLocalServiceWrapper
 			getObjectRelationshipsByObjectDefinitionId2(objectDefinitionId2);
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectRelationship>
+		getObjectRelationshipsByObjectDefinitionId2(
+			long objectDefinitionId2, String type) {
+
+		return _objectRelationshipLocalService.
+			getObjectRelationshipsByObjectDefinitionId2(
+				objectDefinitionId2, type);
+	}
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 71.0.0
+version 71.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3717,8 +3717,9 @@ public class ObjectEntryLocalServiceImpl
 		Map<String, Object> queryExpressions = new HashMap<>();
 
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipPersistence.findByObjectDefinitionId2(
-					objectDefinition2.getObjectDefinitionId())) {
+				_objectRelationshipPersistence.findByODI2_R_T(
+					objectDefinition2.getObjectDefinitionId(), false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectField relationshipObjectField =
 				_objectFieldLocalService.fetchObjectField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -829,6 +829,14 @@ public class ObjectRelationshipLocalServiceImpl
 	}
 
 	@Override
+	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
+		long objectDefinitionId2, String type) {
+
+		return objectRelationshipPersistence.findByODI2_R_T(
+			objectDefinitionId2, false, type);
+	}
+
+	@Override
 	public Map<Long, List<ObjectRelationship>> getObjectRelationshipsMap(
 		long companyId) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -43,11 +43,11 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectFolderItemLocalService;
+import com.liferay.object.service.ObjectLayoutTabLocalService;
 import com.liferay.object.service.base.ObjectRelationshipLocalServiceBaseImpl;
 import com.liferay.object.service.persistence.ObjectActionPersistence;
 import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.object.service.persistence.ObjectFieldPersistence;
-import com.liferay.object.service.persistence.ObjectLayoutTabPersistence;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
@@ -399,7 +399,7 @@ public class ObjectRelationshipLocalServiceImpl
 			objectRelationship.getObjectDefinitionId1(),
 			objectDefinition2.getObjectFolderId());
 
-		_objectLayoutTabPersistence.removeByObjectRelationshipId(
+		_objectLayoutTabLocalService.deleteObjectRelationshipObjectLayoutTabs(
 			objectRelationship.getObjectRelationshipId());
 
 		if (Objects.equals(
@@ -431,8 +431,9 @@ public class ObjectRelationshipLocalServiceImpl
 			ObjectRelationship reverseObjectRelationship =
 				fetchReverseObjectRelationship(objectRelationship, true);
 
-			_objectLayoutTabPersistence.removeByObjectRelationshipId(
-				reverseObjectRelationship.getObjectRelationshipId());
+			_objectLayoutTabLocalService.
+				deleteObjectRelationshipObjectLayoutTabs(
+					reverseObjectRelationship.getObjectRelationshipId());
 
 			objectRelationshipPersistence.remove(
 				reverseObjectRelationship.getObjectRelationshipId());
@@ -2400,7 +2401,7 @@ public class ObjectRelationshipLocalServiceImpl
 	private ObjectFolderItemLocalService _objectFolderItemLocalService;
 
 	@Reference
-	private ObjectLayoutTabPersistence _objectLayoutTabPersistence;
+	private ObjectLayoutTabLocalService _objectLayoutTabLocalService;
 
 	@Reference
 	private RelatedInfoCollectionProviderFactory

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -509,8 +509,11 @@ public class ObjectValidationRuleLocalServiceImpl
 			Map<String, Object> variables)
 		throws PortalException {
 
+		ObjectRelationshipLocalService objectRelationshipLocalService =
+			_objectRelationshipLocalServiceSnapshot.get();
+
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipLocalService.
+				objectRelationshipLocalService.
 					getObjectRelationshipsByObjectDefinitionId2(
 						objectDefinitionId,
 						ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
@@ -1033,6 +1036,10 @@ public class ObjectValidationRuleLocalServiceImpl
 		_objectFieldLocalServiceSnapshot = new Snapshot<>(
 			ObjectValidationRuleSettingLocalServiceImpl.class,
 			ObjectFieldLocalService.class, null, true);
+	private static final Snapshot<ObjectRelationshipLocalService>
+		_objectRelationshipLocalServiceSnapshot = new Snapshot<>(
+			ObjectRelationshipLocalServiceImpl.class,
+			ObjectRelationshipLocalService.class, null, true);
 
 	@Reference
 	private DDMExpressionFactory _ddmExpressionFactory;
@@ -1051,9 +1058,6 @@ public class ObjectValidationRuleLocalServiceImpl
 
 	@Reference
 	private ObjectFieldPersistence _objectFieldPersistence;
-
-	@Reference
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Reference
 	private ObjectScriptingValidator _objectScriptingValidator;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -36,11 +36,11 @@ import com.liferay.object.scripting.exception.ObjectScriptingException;
 import com.liferay.object.scripting.validator.ObjectScriptingValidator;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectValidationRuleSettingLocalService;
 import com.liferay.object.service.base.ObjectValidationRuleLocalServiceBaseImpl;
 import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.object.service.persistence.ObjectFieldPersistence;
-import com.liferay.object.service.persistence.ObjectRelationshipPersistence;
 import com.liferay.object.service.persistence.ObjectValidationRuleSettingPersistence;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.object.validation.rule.ObjectValidationRuleEngine;
@@ -510,9 +510,10 @@ public class ObjectValidationRuleLocalServiceImpl
 		throws PortalException {
 
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipPersistence.findByODI2_R_T(
-					objectDefinitionId, false,
-					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+				_objectRelationshipLocalService.
+					getObjectRelationshipsByObjectDefinitionId2(
+						objectDefinitionId,
+						ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectField relationshipObjectField =
 				_objectFieldPersistence.findByPrimaryKey(
@@ -1052,7 +1053,7 @@ public class ObjectValidationRuleLocalServiceImpl
 	private ObjectFieldPersistence _objectFieldPersistence;
 
 	@Reference
-	private ObjectRelationshipPersistence _objectRelationshipPersistence;
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Reference
 	private ObjectScriptingValidator _objectScriptingValidator;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.object.service.impl;
 import com.liferay.dynamic.data.mapping.expression.CreateExpressionRequest;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleConstants;
 import com.liferay.object.constants.ObjectValidationRuleSettingConstants;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
@@ -509,8 +510,9 @@ public class ObjectValidationRuleLocalServiceImpl
 		throws PortalException {
 
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipPersistence.findByObjectDefinitionId2(
-					objectDefinitionId)) {
+				_objectRelationshipPersistence.findByODI2_R_T(
+					objectDefinitionId, false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectField relationshipObjectField =
 				_objectFieldPersistence.findByPrimaryKey(

--- a/modules/apps/object/object-test-util/bnd.bnd
+++ b/modules/apps/object/object-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object Test Utilities
 Bundle-SymbolicName: com.liferay.object.test.util
-Bundle-Version: 5.1.5
+Bundle-Version: 5.2.0
 Export-Package: com.liferay.object.test.util

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectRelationshipTestUtil.java
@@ -64,12 +64,25 @@ public class ObjectRelationshipTestUtil {
 			String name)
 		throws PortalException {
 
+		return addObjectRelationship(
+			objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2, deletionType, name,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
+	public static ObjectRelationship addObjectRelationship(
+			ObjectRelationshipLocalService objectRelationshipLocalService,
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, String deletionType,
+			String name, String type)
+		throws PortalException {
+
 		return objectRelationshipLocalService.addObjectRelationship(
 			null, TestPropsValues.getUserId(),
 			objectDefinition1.getObjectDefinitionId(),
 			objectDefinition2.getObjectDefinitionId(), 0, deletionType, false,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			name, false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+			name, false, type, null);
 	}
 
 }

--- a/modules/apps/object/object-test-util/src/main/resources/com/liferay/object/test/util/packageinfo
+++ b/modules/apps/object/object-test-util/src/main/resources/com/liferay/object/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -512,6 +512,13 @@ public class ObjectEntryLocalServiceTest {
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.publishObjectDefinition();
 
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
 		ObjectRelationship objectRelationship1 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectRelationshipLocalService, objectDefinition1,
@@ -1690,7 +1697,13 @@ public class ObjectEntryLocalServiceTest {
 			_objectRelationshipLocalService, objectDefinition1,
 			objectDefinition2,
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			"objectRelationship");
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship", ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectField objectField1 = ObjectFieldUtil.addCustomObjectField(
 			new IntegerObjectFieldBuilder(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -16,6 +16,7 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectLayoutBoxConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.DuplicateObjectRelationshipException;
 import com.liferay.object.exception.ObjectDefinitionScopeException;
@@ -34,6 +35,11 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.model.ObjectLayout;
+import com.liferay.object.model.ObjectLayoutBox;
+import com.liferay.object.model.ObjectLayoutColumn;
+import com.liferay.object.model.ObjectLayoutRow;
+import com.liferay.object.model.ObjectLayoutTab;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
@@ -42,7 +48,12 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
+import com.liferay.object.service.ObjectLayoutLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.persistence.ObjectLayoutBoxPersistence;
+import com.liferay.object.service.persistence.ObjectLayoutColumnPersistence;
+import com.liferay.object.service.persistence.ObjectLayoutRowPersistence;
+import com.liferay.object.service.persistence.ObjectLayoutTabPersistence;
 import com.liferay.object.service.test.system.TestSystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
@@ -96,6 +107,7 @@ import java.io.Serializable;
 
 import java.sql.Connection;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -115,6 +127,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 /**
  * @author Brian Wing Shun Chan
@@ -1441,6 +1454,36 @@ public class ObjectRelationshipLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteObjectRelationshipWithObjectLayout()
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectLayout objectLayout = _objectLayoutLocalService.addObjectLayout(
+			TestPropsValues.getUserId(),
+			_objectDefinition1.getObjectDefinitionId(), true,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			Arrays.asList(
+				_addObjectLayoutTab(0),
+				_addObjectLayoutTab(
+					objectRelationship.getObjectRelationshipId())));
+
+		List<ObjectLayoutTab> objectLayoutTabs =
+			objectLayout.getObjectLayoutTabs();
+
+		_assertObjectLayoutTab(1, objectLayoutTabs.get(1));
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+
+		_assertObjectLayoutTab(0, objectLayoutTabs.get(1));
+	}
+
+	@Test
 	public void testRegisterObjectRelationshipsRelatedInfoItemCollectionProviders()
 		throws Exception {
 
@@ -2167,6 +2210,72 @@ public class ObjectRelationshipLocalServiceTest {
 			null, values, ServiceContextTestUtil.getServiceContext());
 	}
 
+	private ObjectLayoutBox _addObjectLayoutBox() throws Exception {
+		ObjectLayoutBox objectLayoutBox = _objectLayoutBoxPersistence.create(0);
+
+		objectLayoutBox.setCollapsable(false);
+		objectLayoutBox.setNameMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()));
+		objectLayoutBox.setPriority(0);
+		objectLayoutBox.setType(ObjectLayoutBoxConstants.TYPE_REGULAR);
+		objectLayoutBox.setObjectLayoutRows(
+			Arrays.asList(
+				_addObjectLayoutRow(), _addObjectLayoutRow(),
+				_addObjectLayoutRow()));
+
+		return objectLayoutBox;
+	}
+
+	private ObjectLayoutColumn _addObjectLayoutColumn() throws Exception {
+		ObjectLayoutColumn objectLayoutColumn =
+			_objectLayoutColumnPersistence.create(0);
+
+		ObjectField objectField = ObjectFieldUtil.addCustomObjectField(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"x" + RandomTestUtil.randomString()
+			).objectDefinitionId(
+				_objectDefinition1.getObjectDefinitionId()
+			).required(
+				true
+			).userId(
+				TestPropsValues.getUserId()
+			).build());
+
+		objectLayoutColumn.setObjectFieldId(objectField.getObjectFieldId());
+
+		return objectLayoutColumn;
+	}
+
+	private ObjectLayoutRow _addObjectLayoutRow() throws Exception {
+		ObjectLayoutRow objectLayoutRow = _objectLayoutRowPersistence.create(0);
+
+		objectLayoutRow.setPriority(0);
+		objectLayoutRow.setObjectLayoutColumns(
+			Collections.singletonList(_addObjectLayoutColumn()));
+
+		return objectLayoutRow;
+	}
+
+	private ObjectLayoutTab _addObjectLayoutTab(long objectRelationshipId)
+		throws Exception {
+
+		ObjectLayoutTab objectLayoutTab = _objectLayoutTabPersistence.create(0);
+
+		objectLayoutTab.setObjectRelationshipId(objectRelationshipId);
+		objectLayoutTab.setNameMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()));
+
+		if (objectRelationshipId == 0) {
+			objectLayoutTab.setObjectLayoutBoxes(
+				Collections.singletonList(_addObjectLayoutBox()));
+		}
+
+		return objectLayoutTab;
+	}
+
 	private ObjectRelationship _addObjectRelationshipSystemObjectDefinition()
 		throws Exception {
 
@@ -2239,6 +2348,26 @@ public class ObjectRelationshipLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectEntry.getObjectEntryId()),
 				role.getRoleId(), ActionKeys.VIEW));
+	}
+
+	private void _assertObjectLayoutTab(
+			int expectedSize, ObjectLayoutTab objectLayoutTab)
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectRelationshipLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		List<ServiceReference<?>> serviceReferences = new ArrayList<>(
+			bundleContext.getServiceReferences(
+				ScreenNavigationCategory.class,
+				"(screen.navigation.category.order:Integer=" +
+					objectLayoutTab.getObjectLayoutTabId() + ")"));
+
+		Assert.assertEquals(
+			serviceReferences.toString(), expectedSize,
+			serviceReferences.size());
 	}
 
 	private void _assertRootObjectDefinitionIdIsZero(
@@ -2777,6 +2906,21 @@ public class ObjectRelationshipLocalServiceTest {
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
+
+	@Inject
+	private ObjectLayoutBoxPersistence _objectLayoutBoxPersistence;
+
+	@Inject
+	private ObjectLayoutColumnPersistence _objectLayoutColumnPersistence;
+
+	@Inject
+	private ObjectLayoutLocalService _objectLayoutLocalService;
+
+	@Inject
+	private ObjectLayoutRowPersistence _objectLayoutRowPersistence;
+
+	@Inject
+	private ObjectLayoutTabPersistence _objectLayoutTabPersistence;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/test/ValidationsObjectDefinitionsScreenNavigationEntryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/test/ValidationsObjectDefinitionsScreenNavigationEntryTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.object.definitions.frontend.taglib.servl
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleConstants;
 import com.liferay.object.constants.ObjectWebKeys;
 import com.liferay.object.model.ObjectDefinition;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -100,6 +102,13 @@ public class ValidationsObjectDefinitionsScreenNavigationEntryTest {
 			ObjectDefinitionTestUtil.addCustomObjectDefinition();
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		ObjectRelationship objectRelationship =
 			ObjectRelationshipTestUtil.addObjectRelationship(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/util/ObjectCodeEditorUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/util/ObjectCodeEditorUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.web.internal.object.definitions.display.context.util;
 
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -402,7 +403,8 @@ public class ObjectCodeEditorUtil {
 		for (ObjectRelationship objectRelationship :
 				ObjectRelationshipLocalServiceUtil.
 					getObjectRelationshipsByObjectDefinitionId2(
-						objectDefinitionId)) {
+						objectDefinitionId,
+						ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectDefinition objectDefinition =
 				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -8,18 +8,18 @@
 	}
 }
 
-.sidebar-fragment {
-	--sidebar-fragment-height: calc(100vh - var(--control-menu-container-height, 0px));
-	--sidebar-fragment-width: 320px;
+.sidebar-layout {
+	--sidebar-layout-height: calc(100vh - var(--control-menu-container-height, 0px));
+	--sidebar-layout-width: 320px;
 
 	display: grid;
 	grid-template-areas: 'sidebar content';
 	grid-template-columns: 0px 1fr;
-	min-height: var(--sidebar-fragment-height);
+	min-height: var(--sidebar-layout-height);
 	transition: 400ms ease-in-out;
 
 	&.open {
-		grid-template-columns: var(--sidebar-fragment-width) 1fr;
+		grid-template-columns: var(--sidebar-layout-width) 1fr;
 	}
 
 	.sidebar-container {
@@ -31,10 +31,10 @@
 	}
 
 	.sidebar {
-		max-height: var(--sidebar-fragment-height);
-		max-width: var(--sidebar-fragment-width);
-		min-height: var(--sidebar-fragment-height);
-		min-width: var(--sidebar-fragment-width);
+		max-height: var(--sidebar-layout-height);
+		max-width: var(--sidebar-layout-width);
+		min-height: var(--sidebar-layout-height);
+		min-width: var(--sidebar-layout-width);
 	}
 
 	.content {

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -1,12 +1,9 @@
-.page-bar {
-	position: sticky;
+.top-bar {
 	top: var(--control-menu-container-height);
-	z-index: 1000;
-
 }
 
 @media (max-width: 575px) {
-	.page-bar {
+	.top-bar {
 		position: static;
 	}
 }

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -52,10 +52,16 @@
 		}
 
 		.sidebar-container {
-			left: calc(-1 * var(--sidebar-fragment-width));
+			height: 100%;
+			left: calc(-1 * var(--sidebar-layout-width));
 			position: absolute;
-			width: var(--sidebar-fragment-width);
+			width: var(--sidebar-layout-width);
 			z-index: 989;
+		}
+
+		.sidebar {
+			height: 100%;
+			max-height: none;
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
@@ -2,7 +2,7 @@
 	<lfr-drop-zone data-lfr-drop-zone-id="topBar"></lfr-drop-zone>
 </div>
 
-<div class="open sidebar-fragment">
+<div class="open sidebar-layout">
 	<nav aria-label="${configuration.sidebarAriaLabel}" class="sidebar-container">
 		<div class="sidebar sidebar-light">
 			<div class="px-0 sidebar-body">

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
@@ -1,4 +1,4 @@
-<div class="page-bar">
+<div class="sticky-top top-bar">
 	<lfr-drop-zone data-lfr-drop-zone-id="topBar"></lfr-drop-zone>
 </div>
 

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.js
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.js
@@ -9,7 +9,7 @@ const sidebarId = `${fragmentEntryLinkNamespace}sidebar`;
 const sidebarOpenKey = `${fragmentEntryLinkNamespace}sidebarOpen`;
 
 const sidebar = fragmentElement.querySelector('.sidebar-container');
-const sidebarContainer = fragmentElement.querySelector('.sidebar-fragment');
+const sidebarContainer = fragmentElement.querySelector('.sidebar-layout');
 const sidebarTrigger = fragmentElement.querySelector('.sidebar-toggle');
 
 if (sidebarTrigger) {

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/search/SiteNavigationMenuIndexer.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/search/SiteNavigationMenuIndexer.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.navigation.internal.search;
+
+import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.BaseIndexer;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
+
+import java.util.Locale;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Joao Victor Alves
+ */
+@Component(service = Indexer.class)
+public class SiteNavigationMenuIndexer extends BaseIndexer<SiteNavigationMenu> {
+
+	public SiteNavigationMenuIndexer() {
+		setDefaultSelectedFieldNames(
+			Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+			Field.GROUP_ID, Field.TITLE, Field.UID);
+		setFilterSearch(true);
+		setPermissionAware(true);
+	}
+
+	@Override
+	public String getClassName() {
+		return _CLASS_NAME;
+	}
+
+	@Override
+	protected void doDelete(SiteNavigationMenu siteNavigationMenu)
+		throws Exception {
+
+		deleteDocument(
+			siteNavigationMenu.getCompanyId(),
+			siteNavigationMenu.getPrimaryKey());
+	}
+
+	@Override
+	protected Document doGetDocument(SiteNavigationMenu siteNavigationMenu) {
+		Document document = getBaseModelDocument(
+			_CLASS_NAME, siteNavigationMenu);
+
+		document.addText(Field.TITLE, siteNavigationMenu.getName());
+		document.addDate(
+			Field.MODIFIED_DATE, siteNavigationMenu.getModifiedDate());
+
+		return document;
+	}
+
+	@Override
+	protected Summary doGetSummary(
+		Document document, Locale locale, String snippet,
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		String title = document.get(Field.TITLE);
+
+		return new Summary(title, snippet);
+	}
+
+	@Override
+	protected void doReindex(SiteNavigationMenu siteNavigationMenu)
+		throws Exception {
+
+		Document document = getDocument(siteNavigationMenu);
+
+		if (document != null) {
+			IndexWriterHelperUtil.updateDocument(
+				siteNavigationMenu.getCompanyId(), document);
+		}
+	}
+
+	@Override
+	protected void doReindex(String className, long classPK) throws Exception {
+		doReindex(
+			_siteNavigationMenuLocalService.getSiteNavigationMenu(classPK));
+	}
+
+	@Override
+	protected void doReindex(String[] ids) throws Exception {
+		long companyId = GetterUtil.getLong(ids[0]);
+
+		_reindexSiteNavigationMenus(companyId);
+	}
+
+	private void _reindexSiteNavigationMenus(long companyId) throws Exception {
+		IndexableActionableDynamicQuery indexableActionableDynamicQuery =
+			_siteNavigationMenuLocalService.
+				getIndexableActionableDynamicQuery();
+
+		indexableActionableDynamicQuery.setCompanyId(companyId);
+		indexableActionableDynamicQuery.setPerformActionMethod(
+			(SiteNavigationMenu siteNavigationMenu) -> {
+				try {
+					indexableActionableDynamicQuery.addDocuments(
+						getDocument(siteNavigationMenu));
+				}
+				catch (PortalException portalException) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to index site navigation menu " +
+								siteNavigationMenu.getSiteNavigationMenuId(),
+							portalException);
+					}
+				}
+			});
+
+		indexableActionableDynamicQuery.performActions();
+	}
+
+	private static final String _CLASS_NAME =
+		SiteNavigationMenu.class.getName();
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SiteNavigationMenuIndexer.class);
+
+	@Reference
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
+
+}

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	default_tear_down

--- a/modules/test/playwright/tests/analytics-settings-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/analytics-settings-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	default_tear_down

--- a/modules/test/playwright/tests/analytics-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/analytics-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	default_tear_down

--- a/modules/test/playwright/tests/client-extension-web/cluster/env/set_up.sh
+++ b/modules/test/playwright/tests/client-extension-web/cluster/env/set_up.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function cluster_set_up {
 	prepare_additional_bundles ${1}

--- a/modules/test/playwright/tests/client-extension-web/cluster/env/tear_down.sh
+++ b/modules/test/playwright/tests/client-extension-web/cluster/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	default_tear_down

--- a/modules/test/playwright/tests/object-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/object-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	stop_client_extension_spring_boot_application workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot

--- a/modules/test/playwright/tests/osb-faro-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/osb-faro-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 default_tear_down
 

--- a/modules/test/playwright/tests/portal-security-ldap/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function ldap_tear_down {
 	local dependencies_dir_name=${CURRENT_DIR_NAME}/../dependencies

--- a/modules/test/playwright/tests/portal-web/main/html/taglib/ui/roleSelector.spec.ts
+++ b/modules/test/playwright/tests/portal-web/main/html/taglib/ui/roleSelector.spec.ts
@@ -25,7 +25,7 @@ test(
 		});
 
 		await test.step('Create extra roles', async () => {
-			for (let i = 0; i <= maxNumberOfRoles; i++) {
+			for (let i = 0; i < maxNumberOfRoles; i++) {
 				const role = await apiHelpers.headlessAdminUser.postRole({
 					name: 'role' + i,
 					rolePermissions: [

--- a/modules/test/playwright/tests/portal-web/main/html/taglib/ui/roleSelector.spec.ts
+++ b/modules/test/playwright/tests/portal-web/main/html/taglib/ui/roleSelector.spec.ts
@@ -5,17 +5,43 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {dataApiHelpersTest} from '../../../../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../../../../fixtures/loginTest';
 import {PORTLET_URLS} from '../../../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../../../utils/waitForAlert';
 
-const test = mergeTests(loginTest());
+const test = mergeTests(dataApiHelpersTest, loginTest());
 
 test(
 	'Multiple selection with pagination in SearchContainer modal',
 	{tag: '@LPD-50672'},
-	async ({page}) => {
+	async ({apiHelpers, page}) => {
+		const maxNumberOfRoles = 15;
 		let iframeSelectRole;
+		const roleIds = [];
+
+		const companyId = await page.evaluate(() => {
+			return Liferay.ThemeDisplay.getCompanyId();
+		});
+
+		await test.step('Create extra roles', async () => {
+			for (let i = 0; i <= maxNumberOfRoles; i++) {
+				const role = await apiHelpers.headlessAdminUser.postRole({
+					name: 'role' + i,
+					rolePermissions: [
+						{
+							actionIds: ['VIEW'],
+							primaryKey: companyId,
+							resourceName:
+								'com.liferay.account.model.AccountEntry',
+							scope: 1,
+						},
+					],
+				});
+
+				roleIds.push(role.id);
+			}
+		});
 
 		await test.step('Navigate to Configuration > Site Settings > Menu Access', async () => {
 			await page.goto(`/group/guest${PORTLET_URLS.siteSettings}`);
@@ -79,7 +105,7 @@ test(
 				'Analytics Administrator'
 			);
 
-			await expect(Number(selectedRoleValue)).toBeGreaterThanOrEqual(0);
+			expect(Number(selectedRoleValue)).toBeGreaterThanOrEqual(0);
 		});
 	}
 );

--- a/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 function main {
 	stop_client_extension_spring_boot_application workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot

--- a/modules/test/playwright/tests/segments-web/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/segments-web/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
 
 default_tear_down
 

--- a/modules/test/playwright/tests/workspaces/liferay-workspace-jethr0/main/env/tear_down.sh
+++ b/modules/test/playwright/tests/workspaces/liferay-workspace-jethr0/main/env/tear_down.sh
@@ -4,7 +4,7 @@ CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
-source ${CURRENT_DIR_NAME}/../../../../env/common.sh
+source ${CURRENT_DIR_NAME}/../../../../../env/common.sh
 
 function main {
 	stop_client_extension_spring_boot_application workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
@@ -129,7 +129,6 @@ definition {
 
 	@description = "This is for LPS-176136. Verify is possible to hide or show Control Menu of a Role and that Administrator and Site Administrator cannot be deleted."
 	@priority = 4
-	@uitest
 	test ShowControlMenuByOOTBRoles {
 		task ("Given the site administrator accesses to the Site Configuration") {
 			Permissions.definePermissionViaJSONAPI(
@@ -224,7 +223,6 @@ definition {
 
 	@description = "This is for LPS-176136. Verify that users accessing the admin Page directly will see the Control Menu."
 	@priority = 4
-	@uitest
 	test ViewControlMenuInWebContentAdminAsUserWithRoleOutsideRolesThatCanSeeTheControlMenu {
 		var randomRoleKey = StringUtil.randomString(8);
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/productmenu/ProductMenuWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/productmenu/ProductMenuWithStaging.testcase
@@ -37,7 +37,6 @@ definition {
 
 	@description = "This is a test for LPS-112994. The Product Menu icon should not be shown when the user is in the Control Panel Apps even though enable Live"
 	@priority = 4
-	@uitest
 	test ViewProductMenuIconInvisibleInGlobalAppAfterEnableLive {
 		task ("View product menu icon is not shown in Control Panel apps") {
 			User.openUsersAdmin();

--- a/test.properties
+++ b/test.properties
@@ -6,19 +6,6 @@
 ##
 
 ##
-## Accessibility Menu
-##
-
-    test.batch.dist.app.servers[accessibility-menu]=tomcat
-
-    test.batch.names[accessibility-menu]=\
-        functional-tomcat90-mysql57
-
-    test.batch.run.property.query[functional-tomcat90-mysql57][accessibility-menu]=\
-        (portal.upstream == true) AND \
-        (testray.main.component.name == "Accessibility Menu")
-
-##
 ## Analytics Cloud
 ##
 
@@ -4680,55 +4667,15 @@
         functional-tomcat90-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
+        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat90-postgresql163,\
+        semantic-versioning,\
         unit
 
     test.batch.run.property.query[functional-tomcat90-*][platform-experience]=\
         (\
             (portal.acceptance != quarantine) AND \
-            (portal.upstream == true)\
-        ) AND \
-        (\
-            (testray.main.component.name == "Accessibility Framework") OR \
-            (testray.main.component.name == "Accessibility Menu") OR \
-            (testray.main.component.name == "Clay") OR \
-            (testray.main.component.name == "Feature Flag") OR \
-            (testray.main.component.name == "Instance Settings") OR \
-            (testray.main.component.name == "Language Override") OR \
-            (testray.main.component.name == "Liferay Themes") OR \
-            (testray.main.component.name == "Style Books") OR \
-            (testray.main.component.name == "System Settings")\
-        )
-
-    #
-    # Platform Experience Acceptance
-    #
-
-    test.batch.class.names.includes[platform-experience-acceptance]=\
-        **/feature-flag/**/*Test.java,\
-        **/frontend-css/**/*Test.java,\
-        **/frontend-taglib/**/*Test.java,\
-        **/frontend-theme/**/*Test.java,\
-        **/portal-instances/**/*Test.java,\
-        **/portal-language-override-test/**/*Test.java,\
-        **/product-navigation/**/*Test.java,\
-        **/style-book/**/*Test.java
-
-    test.batch.dist.app.servers[platform-experience-acceptance]=tomcat
-
-    test.batch.names[platform-experience-acceptance]=\
-        functional-tomcat90-mysql57,\
-        js-unit,\
-        modules-integration-postgresql163,\
-        modules-semantic-versioning,\
-        modules-unit,\
-        semantic-versioning,\
-        unit
-
-    test.batch.run.property.query[functional-tomcat90-mysql57][platform-experience-acceptance]=\
-        (\
-            (portal.acceptance == true) AND \
             (portal.upstream == true)\
         ) AND \
         (\
@@ -4746,51 +4693,6 @@
         )
 
     #
-    # Platform Experience Accessibility
-    #
-
-    test.batch.dist.app.servers[platform-experience-accessibility]=tomcat
-
-    test.batch.names[platform-experience-accessibility]=\
-        functional-tomcat90-mysql57,\
-        js-unit
-
-    test.batch.run.property.query[functional-tomcat90-mysql57][platform-experience-accessibility]=\
-        (\
-            (portal.acceptance != quarantine) AND \
-            (portal.accessibility == true)\
-        )
-
-    #
-    # Platform Experience Configuration Framework
-    #
-
-    test.batch.class.names.includes[configuration-framework]=\
-        **/feature-flag/**/*Test.java,\
-        **/portal-instances/**/*Test.java,\
-        **/portal-language-override-test/**/*Test.java
-
-    test.batch.dist.app.servers[configuration-framework]=tomcat
-
-    test.batch.names[configuration-framework]=\
-        functional-tomcat90-mysql57,\
-        js-unit,\
-        modules-integration-postgresql163,\
-        modules-unit
-
-    test.batch.run.property.query[functional-tomcat90-mysql57][configuration-framework]=\
-        (\
-            (portal.acceptance != quarantine) AND \
-            (portal.upstream == true)\
-        ) AND \
-        (\
-            (testray.main.component.name == "Feature Flag") OR \
-            (testray.main.component.name == "Instance Settings") OR \
-            (testray.main.component.name == "Language Override") OR \
-            (testray.main.component.name == "System Settings")\
-        )
-
-    #
     # Platform Experience Database Partition
     #
 
@@ -4798,32 +4700,6 @@
 
     test.batch.class.names.includes[platform-experience-db-partition]=\
         **/product-navigation/**/*Test.java
-
-    #
-    # Platform Experience Navigation Framework
-    #
-
-    test.batch.class.names.includes[navigation-framework]=\
-        **/application-list/**/*Test.java,\
-        **/product-navigation-control-panel/**/*Test.java
-
-    test.batch.dist.app.servers[navigation-framework]=tomcat
-
-    test.batch.names[navigation-framework]=\
-        functional-tomcat90-mysql57,\
-        js-unit,\
-        modules-integration-postgresql163,\
-        modules-unit
-
-    test.batch.run.property.query[functional-tomcat90-mysql57][navigation-framework]=\
-        (\
-            (portal.acceptance != quarantine) AND \
-            (portal.upstream == true)\
-        ) AND \
-        (\
-            (testray.main.component.name == "Control Menu") OR \
-            (testray.main.component.name == "Product Menu")\
-        )
 
     #
     # Playwright


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-53456

This features can be tested by the API: http://localhost:8080/o/api in headless-delivery.

You can use the `postSiteNavigationMenusPageExportBatch` method to create a export task and filter it by the creation/modification date range, and then retriever the result in the headless-batch-engine API with one of the GET methods.

This is a example of a filter that can be used: `dateCreated gt 2024-01-01T00:00:00Z`