### PR TITLE
LPD-66278 Delegate the initial creation of the site to 'putSiteByExternalReferenceCode'

### DIFF
--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -207,8 +207,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 	public Site postSiteSiteInitializer(MultipartBody multipartBody)
 		throws Exception {
 
-		Site site = postSite(
-			multipartBody.getValueAsInstance("site", Site.class));
+		Site site = multipartBody.getValueAsInstance("site", Site.class);
 
 		return putSiteByExternalReferenceCode(
 			site.getExternalReferenceCode(), multipartBody);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66278

# How am I fixing it?

With the changes made in LPD-64145, a bug was fixed where `putSiteByExternalReferenceCode` tried to run the Site Initializer on a site that as already initialized.

Unfortunately, `postSiteSiteInitializer` relied on this bug in order to work properly and so a regression was created. This method first created the site and then initialized it. Since it happened in two separate calls, the `putSiteByExternalReferenceCode` saw that the group already existed and did not run the initializer.

With the current changes the creation of the group and its initialization happens in the same method to avoid returning early.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'formWithTranslation.spec.ts'`