### PR TITLE
LPD-62357 Analyze test failure com.liferay.layout.portlet.test.LayoutFriendlyURLSeparatorCompositeTest

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/build.gradle
+++ b/modules/apps/friendly-url/friendly-url-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-taglib")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-test-util")
 	testIntegrationImplementation project(":apps:journal:journal-api")
+	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
@@ -10,11 +10,14 @@ import com.liferay.friendly.url.test.util.configuration.manager.FriendlyURLSepar
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.LayoutFriendlyURLSeparatorComposite;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -29,6 +32,7 @@ import java.util.HashMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +51,13 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
 
+	@BeforeClass
+	public static void setUpClass() {
+		ReflectionTestUtil.setFieldValue(
+			FriendlyURLResolverRegistryUtil.class, "_urlSeparators",
+			_urlSeparators);
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
@@ -58,6 +69,8 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 	@After
 	public void tearDown() throws Exception {
 		ServiceContextThreadLocal.popServiceContext();
+
+		_urlSeparators.remove();
 	}
 
 	@Test
@@ -118,6 +131,11 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 			urlSeparator,
 			layoutFriendlyURLSeparatorComposite.getURLSeparator());
 	}
+
+	private static final ThreadLocal<String[]> _urlSeparators =
+		new CentralizedThreadLocal<>(
+			FriendlyURLResolverRegistryUtil.class.getName() +
+				"._urlSeparators");
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.layout.portlet.test;
+package com.liferay.friendly.url.portlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.friendly.url.test.util.configuration.manager.FriendlyURLSeparatorConfigurationManagerTemporarySwapper;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62357

# How am I fixing it?

This test was part of the Page's team test routine and they have now moved it to ours. Additionally, this test was failing due to the changes in LPD-61064.

# How can you verify that it works?

In `friendly-url-test` run `gw testIntegration --tests *.LayoutFriendlyURLSeparatorCompositeTest`