### PR TITLE
LPD-60418 API for retrieving sites

### DIFF
--- a/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Site API
 Bundle-SymbolicName: com.liferay.headless.site.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.headless.site.dto.v1_0,\
 	com.liferay.headless.site.resource.v1_0

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
@@ -15,6 +15,8 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -53,6 +55,9 @@ public interface SiteResource {
 
 	public Response getSiteByExternalReferenceCodeSiteInitializer(
 			String externalReferenceCode)
+		throws Exception;
+
+	public Page<Site> getSitesPage(String search, Pagination pagination)
 		throws Exception;
 
 	public Site postSite(Site site) throws Exception;

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
@@ -7,6 +7,8 @@ package com.liferay.headless.site.client.resource.v1_0;
 
 import com.liferay.headless.site.client.dto.v1_0.Site;
 import com.liferay.headless.site.client.http.HttpInvoker;
+import com.liferay.headless.site.client.pagination.Page;
+import com.liferay.headless.site.client.pagination.Pagination;
 import com.liferay.headless.site.client.problem.Problem;
 import com.liferay.headless.site.client.serdes.v1_0.SiteSerDes;
 
@@ -61,6 +63,13 @@ public interface SiteResource {
 	public HttpInvoker.HttpResponse
 			getSiteByExternalReferenceCodeSiteInitializerHttpResponse(
 				String externalReferenceCode)
+		throws Exception;
+
+	public Page<Site> getSitesPage(String search, Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSitesPageHttpResponse(
+			String search, Pagination pagination)
 		throws Exception;
 
 	public Site postSite(Site site) throws Exception;
@@ -598,6 +607,120 @@ public interface SiteResource {
 						"/o/headless-site/v1.0/sites/by-external-reference-code/{externalReferenceCode}/site-initializer");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Site> getSitesPage(String search, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse = getSitesPageHttpResponse(
+				search, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SiteSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSitesPageHttpResponse(
+				String search, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
@@ -76,6 +76,38 @@ paths:
                         application/xml: {}
             tags: ["Site"]
     /sites:
+        get:
+            description:
+                Retrieves the sites. Results can be paginated, filtered, searched, and sorted.
+            parameters:
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Site"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Site"
+                                type: array
+                    description:
+                        default response
+            tags: ["Site"]
         post:
             description:
                 Adds a new site

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
@@ -79,6 +79,7 @@ paths:
         get:
             description:
                 Retrieves the sites. Results can be paginated, filtered, searched, and sorted.
+            operationId: getSitesPage
             parameters:
                 -   in: query
                     name: page

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -20,6 +20,8 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -32,6 +34,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -171,6 +174,47 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-site/v1.0/sites'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the sites. Results can be paginated, filtered, searched, and sorted."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/sites")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Site> getSitesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
 	}
 
 	/**

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -148,6 +148,10 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 	public Page<Site> getSitesPage(String search, Pagination pagination)
 		throws Exception {
 
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
 		long[] classNameIds = {
 			_portal.getClassNameId(Company.class.getName()),
 			_portal.getClassNameId(Group.class.getName())

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -103,15 +103,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		Group group = _groupLocalService.getGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
 
-		return new Site() {
-			{
-				setExternalReferenceCode(group::getExternalReferenceCode);
-				setFriendlyUrlPath(group::getFriendlyURL);
-				setId(group::getGroupId);
-				setKey(group::getGroupKey);
-				setName(() -> group.getName(LocaleUtil.getDefault()));
-			}
-		};
+		return _toSite(group);
 	}
 
 	@Override
@@ -170,16 +162,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					contextCompany.getCompanyId(), classNameIds, search, null,
 					params, true, pagination.getStartPosition(),
 					pagination.getEndPosition(), new GroupNameComparator()),
-				group -> new Site() {
-					{
-						setExternalReferenceCode(
-							group::getExternalReferenceCode);
-						setFriendlyUrlPath(group::getFriendlyURL);
-						setId(group::getGroupId);
-						setKey(group::getGroupKey);
-						setName(() -> group.getName(LocaleUtil.getDefault()));
-					}
-				}),
+				group -> _toSite(group)),
 			pagination,
 			_groupService.searchCount(
 				contextCompany.getCompanyId(), classNameIds, search, params));
@@ -199,15 +182,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		try {
 			Group group = _addGroup(site.getExternalReferenceCode(), site);
 
-			return new Site() {
-				{
-					setExternalReferenceCode(group::getExternalReferenceCode);
-					setFriendlyUrlPath(group::getFriendlyURL);
-					setId(group::getGroupId);
-					setKey(group::getGroupKey);
-					setName(() -> group.getName(LocaleUtil.getDefault()));
-				}
-			};
+			return _toSite(group);
 		}
 		catch (Throwable throwable) {
 			throw new Exception(throwable);
@@ -287,15 +262,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 		Group finalGroup = group;
 
-		return new Site() {
-			{
-				setExternalReferenceCode(finalGroup::getExternalReferenceCode);
-				setFriendlyUrlPath(finalGroup::getFriendlyURL);
-				setId(finalGroup::getGroupId);
-				setKey(finalGroup::getGroupKey);
-				setName(() -> finalGroup.getName(LocaleUtil.getDefault()));
-			}
-		};
+		return _toSite(finalGroup);
 	}
 
 	private Group _addGroup(String externalReferenceCode, Site site)
@@ -480,6 +447,18 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			WebKeys.THEME_DISPLAY);
 
 		themeDisplay.setResponse(new DummyHttpServletResponse());
+	}
+
+	private Site _toSite(Group group) {
+		return new Site() {
+			{
+				setExternalReferenceCode(group::getExternalReferenceCode);
+				setFriendlyUrlPath(group::getFriendlyURL);
+				setId(group::getGroupId);
+				setKey(group::getGroupKey);
+				setName(() -> group.getName(LocaleUtil.getDefault()));
+			}
+		};
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -33,12 +34,17 @@ import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.util.comparator.GroupNameComparator;
 import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerFactory;
 import com.liferay.site.initializer.SiteInitializerRegistry;
@@ -50,6 +56,7 @@ import jakarta.ws.rs.core.Response;
 import java.io.File;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -135,6 +142,43 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 			//file.delete();
 		}
+	}
+
+	@Override
+	public Page<Site> getSitesPage(String search, Pagination pagination)
+		throws Exception {
+
+		long[] classNameIds = {
+			_portal.getClassNameId(Company.class.getName()),
+			_portal.getClassNameId(Group.class.getName())
+		};
+
+		LinkedHashMap<String, Object> params =
+			LinkedHashMapBuilder.<String, Object>put(
+				"active", true
+			).put(
+				"site", true
+			).build();
+
+		return Page.of(
+			transform(
+				_groupService.search(
+					contextCompany.getCompanyId(), classNameIds, search, null,
+					params, true, pagination.getStartPosition(),
+					pagination.getEndPosition(), new GroupNameComparator()),
+				group -> new Site() {
+					{
+						setExternalReferenceCode(
+							group::getExternalReferenceCode);
+						setFriendlyUrlPath(group::getFriendlyURL);
+						setId(group::getGroupId);
+						setKey(group::getGroupKey);
+						setName(() -> group.getName(LocaleUtil.getDefault()));
+					}
+				}),
+			pagination,
+			_groupService.searchCount(
+				contextCompany.getCompanyId(), classNameIds, search, params));
 	}
 
 	@Override
@@ -442,6 +486,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private SiteInitializerFactory _siteInitializerFactory;

--- a/modules/apps/headless/headless-site/headless-site-test/build.gradle
+++ b/modules/apps/headless/headless-site/headless-site-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.2"
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:headless:headless-site:headless-site-api")
 	testIntegrationImplementation project(":apps:headless:headless-site:headless-site-client")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.site.client.dto.v1_0.Site;
 import com.liferay.headless.site.client.http.HttpInvoker;
 import com.liferay.headless.site.client.pagination.Page;
+import com.liferay.headless.site.client.pagination.Pagination;
 import com.liferay.headless.site.client.resource.v1_0.SiteResource;
 import com.liferay.headless.site.client.serdes.v1_0.SiteSerDes;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -250,6 +252,113 @@ public abstract class BaseSiteResourceTestCase {
 		throws Exception {
 
 		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGetSitesPage() throws Exception {
+		Page<Site> page = siteResource.getSitesPage(null, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		Site site1 = testGetSitesPage_addSite(randomSite());
+
+		Site site2 = testGetSitesPage_addSite(randomSite());
+
+		page = siteResource.getSitesPage(null, Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(site1, (List<Site>)page.getItems());
+		assertContains(site2, (List<Site>)page.getItems());
+		assertValid(page, testGetSitesPage_getExpectedActions());
+
+		siteResource.deleteSite(site1.getId());
+
+		siteResource.deleteSite(site2.getId());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSitesPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSitesPageWithPagination() throws Exception {
+		Page<Site> sitesPage = siteResource.getSitesPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(sitesPage.getTotalCount());
+
+		Site site1 = testGetSitesPage_addSite(randomSite());
+
+		Site site2 = testGetSitesPage_addSite(randomSite());
+
+		Site site3 = testGetSitesPage_addSite(randomSite());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<Site> page1 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(site1, (List<Site>)page1.getItems());
+
+			Page<Site> page2 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(site2, (List<Site>)page2.getItems());
+
+			Page<Site> page3 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(site3, (List<Site>)page3.getItems());
+		}
+		else {
+			Page<Site> page1 = siteResource.getSitesPage(
+				null, Pagination.of(1, totalCount + 2));
+
+			List<Site> sites1 = (List<Site>)page1.getItems();
+
+			Assert.assertEquals(
+				sites1.toString(), totalCount + 2, sites1.size());
+
+			Page<Site> page2 = siteResource.getSitesPage(
+				null, Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<Site> sites2 = (List<Site>)page2.getItems();
+
+			Assert.assertEquals(sites2.toString(), 1, sites2.size());
+
+			Page<Site> page3 = siteResource.getSitesPage(
+				null, Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(site1, (List<Site>)page3.getItems());
+			assertContains(site2, (List<Site>)page3.getItems());
+			assertContains(site3, (List<Site>)page3.getItems());
+		}
+	}
+
+	protected Site testGetSitesPage_addSite(Site site) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -75,7 +75,11 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		Collections.reverse(_sites);
 
 		for (Site site : _sites) {
-			_groupLocalService.deleteGroup(site.getId());
+			Group group = _groupLocalService.fetchGroup(site.getId());
+
+			if (group != null) {
+				_groupLocalService.deleteGroup(site.getId());
+			}
 		}
 
 		PrincipalThreadLocal.setName(_originalName);

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.poshi.core.util.GetterUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
 import java.io.File;
@@ -167,6 +168,82 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	@Override
 	@Test
+	public void testGetSitesPageWithPagination() throws Exception {
+		Page<Site> sitesPage = null;
+
+		try {
+			sitesPage = siteResource.getSitesPage(null, null);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		int totalCount = GetterUtil.getInteger(sitesPage.getTotalCount());
+
+		Site site1 = testGetSitesPage_addSite(randomSite());
+
+		Site site2 = testGetSitesPage_addSite(randomSite());
+
+		Site site3 = testGetSitesPage_addSite(randomSite());
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<Site> page1 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(site1, (List<Site>)page1.getItems());
+
+			Page<Site> page2 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(site2, (List<Site>)page2.getItems());
+
+			Page<Site> page3 = siteResource.getSitesPage(
+				null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(site3, (List<Site>)page3.getItems());
+		}
+		else {
+			Page<Site> page1 = siteResource.getSitesPage(
+				null, Pagination.of(1, totalCount + 2));
+
+			List<Site> sites1 = (List<Site>)page1.getItems();
+
+			Assert.assertEquals(
+				sites1.toString(), totalCount + 2, sites1.size());
+
+			Page<Site> page2 = siteResource.getSitesPage(
+				null, Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<Site> sites2 = (List<Site>)page2.getItems();
+
+			Assert.assertEquals(sites2.toString(), 1, sites2.size());
+
+			Page<Site> page3 = siteResource.getSitesPage(
+				null, Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(site1, (List<Site>)page3.getItems());
+			assertContains(site2, (List<Site>)page3.getItems());
+			assertContains(site3, (List<Site>)page3.getItems());
+		}
+	}
+
+	@Override
+	@Test
 	public void testPostSite() throws Exception {
 		super.testPostSite();
 
@@ -294,8 +371,8 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		Group group = _groupLocalService.getGroup(postSite.getId());
 
-		group.setActive(active);
 		group.setSite(site);
+		group.setActive(active);
 
 		_groupLocalService.updateGroup(group);
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -6,7 +6,11 @@
 package com.liferay.headless.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.site.client.dto.v1_0.Site;
+import com.liferay.headless.site.client.pagination.Page;
+import com.liferay.headless.site.client.pagination.Pagination;
 import com.liferay.headless.site.client.problem.Problem;
 import com.liferay.headless.site.client.resource.v1_0.SiteResource;
 import com.liferay.petra.string.StringPool;
@@ -19,7 +23,9 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -28,6 +34,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.site.initializer.SiteInitializer;
 
@@ -145,6 +152,19 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		throws Exception {
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Override
+	@Test
+	public void testGetSitesPage() throws Exception {
+		super.testGetSitesPage();
+
+		_testGetSitesPageWithActiveOrSiteGroups(false, true);
+		_testGetSitesPageWithActiveOrSiteGroups(true, false);
+		_testGetSitesPageWithDepotEntry();
+		_testGetSitesPageWithSearch();
+		_testGetSitesPageWithoutAuthentication();
+	}
+
 	@Override
 	@Test
 	public void testPostSite() throws Exception {
@@ -211,6 +231,15 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	}
 
 	@Override
+	protected Site testGetSitesPage_addSite(Site site) throws Exception {
+		Site postSite = siteResource.postSite(site);
+
+		_sites.add(postSite);
+
+		return postSite;
+	}
+
+	@Override
 	protected Site testPostFormDataSite_addSite(
 			Site site, Map<String, File> multipartFiles)
 		throws Exception {
@@ -250,6 +279,85 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		assertEquals(postSite, getSite);
 		assertValid(getSite);
+	}
+
+	private void _testGetSitesPageWithActiveOrSiteGroups(
+			boolean active, boolean site)
+		throws Exception {
+
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			null, Pagination.of(1, 100));
+
+		List<Site> originalItems = (List<Site>)sitesPage.getItems();
+
+		Site postSite = testGetSitesPage_addSite(randomSite());
+
+		Group group = _groupLocalService.getGroup(postSite.getId());
+
+		group.setActive(active);
+		group.setSite(site);
+
+		_groupLocalService.updateGroup(group);
+
+		sitesPage = siteResource.getSitesPage(null, Pagination.of(1, 100));
+
+		List<Site> existingItems = (List<Site>)sitesPage.getItems();
+
+		Assert.assertEquals(originalItems, existingItems);
+	}
+
+	private void _testGetSitesPageWithDepotEntry() throws Exception {
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			null, Pagination.of(1, 100));
+
+		List<Site> originalItems = (List<Site>)sitesPage.getItems();
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, ServiceContextTestUtil.getServiceContext());
+
+		sitesPage = siteResource.getSitesPage(null, Pagination.of(1, 100));
+
+		List<Site> existingItems = (List<Site>)sitesPage.getItems();
+
+		Assert.assertEquals(originalItems, existingItems);
+	}
+
+	private void _testGetSitesPageWithoutAuthentication() throws Exception {
+		SiteResource.Builder builder = SiteResource.builder();
+
+		SiteResource siteResource = builder.build();
+
+		try {
+			siteResource.getSitesPage(null, Pagination.of(1, 1));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("403", problem.getStatus());
+		}
+	}
+
+	private void _testGetSitesPageWithSearch() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		Site randomSite = new Site();
+
+		randomSite.setName(name);
+
+		Site postSite = _testPostSite_addSite(randomSite);
+
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			name, Pagination.of(1, 10));
+
+		List<Site> items = (List<Site>)sitesPage.getItems();
+
+		Assert.assertEquals(items.toString(), 1, items.size());
+
+		assertEquals(postSite, items.get(0));
 	}
 
 	private Site _testPostSite_addSite(Site site) throws Exception {
@@ -605,6 +713,12 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	private static final String _CLASS_NAME_EXCEPTION_MAPPER =
 		"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 			"ExceptionMapper";
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
APIs for retrieving sites

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-60418)

For the new CMS we need an endpoint to retrieve sites so that we can assign them to the spaces

# What am I doing?

This is a very simple API, it receives only the search and pagination parameters and calls the search method accordingly. We added only company class name (because of global site) and group class names for the search. Only active and sites are shown.

The results are retrieved by the name comparator.

We have added it under the FF for the CMS: LPD-17564 

# How can you verify that it works?

There are several tests provided
