### PR TITLE
LPD-61746 Create integration test to ensure that Display Page Templates appear in the Sitemap when XML index is enabled

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -419,7 +419,7 @@ public class SitemapManagerTest {
 			_setUpAssetCategoryDisplayPage();
 
 			_assertSitemap(
-				_group.getGroupId(), _layout.getUuid(),
+				true, _group.getGroupId(), _layout.getUuid(),
 				_getExpectedAssetCategoryUrls());
 		}
 	}
@@ -474,6 +474,52 @@ public class SitemapManagerTest {
 			childLayout.getUuid());
 		_testEmptySitemapIncludePagesCompanyEnabledGroupEnabled(
 			grandChildLayout.getUuid());
+	}
+
+	@Test
+	public void testSitemapIncludeLayoutPageTemplateEntryWithXMLSitemapIndexEnabled()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).build())) {
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+					_group.getGroupId(),
+					_portal.getClassNameId(JournalArticle.class.getName()), 0,
+					true, WorkflowConstants.STATUS_APPROVED);
+
+			Layout layout = _layoutLocalService.getLayout(
+				layoutPageTemplateEntry.getPlid());
+
+			String[] urls = {
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _portal.getPathContext(),
+					"/sitemap.xml?p_l_id=", _layout.getPlid(), "&layoutUuid=",
+					_layout.getUuid(), "&groupId=", _group.getGroupId(),
+					"&privateLayout=", _layout.isPrivateLayout()),
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _portal.getPathContext(),
+					"/sitemap.xml?p_l_id=", layout.getPlid(), "&layoutUuid=",
+					layout.getUuid(), "&groupId=", _group.getGroupId(),
+					"&privateLayout=", layout.isPrivateLayout())
+			};
+
+			_assertSitemap(false, _group.getGroupId(), StringPool.BLANK, urls);
+		}
 	}
 
 	@Test
@@ -740,7 +786,7 @@ public class SitemapManagerTest {
 				assetDisplayPageEntry.getPlid());
 
 			_assertSitemap(
-				_group.getGroupId(), layout.getUuid(),
+				true, _group.getGroupId(), layout.getUuid(),
 				_portal.getCanonicalURL(
 					StringBundler.concat(
 						_portal.getGroupFriendlyURL(
@@ -805,7 +851,8 @@ public class SitemapManagerTest {
 				uuid, _group.getGroupId(), false, _themeDisplay));
 	}
 
-	private void _assertSitemap(long groupId, String uuid, String... urls)
+	private void _assertSitemap(
+			boolean encodeURL, long groupId, String uuid, String... urls)
 		throws Exception {
 
 		String xml = _sitemapManager.getSitemap(
@@ -820,8 +867,11 @@ public class SitemapManagerTest {
 		Assert.assertEquals(elements.toString(), urls.length, elements.size());
 
 		for (String url : urls) {
-			Assert.assertNotNull(
-				_getLocElement(elements, _sitemapManager.encodeXML(url)));
+			if (encodeURL) {
+				url = _sitemapManager.encodeXML(url);
+			}
+
+			Assert.assertNotNull(_getLocElement(elements, url));
 		}
 	}
 
@@ -890,7 +940,9 @@ public class SitemapManagerTest {
 
 	private Element _getLocElement(List<Element> elements, String url) {
 		for (Element element : elements) {
-			if (!Objects.equals(element.getName(), "url")) {
+			if (!Objects.equals(element.getName(), "sitemap") &&
+				!Objects.equals(element.getName(), "url")) {
+
 				continue;
 			}
 
@@ -1026,7 +1078,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertSitemap(guestGroupId, null, urls);
+			_assertSitemap(true, guestGroupId, null, urls);
 		}
 	}
 
@@ -1126,7 +1178,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertSitemap(groupId, uuid, urls);
+			_assertSitemap(true, groupId, uuid, urls);
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61746

# How am I fixing it?

This test provides coverage for LPS-108211. This area of code came up in LPP-59743 where it was suggest to switch from using `getAllLayouts` to `getLayouts`. If this change is made then LPS-108211 is undone but all the tests still pass. Now, this new test will fail if that change is made.

# How can you verify that it works?

In `site-test` run `gw testIntegration --tests *.SitemapManagerTest`