### PR TITLE
LPD-62284 Correct Sort Order

### DIFF
--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/asset-list-entries.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/asset-list-entries.json
@@ -17,7 +17,7 @@
 				},
 				{
 					"key": "orderByType1",
-					"value": "ASC"
+					"value": "DESC"
 				},
 				{
 					"key": "orderByType2",


### PR DESCRIPTION
As discussed on Slack: A minor change. This changes the sort order for the "Blog" accounts, so that newer articles - once created after the site initializer ran - appear on top and visible, rather than at the bottom of the list.