### PR TITLE
LPD-57308 Fix flaky test

### DIFF
--- a/modules/test/playwright/tests/site-navigation-directory-web/main/sitesDirectoryWidget.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-directory-web/main/sitesDirectoryWidget.spec.ts
@@ -89,9 +89,11 @@ test('Ensure Sites Directory widget can display parent site', async ({
 
 	await widgetPagePage.saveAndClose('Sites Directory');
 
-	await expect(page.locator('[id$="groupsSearchContainer_1"]')).toHaveText(
-		site.name
-	);
+	const breadcrumbEntries = await page
+		.locator('[id*="groupsSearchContainer_"]')
+		.allInnerTexts();
+
+	await expect(breadcrumbEntries).toContainEqual(site.name);
 
 	await apiHelpers.headlessSite.deleteSite(childSite.id);
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-57308

# How am I fixing it?

There were sometimes multiple matching elements to the locator. This made the test flaky and unreliable.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'Ensure Sites Directory widget can display parent site'`