### PR TITLE
LPD-57285 Update link localized names

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
@@ -183,7 +183,7 @@ definition {
 
 			ProductMenu.gotoPortlet(
 				category = "Generador del sitio",
-				portlet = "Páginas del sitio web");
+				portlet = "Páginas");
 
 			PagesAdmin.gotoPageEllipsisMenuItem(
 				menuItem = "Configurar",
@@ -491,7 +491,7 @@ definition {
 
 				ProductMenu.gotoPortlet(
 					category = "Generador del sitio",
-					portlet = "Páginas del sitio web");
+					portlet = "Páginas");
 
 				PagesAdmin.gotoPageEllipsisMenuItem(
 					menuItem = "Configurar",
@@ -519,7 +519,7 @@ definition {
 
 			ProductMenu.gotoPortlet(
 				category = "Configuración",
-				portlet = "Ajustes del sitio");
+				portlet = "Configuración del sitio web");
 
 			Site.configureCurrentLanguagesCP(
 				category = "Localización",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-57285

# How am I fixing it?

The translations have been updated so the test has been updated to reflect the new link names.

# How can you verify that it works?

In the root folder run:
`ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#ConfigureSiteDefaultLanguage`
`ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#ViewPortletInteractWithLocalization`