### PR TITLE
LPD-56965 Extract styles in order to remove SF suppressions

### DIFF
--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-absolute-container/index.html
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-absolute-container/index.html
@@ -1,3 +1,14 @@
-<div class="masterclass-container" style="bottom: ${configuration.positionBottom}px; left: ${configuration.positionLeft}px; position: ${configuration.position}; right: ${configuration.positionRight}px; top: ${configuration.positionTop}px; z-index: ${configuration.zIndex};">
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}-container-padding {
+		bottom: ${configuration.positionBottom}px;
+		left: ${configuration.positionLeft}px;
+		position: ${configuration.position};
+		right: ${configuration.positionRight}px;
+		top: ${configuration.positionTop}px;
+		z-index: ${configuration.zIndex};
+	}
+[/@]
+
+<div class="${fragmentEntryLinkNamespace}-container-padding masterclass-container">
 	<lfr-drop-zone></lfr-drop-zone>
 </div>

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-video/index.html
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-video/index.html
@@ -1,4 +1,11 @@
-<div style="display: flex; justify-content: ${configuration.align};">
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}-video-display {
+		display: flex;
+		justify-content: ${configuration.align};
+	}
+[/@]
+
+<div class="${fragmentEntryLinkNamespace}-video-display">
 	<div class="video">
 		<div class="alert alert-info error-message" hidden role="alert">
 			<p>Please enter a valid video URL.</p>

--- a/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/video/index.html
+++ b/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/video/index.html
@@ -1,4 +1,11 @@
-<div style="display: flex; justify-content: ${configuration.align};">
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}-video-display {
+		display: flex;
+		justify-content: ${configuration.align};
+	}
+[/@]
+
+<div class="${fragmentEntryLinkNamespace}-video-display">
 	<div class="video">
 		<div class="alert alert-info error-message" hidden role="alert">
 			<p>Please enter a valid video URL.</p>

--- a/modules/apps/site-initializer/source-formatter-suppressions.xml
+++ b/modules/apps/site-initializer/source-formatter-suppressions.xml
@@ -7,9 +7,6 @@
 		<suppress checks="UnprocessedExceptionCheck" files="site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer\.java" />
 	</checkstyle>
 	<source-check>
-		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-absolute-container/index\.html" />
-		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-video/index\.html" />
-		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/video/index\.html" />
 		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-teaser-showcase/src/main/resources/site-initializer/ddm-templates/product-detail/ddm-template\.ftl" />
 		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-teaser-showcase/src/main/resources/site-initializer/ddm-templates/search-category/ddm-template\.ftl" />
 		<suppress checks="CSPTagIllegalAttributesCheck" files="site-initializer-teaser-showcase/src/main/resources/site-initializer/fragments/group/clarity-components/fragments/icon/index\.html" />


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-56965

# How am I fixing it?

The styles are extracted out to no longer be inlined. https://github.com/brianchandotcom/liferay-portal/pull/162091/files was used as a guide.