### PR TITLE
LPD-59219 Test fix for UpgradeVirtualHostTest

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeVirtualHostTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeVirtualHostTest.java
@@ -54,6 +54,10 @@ public class UpgradeVirtualHostTest extends BaseCTUpgradeProcessTestCase {
 	}
 
 	@Override
+	protected void deleteCTModel(long primaryKey) {
+	}
+
+	@Override
 	protected CTService<?> getCTService() {
 		return _virtualHostLocalService;
 	}


### PR DESCRIPTION
Related issue: [LPD-59219](https://liferay.atlassian.net/browse/LPD-59219)
---
Hi team!

I'm sending in this change because `UpgradeVirtualHostTest` is deleting a default database entry within the test, which is not expected and is causing several oAuth2 tests to fail if this test is run before them.

Basically it's leading `Company.getVirtualHostname() ` to return "null" when we need it to return "localhost".

I'm requesting Site Management's review on this since you've created this test and its base test. 

Let me know if you need any more info! :)

Kind regards,
Manuele Castro

cc: @rafaprax