### PR TITLE
LPD-52945 Force show bulk action buttons and fix FDS table styling to have correct padding

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -272,6 +272,9 @@ public class ViewChangesDisplayContext {
 			}
 		}
 
+		bulkActionDropdownItems.forEach(
+			item -> item.putData("highlighted", "true"));
+
 		return bulkActionDropdownItems;
 	}
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_changes.jsp
@@ -54,6 +54,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "review-changes"));
 			id="<%= PublicationsFDSNames.PUBLICATIONS_CHANGES %>"
 			selectedItemsKey="id"
 			selectionType="multiple"
+			style="fluid"
 		/>
 	</aui:form>
 </div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52945

- By default, bulk action dropdown items aren't set to show buttons for. Setting the highlighted properyty to true forces them to appear. Although FDSActionDropdownItem has a `setHighlighted(...)` method, that method returns void instead of the `this` object so  I had to set it in a separate `forEach(...)` instead of chaining.  

  Additionally, the `bulkActionDropdownItems` FDS tag only accepts type DropdownItem so I had to set the "highlighted" property in a more manual way with `.putData(...)`
- I can't recall which ticket or where, but I'm quite certain that I saw a remark or bug description that the Publications FDS table is missing the padding on the left and right of the table. I added the `style="fluid"` in `view_changes.jsp` to correct that. 