### PR TITLE
LPD-55273 Fix siteLanguagesConfiguration.spec.ts and LocalizationWithSites#CannotRemoveSiteDefaultLanguageInInstanceSettings

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/siteLanguagesConfiguration.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/siteLanguagesConfiguration.spec.ts
@@ -79,11 +79,11 @@ test(
 		for (let i = 0; i < currentInstanceLanguages.length; i++) {
 			await page.waitForTimeout(500);
 			await page
-				.getByLabel('Current')
+				.getByLabel('Current', {exact: true})
 				.selectOption(currentInstanceLanguages[i]);
 			await page
 				.getByRole('button', {
-					name: 'Transfer Item Left to Right',
+					name: 'Move selected items from Current to Available',
 				})
 				.click({force: true});
 		}
@@ -109,11 +109,11 @@ test(
 		for (let i = 0; i < currentInstanceLanguages.length; i++) {
 			await page.waitForTimeout(500);
 			await page
-				.getByLabel('Available')
+				.getByLabel('Available', {exact: true})
 				.selectOption(currentInstanceLanguages[i]);
 			await page
 				.getByRole('button', {
-					name: 'Transfer Item Right to Left',
+					name: 'Move selected items from Available to Current',
 				})
 				.click({force: true});
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -582,12 +582,12 @@
 </tr>
 <tr>
 	<td>MOVE_AVAILABLE_TO_CURRENT</td>
-	<td>//button[@title='Move selected items from Available to Current.']</td>
+	<td>//button[@aria-label='Move selected items from Available to Current.']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>MOVE_CURRENT_TO_AVAILABLE</td>
-	<td>//button[@title='Move selected items from Current to Available.']</td>
+	<td>//button[@aria-label='Move selected items from Current to Available.']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
@@ -78,12 +78,6 @@ definition {
 	test CannotRemoveSiteDefaultLanguageInInstanceSettings {
 		property portal.acceptance = "true";
 
-		task ("Add a widget page") {
-			JSONLayout.addPublicLayout(
-				groupName = "Test Site Name 1",
-				layoutName = "Test Page Name");
-		}
-
 		task ("Configure site languages") {
 			Site.openSiteSettingsAdmin(siteURLKey = "test-site-name-1");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55273

# How am I fixing it?

Recently changes were made to the front end and a regression was caused (see https://liferay.atlassian.net/browse/LPD-54241 and https://liferay.atlassian.net/browse/LPD-54563). After all the changes, modifications to the tests needed to be done.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'LPD-37997'`
In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#CannotRemoveSiteDefaultLanguageInInstanceSettings`