### PR TITLE
LPD-62998 Fix flaky test redirect-web/main/redirectAlias.spec.ts > Ensure redirect entry can be deleted

### DIFF
--- a/modules/test/playwright/pages/redirect-web/RedirectPage.ts
+++ b/modules/test/playwright/pages/redirect-web/RedirectPage.ts
@@ -58,7 +58,7 @@ export class RedirectPage {
 
 		await this.createButton.click();
 
-		await this.page.getByText(sourceURL).waitFor();
+		await waitForAlert(this.page);
 	}
 
 	async addRedirectPattern(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62998

# How am I fixing it?

In this test it first adds a redirect and then tries to delete it. When adding, an alert is produced but never cleared. When it is deleted, it tries to clear the alert message but since the alert from adding still exists it fails since it believes it never cleared the alert.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'redirectAlias.spec.ts'`