### PR TITLE
LPD-64149 Update locator to correctly click on checkbox

### DIFF
--- a/modules/test/playwright/tests/site-navigation-admin-web/main/itemAddition.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/itemAddition.spec.ts
@@ -602,7 +602,7 @@ test(
 
 		await page.getByText(pageName1).click();
 
-		await page.getByLabel('Use Custom Name When checked').check();
+		await page.getByText('Use Custom Name').check();
 
 		const pageName3 = getRandomString();
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64149

# How am I fixing it?

The test was unable to click on the checkbox so the locator has been udpated.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'Rename Page type Navigation Menu Item'`