### PR TITLE
LPD-55289 Site Navigation Menu type is not defined in postSiteNavigationMenu method

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenuItem.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenuItem.java
@@ -19,6 +19,7 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 import jakarta.annotation.Generated;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
 
@@ -42,6 +43,10 @@ import java.util.function.Supplier;
 @GraphQLName(
 	description = "Represents a navigation menu item.",
 	value = "NavigationMenuItem"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "Represents a navigation menu item.",
+	requiredProperties = {"typeSettings"}
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "NavigationMenuItem")
@@ -760,11 +765,57 @@ public class NavigationMenuItem implements Serializable {
 	}
 
 	@GraphQLField(description = "The navigation menu item's type.")
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String type;
 
 	@JsonIgnore
 	private Supplier<String> _typeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The navigation menu item's type settings."
+	)
+	@Valid
+	public Map<String, String> getTypeSettings() {
+		if (_typeSettingsSupplier != null) {
+			typeSettings = _typeSettingsSupplier.get();
+
+			_typeSettingsSupplier = null;
+		}
+
+		return typeSettings;
+	}
+
+	public void setTypeSettings(Map<String, String> typeSettings) {
+		this.typeSettings = typeSettings;
+
+		_typeSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTypeSettings(
+		UnsafeSupplier<Map<String, String>, Exception>
+			typeSettingsUnsafeSupplier) {
+
+		_typeSettingsSupplier = () -> {
+			try {
+				return typeSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The navigation menu item's type settings.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
+	protected Map<String, String> typeSettings;
+
+	@JsonIgnore
+	private Supplier<Map<String, String>> _typeSettingsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The navigation menu item's linked URL."
@@ -1135,6 +1186,18 @@ public class NavigationMenuItem implements Serializable {
 			sb.append(_escape(type));
 
 			sb.append("\"");
+		}
+
+		Map<String, String> typeSettings = getTypeSettings();
+
+		if (typeSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"typeSettings\": ");
+
+			sb.append(_toJSON(typeSettings));
 		}
 
 		String url = getUrl();

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 34.0.1
+version 34.1.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/NavigationMenuItem.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/NavigationMenuItem.java
@@ -368,6 +368,28 @@ public class NavigationMenuItem implements Cloneable, Serializable {
 
 	protected String type;
 
+	public Map<String, String> getTypeSettings() {
+		return typeSettings;
+	}
+
+	public void setTypeSettings(Map<String, String> typeSettings) {
+		this.typeSettings = typeSettings;
+	}
+
+	public void setTypeSettings(
+		UnsafeSupplier<Map<String, String>, Exception>
+			typeSettingsUnsafeSupplier) {
+
+		try {
+			typeSettings = typeSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> typeSettings;
+
 	public String getUrl() {
 		return url;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuItemSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuItemSerDes.java
@@ -291,6 +291,16 @@ public class NavigationMenuItemSerDes {
 			sb.append("\"");
 		}
 
+		if (navigationMenuItem.getTypeSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"typeSettings\": ");
+
+			sb.append(_toJSON(navigationMenuItem.getTypeSettings()));
+		}
+
 		if (navigationMenuItem.getUrl() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -473,6 +483,15 @@ public class NavigationMenuItemSerDes {
 			map.put("type", String.valueOf(navigationMenuItem.getType()));
 		}
 
+		if (navigationMenuItem.getTypeSettings() == null) {
+			map.put("typeSettings", null);
+		}
+		else {
+			map.put(
+				"typeSettings",
+				String.valueOf(navigationMenuItem.getTypeSettings()));
+		}
+
 		if (navigationMenuItem.getUrl() == null) {
 			map.put("url", null);
 		}
@@ -560,6 +579,9 @@ public class NavigationMenuItemSerDes {
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "typeSettings")) {
+				return true;
 			}
 			else if (Objects.equals(jsonParserFieldName, "url")) {
 				return false;
@@ -699,6 +721,12 @@ public class NavigationMenuItemSerDes {
 			else if (Objects.equals(jsonParserFieldName, "type")) {
 				if (jsonParserFieldValue != null) {
 					navigationMenuItem.setType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "typeSettings")) {
+				if (jsonParserFieldValue != null) {
+					navigationMenuItem.setTypeSettings(
+						(Map<String, String>)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "url")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -3573,8 +3573,13 @@ components:
                     # @review
                     description:
                         The navigation menu item's type.
-                    readOnly: true
                     type: string
+                typeSettings:
+                    additionalProperties:
+                        type: string
+                    description:
+                        The navigation menu item's type settings.
+                    type: object
                 url:
                     # @review
                     description:
@@ -3582,6 +3587,8 @@ components:
                     type: string
                 useCustomName:
                     type: boolean
+            required:
+                -   typeSettings
         NoneActionExecutionResult:
             # @review
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -65,7 +65,6 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -269,13 +268,14 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 			long siteId, long siteNavigationMenuId)
 		throws Exception {
 
-		String unicodeProperties = _getUnicodeProperties(
-			true, navigationMenuItem, siteId, null);
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.putAll(
+			navigationMenuItem.getTypeSettings()
+		).build();
 
 		SiteNavigationMenuItem siteNavigationMenuItem =
 			_siteNavigationMenuItemService.addSiteNavigationMenuItem(
 				null, siteId, siteNavigationMenuId, parentNavigationMenuId,
-				_getType(navigationMenuItem), unicodeProperties,
+				navigationMenuItem.getType(), unicodeProperties.toString(),
 				ServiceContextBuilder.create(
 					siteId, contextHttpServletRequest, null
 				).expandoBridgeAttributes(
@@ -318,18 +318,6 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 
 		return _layoutLocalService.fetchLayoutByUuidAndGroupId(
 			layoutUuid, siteNavigationMenuItem.getGroupId(), privateLayout);
-	}
-
-	private Layout _getLayout(String link, long siteId) throws Exception {
-		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-			siteId, false, link);
-
-		if (layout == null) {
-			layout = _layoutLocalService.getLayoutByFriendlyURL(
-				siteId, true, link);
-		}
-
-		return layout;
 	}
 
 	private Locale _getLocaleFromProperty(Map.Entry<String, String> property) {
@@ -448,83 +436,6 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 		}
 
 		return siteNavigationMenuItemsMap;
-	}
-
-	private String _getType(NavigationMenuItem navigationMenuItem) {
-		if (navigationMenuItem.getLink() != null) {
-			return "layout";
-		}
-		else if (navigationMenuItem.getUrl() != null) {
-			return "url";
-		}
-
-		return "node";
-	}
-
-	private String _getUnicodeProperties(
-			boolean add, NavigationMenuItem navigationMenuItem, long siteId,
-			SiteNavigationMenuItem siteNavigationMenuItem)
-		throws Exception {
-
-		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
-
-		if (navigationMenuItem.getLink() != null) {
-			unicodeProperties.setProperty(
-				"defaultLanguageId",
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
-
-			Layout layout = _getLayout(navigationMenuItem.getLink(), siteId);
-
-			unicodeProperties.setProperty(
-				"groupId", String.valueOf(layout.getGroupId()));
-			unicodeProperties.setProperty("layoutUuid", layout.getUuid());
-
-			Map<Locale, String> nameMap = LocalizedMapUtil.getLocalizedMap(
-				contextAcceptLanguage.getPreferredLocale(),
-				navigationMenuItem.getName(), navigationMenuItem.getName_i18n(),
-				_getLocalizedNamesFromProperties(
-					_getUnicodeProperties(siteNavigationMenuItem)));
-
-			for (Map.Entry<Locale, String> entry : nameMap.entrySet()) {
-				unicodeProperties.setProperty(
-					"name_" + LocaleUtil.toLanguageId(entry.getKey()),
-					nameMap.get(entry.getKey()));
-			}
-
-			unicodeProperties.setProperty(
-				"privateLayout", String.valueOf(layout.isPrivateLayout()));
-			unicodeProperties.setProperty(
-				"useCustomName",
-				String.valueOf(navigationMenuItem.getUseCustomName()));
-		}
-		else {
-			Map<Locale, String> nameMap = LocalizedMapUtil.getLocalizedMap(
-				contextAcceptLanguage.getPreferredLocale(),
-				navigationMenuItem.getName(), navigationMenuItem.getName_i18n(),
-				_getLocalizedNamesFromProperties(
-					_getUnicodeProperties(siteNavigationMenuItem)));
-
-			LocalizedMapUtil.validateI18n(
-				add, LocaleUtil.getSiteDefault(), "Navigation Menu item",
-				nameMap, new HashSet<>());
-
-			unicodeProperties.setProperty(
-				"defaultLanguageId",
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
-
-			for (Map.Entry<Locale, String> entry : nameMap.entrySet()) {
-				unicodeProperties.setProperty(
-					"name_" + LocaleUtil.toLanguageId(entry.getKey()),
-					nameMap.get(entry.getKey()));
-			}
-
-			if (navigationMenuItem.getUrl() != null) {
-				unicodeProperties.setProperty(
-					"url", navigationMenuItem.getUrl());
-			}
-		}
-
-		return unicodeProperties.toString();
 	}
 
 	private UnicodeProperties _getUnicodeProperties(
@@ -750,21 +661,8 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 							"getSiteSitePage", contextUriInfo,
 							arguments.toArray(new Object[0]));
 					});
-				setType(
-					() -> {
-						DTOConverter<?, ?> dtoConverter =
-							_dtoConverterRegistry.getDTOConverter(
-								navigationMenuItemType);
-
-						if (dtoConverter == null) {
-							return navigationMenuItemType;
-						}
-
-						String contentType = dtoConverter.getContentType();
-
-						return Character.toLowerCase(contentType.charAt(0)) +
-							contentType.substring(1);
-					});
+				setType(siteNavigationMenuItem::getType);
+				setTypeSettings(() -> unicodeProperties);
 				setUrl(() -> unicodeProperties.getProperty("url"));
 				setUseCustomName(
 					() -> Boolean.valueOf(
@@ -880,9 +778,8 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 						_siteNavigationMenuItemService.
 							updateSiteNavigationMenuItem(
 								navigationMenuItemId,
-								_getUnicodeProperties(
-									false, navigationMenuItem, siteId,
-									siteNavigationMenuItem),
+								navigationMenuItem.getTypeSettings(
+								).toString(),
 								ServiceContextBuilder.create(
 									siteId, contextHttpServletRequest, null
 								).expandoBridgeAttributes(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -75,6 +75,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -186,8 +187,8 @@ public class NavigationMenuResourceTest
 		_testGetNavigationMenu(
 			blogsEntry.getPrimaryKey(), 0, BlogsEntry.class,
 			"blog-postings/" + blogsEntry.getPrimaryKey(),
-			BlogsEntry.class.getName(), blogsEntry.getTitle(), "blogPosting",
-			true);
+			BlogsEntry.class.getName(), blogsEntry.getTitle(),
+			BlogsEntry.class.getName(), true);
 
 		FileEntry fileEntry = DLAppTestUtil.addFileEntryWithWorkflow(
 			TestPropsValues.getUserId(), _depotEntry.getGroupId(),
@@ -201,7 +202,8 @@ public class NavigationMenuResourceTest
 			fileEntry.getPrimaryKey(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			DLFileEntry.class, "documents/" + fileEntry.getFileEntryId(),
-			FileEntry.class.getName(), fileEntry.getTitle(), "document", true);
+			FileEntry.class.getName(), fileEntry.getTitle(),
+			FileEntry.class.getName(), true);
 
 		fileEntry = DLAppTestUtil.addFileEntryWithWorkflow(
 			TestPropsValues.getUserId(), testGroup.getGroupId(),
@@ -215,7 +217,8 @@ public class NavigationMenuResourceTest
 			fileEntry.getPrimaryKey(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			DLFileEntry.class, "documents/" + fileEntry.getFileEntryId(),
-			FileEntry.class.getName(), fileEntry.getTitle(), "document", true);
+			FileEntry.class.getName(), fileEntry.getTitle(),
+			FileEntry.class.getName(), true);
 
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_depotEntry.getGroupId(),
@@ -226,7 +229,7 @@ public class NavigationMenuResourceTest
 			journalArticle.getDDMStructureId(), JournalArticle.class,
 			"structured-contents/" + journalArticle.getResourcePrimKey(),
 			JournalArticle.class.getName(), journalArticle.getTitle(),
-			"structuredContent", false);
+			JournalArticle.class.getName(), false);
 
 		journalArticle = JournalTestUtil.addArticle(
 			testGroup.getGroupId(),
@@ -237,7 +240,7 @@ public class NavigationMenuResourceTest
 			journalArticle.getDDMStructureId(), JournalArticle.class,
 			"structured-contents/" + journalArticle.getResourcePrimKey(),
 			JournalArticle.class.getName(), journalArticle.getTitle(),
-			"structuredContent", false);
+			JournalArticle.class.getName(), false);
 
 		_testGetNavigationMenuWithChildNavigationMenusAndNavigationMenuItems();
 		_testGetNavigationMenuWithNestedFields();
@@ -258,8 +261,8 @@ public class NavigationMenuResourceTest
 		_testGetSiteNavigationMenusPage(
 			blogsEntry.getPrimaryKey(), 0, BlogsEntry.class,
 			"blog-postings/" + blogsEntry.getPrimaryKey(),
-			BlogsEntry.class.getName(), blogsEntry.getTitle(), "blogPosting",
-			false);
+			BlogsEntry.class.getName(), blogsEntry.getTitle(),
+			BlogsEntry.class.getName(), false);
 
 		FileEntry fileEntry = DLAppTestUtil.addFileEntryWithWorkflow(
 			TestPropsValues.getUserId(), _depotEntry.getGroupId(),
@@ -273,7 +276,8 @@ public class NavigationMenuResourceTest
 			fileEntry.getPrimaryKey(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			DLFileEntry.class, "documents/" + fileEntry.getFileEntryId(),
-			FileEntry.class.getName(), fileEntry.getTitle(), "document", false);
+			FileEntry.class.getName(), fileEntry.getTitle(),
+			FileEntry.class.getName(), false);
 
 		fileEntry = DLAppTestUtil.addFileEntryWithWorkflow(
 			TestPropsValues.getUserId(), testGroup.getGroupId(),
@@ -287,7 +291,8 @@ public class NavigationMenuResourceTest
 			fileEntry.getPrimaryKey(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			DLFileEntry.class, "documents/" + fileEntry.getFileEntryId(),
-			FileEntry.class.getName(), fileEntry.getTitle(), "document", false);
+			FileEntry.class.getName(), fileEntry.getTitle(),
+			FileEntry.class.getName(), false);
 
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_depotEntry.getGroupId(),
@@ -298,7 +303,7 @@ public class NavigationMenuResourceTest
 			journalArticle.getDDMStructureId(), JournalArticle.class,
 			"structured-contents/" + journalArticle.getResourcePrimKey(),
 			JournalArticle.class.getName(), journalArticle.getTitle(),
-			"structuredContent", true);
+			JournalArticle.class.getName(), true);
 
 		journalArticle = JournalTestUtil.addArticle(
 			testGroup.getGroupId(),
@@ -309,7 +314,7 @@ public class NavigationMenuResourceTest
 			journalArticle.getDDMStructureId(), JournalArticle.class,
 			"structured-contents/" + journalArticle.getResourcePrimKey(),
 			JournalArticle.class.getName(), journalArticle.getTitle(),
-			"structuredContent", true);
+			JournalArticle.class.getName(), true);
 
 		_testGetSiteNavigationMenusPageWithSearch();
 	}
@@ -538,6 +543,40 @@ public class NavigationMenuResourceTest
 			CustomField.class);
 	}
 
+	private HashMap<String, String> _getPropertiesMapBuilder(
+		Layout layout, Map<String, String> nameI18nMap, String type,
+		String useCustomName) {
+
+		HashMapBuilder.HashMapWrapper<String, String> nodeTypeSettings =
+			HashMapBuilder.put(
+				"defaultLanguageId",
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+		for (Map.Entry<String, String> entry : nameI18nMap.entrySet()) {
+			nodeTypeSettings.put(
+				"name_" + LocaleUtil.fromLanguageId(entry.getKey()),
+				nameI18nMap.get(entry.getKey()));
+		}
+
+		if (type.equals("layout")) {
+			return nodeTypeSettings.put(
+				"groupId", GetterUtil.getString(layout.getGroupId())
+			).put(
+				"layoutUuid", layout.getUuid()
+			).put(
+				"privateLayout", GetterUtil.getString(layout.isPrivateLayout())
+			).put(
+				"title", layout.getTitle()
+			).put(
+				"useCustomName", useCustomName
+			).build();
+		}
+
+		return nodeTypeSettings.put(
+			"useCustomName", useCustomName
+		).build();
+	}
+
 	private ServiceContext _getServiceContext(boolean expandoBridgeAttributes)
 		throws Exception {
 
@@ -652,11 +691,23 @@ public class NavigationMenuResourceTest
 								name = RandomTestUtil.randomString();
 								navigationMenuItems = new NavigationMenuItem[0];
 								type = "url";
-								url = RandomTestUtil.randomString();
+								typeSettings = HashMapBuilder.put(
+									"name_en_US", name
+								).put(
+									"url", "https://www.google.com"
+								).put(
+									"useNewTab", "false"
+								).build();
+								url = "https://www.google.com";
 							}
 						}
 					};
-					type = "navigationMenu";
+					type = "node";
+					typeSettings = HashMapBuilder.put(
+						"defaultLanguageId", "en_US"
+					).put(
+						"name_en_US", name
+					).build();
 				}
 			}
 		};
@@ -670,7 +721,9 @@ public class NavigationMenuResourceTest
 			new NavigationMenuItem() {
 				{
 					name_i18n = nameI18nMap1;
-					type = "navigationMenu";
+					type = "node";
+					typeSettings = _getPropertiesMapBuilder(
+						layout1, nameI18nMap1, "node", "false");
 					useCustomName = false;
 				}
 			},
@@ -683,7 +736,9 @@ public class NavigationMenuResourceTest
 						"es-ES", layout1.getFriendlyURL(LocaleUtil.SPAIN)
 					).build();
 					name_i18n = nameI18nMap1;
-					type = "page";
+					type = "layout";
+					typeSettings = _getPropertiesMapBuilder(
+						layout1, nameI18nMap1, "layout", "true");
 					useCustomName = true;
 				}
 			},
@@ -694,7 +749,9 @@ public class NavigationMenuResourceTest
 						"en-US", layout1.getFriendlyURL(LocaleUtil.US)
 					).build();
 					name_i18n = nameI18nMap2;
-					type = "page";
+					type = "layout";
+					typeSettings = _getPropertiesMapBuilder(
+						layout1, nameI18nMap2, "layout", "true");
 					useCustomName = true;
 				}
 			},
@@ -705,7 +762,9 @@ public class NavigationMenuResourceTest
 						"en-US", layout1.getFriendlyURL(LocaleUtil.US)
 					).build();
 					name_i18n = nameI18nMap1;
-					type = "page";
+					type = "layout";
+					typeSettings = _getPropertiesMapBuilder(
+						layout1, nameI18nMap1, "layout", "false");
 					useCustomName = false;
 				}
 			},
@@ -716,7 +775,9 @@ public class NavigationMenuResourceTest
 						"en-US", layout2.getFriendlyURL(LocaleUtil.US)
 					).build();
 					name_i18n = nameI18nMap1;
-					type = "page";
+					type = "layout";
+					typeSettings = _getPropertiesMapBuilder(
+						layout2, nameI18nMap1, "layout", "false");
 					useCustomName = false;
 				}
 			}
@@ -846,14 +907,13 @@ public class NavigationMenuResourceTest
 
 		_assertNavigationMenuItem(
 			nameI18nMap1.get(LocaleUtil.SPAIN.toLanguageTag()), nameI18nMap1,
-			getNavigationMenu.getNavigationMenuItems()[0], "navigationMenu",
-			false);
+			getNavigationMenu.getNavigationMenuItems()[0], "node", false);
 		_assertNavigationMenuItem(
 			nameI18nMap1.get(LocaleUtil.SPAIN.toLanguageTag()), nameI18nMap1,
-			getNavigationMenu.getNavigationMenuItems()[1], "page", true);
+			getNavigationMenu.getNavigationMenuItems()[1], "layout", true);
 		_assertNavigationMenuItem(
 			nameI18nMap2.get(LocaleUtil.US.toLanguageTag()), nameI18nMap2,
-			getNavigationMenu.getNavigationMenuItems()[2], "page", true);
+			getNavigationMenu.getNavigationMenuItems()[2], "layout", true);
 		_assertNavigationMenuItem(
 			layoutNameMap1.get(LocaleUtil.SPAIN),
 			HashMapBuilder.put(
@@ -862,13 +922,13 @@ public class NavigationMenuResourceTest
 				LocaleUtil.SPAIN.toLanguageTag(),
 				layoutNameMap1.get(LocaleUtil.SPAIN)
 			).build(),
-			getNavigationMenu.getNavigationMenuItems()[3], "page", false);
+			getNavigationMenu.getNavigationMenuItems()[3], "layout", false);
 		_assertNavigationMenuItem(
 			layoutNameMap2.get(LocaleUtil.US),
 			HashMapBuilder.put(
 				LocaleUtil.US.toLanguageTag(), layoutNameMap2.get(LocaleUtil.US)
 			).build(),
-			getNavigationMenu.getNavigationMenuItems()[4], "page", false);
+			getNavigationMenu.getNavigationMenuItems()[4], "layout", false);
 	}
 
 	private void _testGetNavigationMenuWithNestedFields() throws Exception {


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-55289

In order to fix the issue, the `unicodeProperties` are now set in the request using the `typeSettings` parameter, so we don't need to fetch all the entities in the `NavigationMenuResourceImpl` class to set it, and the `type` can now be set as well, removing the dependency of the `link` and `url` properties.