### PR TITLE
LPD-58397 Remove low priority Site Management test from Acceptance

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/Sites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/Sites.testcase
@@ -324,7 +324,6 @@ definition {
 	@description = "Could not add invalid friendly URL and can access by former friendly URL."
 	@priority = 3
 	test EditSiteFriendlyURLInvalid {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Hello,
The Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on the Acceptance Test Suite.
If you believe any of these tests should not be removed, please let us know so we can update the priority and keep the test running on Acceptance.
Thank you!

https://liferay.atlassian.net/browse/LPD-58384
https://liferay.atlassian.net/browse/LPD-58065