### PR TITLE
LPD-54034 XML Sitemap configuration causes issues when going to a different configuration

### DIFF
--- a/modules/apps/site/site-sitemap-web/src/main/resources/META-INF/resources/js/SitemapCompanyConfiguration.ts
+++ b/modules/apps/site/site-sitemap-web/src/main/resources/META-INF/resources/js/SitemapCompanyConfiguration.ts
@@ -155,7 +155,7 @@ export default function ({
 
 	return {
 		dispose() {
-			onRemoveSite.dispose();
+			onRemoveSite.detach();
 			selectDelegate.dispose();
 		},
 	};

--- a/modules/apps/site/site-sitemap-web/test.properties
+++ b/modules/apps/site/site-sitemap-web/test.properties
@@ -1,0 +1,22 @@
+##
+## Test Suites
+##
+
+    modified.files.includes[relevant][site-sitemap-web-rule]=**
+    relevant.rule.names=site-sitemap-web-rule
+
+    test.batch.names[relevant][site-sitemap-web-rule]=\
+        playwright-js-tomcat90-mysql57
+
+    #
+    # Relevant
+    #
+
+    playwright.projects.includes[playwright-js-tomcat90-mysql57][relevant][site-sitemap-web-rule]=\
+        site-sitemap-web
+
+##
+## Testray
+##
+
+    testray.main.component.name=Sitemap Protocol

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -126,6 +126,7 @@ import {config as siteNavigationBreadcrumbWebConfig} from './tests/site-navigati
 import {config as siteNavigationDirectoryWebConfig} from './tests/site-navigation-directory-web/config';
 import {config as siteNavigationLanguageWebConfig} from './tests/site-navigation-language-web/config';
 import {config as siteNavigationMenuWebConfig} from './tests/site-navigation-menu-web/config';
+import {config as siteSitemapWebConfig} from './tests/site-sitemap-web/config';
 import {config as smokeConfig} from './tests/smoke/config';
 import {config as stagingConfig} from './tests/staging-configuration-web/config';
 import {config as stylebookWebConfig} from './tests/style-book-web/config';
@@ -267,6 +268,7 @@ export default defineConfig({
 		siteNavigationDirectoryWebConfig,
 		siteNavigationLanguageWebConfig,
 		siteNavigationMenuWebConfig,
+		siteSitemapWebConfig,
 		smokeConfig,
 		stagingConfig,
 		stylebookWebConfig,

--- a/modules/test/playwright/tests/site-sitemap-web/config.ts
+++ b/modules/test/playwright/tests/site-sitemap-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'site-sitemap-web',
+	testDir: 'tests/site-sitemap-web',
+};

--- a/modules/test/playwright/tests/site-sitemap-web/sitemap.spec.ts
+++ b/modules/test/playwright/tests/site-sitemap-web/sitemap.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {instanceSettingsPagesTest} from '../../fixtures/instanceSettingsPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+
+export const test = mergeTests(instanceSettingsPagesTest, loginTest());
+
+test(
+	'XML Sitemap configuration does not cause issues going to different configuration',
+	{
+		tag: '@LPD-54034',
+	},
+	async ({instanceSettingsPage, page}) => {
+		await instanceSettingsPage.goToInstanceSetting('SEO', 'XML Sitemap');
+
+		await expect(page.getByText('XML Sitemap Index Enabled')).toBeVisible();
+
+		await page.getByRole('menuitem', {name: 'Friendly URL'}).click();
+
+		await expect(
+			page.getByText('URL Separator', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Friendly URL'})
+		).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/site-sitemap-web/test.properties
+++ b/modules/test/playwright/tests/site-sitemap-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Sitemap Protocol

--- a/test.properties
+++ b/test.properties
@@ -6470,7 +6470,8 @@
         site-navigation-admin-web,\
         site-navigation-breadcrumb-web,\
         site-navigation-directory-web,\
-        site-navigation-menu-web
+        site-navigation-menu-web,\
+        site-sitemap-web
 
     site.management.testing.modules=\
         apps/click-to-chat/**,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54034

# How am I fixing it?

The `dispose` function does not exist on this object. Previously, when this functionality was part of a JSP prior to LPD-17734, it used the `detach` function.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-54034'`