### PR TITLE
LPP-60902 Update relationship fetch to use ERC instead of name

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -3472,9 +3472,9 @@ public class BundleSiteInitializer implements SiteInitializer {
 			com.liferay.object.model.ObjectRelationship
 				existingObjectRelationship =
 					_objectRelationshipLocalService.
-						fetchObjectRelationshipByObjectDefinitionId1(
-							objectRelationship.getObjectDefinitionId1(),
-							objectRelationship.getName());
+						fetchObjectRelationshipByExternalReferenceCode(
+							objectRelationship.getExternalReferenceCode(),
+							objectRelationship.getObjectDefinitionId1());
 
 			if (existingObjectRelationship == null) {
 				objectRelationshipResource.


### PR DESCRIPTION
Hello team,

This PR is regarding a change required to ensure the client extension from [LPP-60902](https://liferay.atlassian.net/browse/LPP-60902) works properly.

## Problem Background

The client reported a race condition occurring during the execution of the attached client extension (site-initializer).  

When an Object Layout references a relationship that is defined separately from the object definition file, the following happens:

- The initializer attempts to create the layout before the relationship field exists.  
- As a result, initialization fails with a `NoSuchObjectFieldException`, indicating that the referenced field could not be found.  

This issue was reproduced both on the client’s tag **2025.Q2.10** and on **master**.

## Root Cause

The provided configuration (`sample-obj-two.json`) defined a layout that referenced the relationship field `r_sampSampleTwoRel_c_Id`, but the relationship itself was not declared in the same file.  

Because the Site Initializer processes files sequentially without guaranteeing execution order across different files, the layout was created before the relationship, leading to the exception.  

## Solution

The fix was applied in two parts:

1. **Configuration Fix**  
   The `sample-obj-two.json` file was adjusted so that the relationship field definition is included in the same file as the layout that references it.  
   This ensures the field is created before the layout is processed, preventing the race condition.

2. **Implementation Fix**  
   An update was made to `BundleSiteInitializer._addOrUpdateObjectRelationships`, so that object relationships are now fetched using their **external reference code (ERC)** instead of the name.  
   This change has been proposed to the **site-management team**, since they are the owners of the `site-initializer-extender` module.


## Reproducing the Issue with Broken `objlayout.zip`

The steps to reproduce the issue on 2025.Q2.10 and on master differ due to differences in how `client-extension.yaml` is processed depending on the version.

### Steps to Reproduce (2025.Q2.10)

1. Download the file `objlayout.zip` from [LPP-60902](https://liferay.atlassian.net/browse/LPP-60902) and unzip it.
2. Open a bash command line and navigate to the testit folder inside the extracted files.
3. Since this is a git repository, switch to the layout branch using: `git checkout layout`
4. Run `gw deploy`. This will generate the file `bundles/osgi/client-extensions/sample-site-initializer.zip` inside the testit folder.
5. Spin up a vanilla Liferay portal on the **2025.Q2.10** tag using a MySQL database.
6. Copy the generated `bundles/osgi/client-extensions/sample-site-initializer.zip` from `testit` and paste it into the portal build directory under `/osgi/client-extensions`.

Desired Behavior

- The object definitions, relationships, and layout are created successfully without errors.

Current Behavior

- The initialization fails with errors such as:
	```bash
	2025-09-22 20:58:22.228 ERROR [fileinstall-directory-watcher][BundleSiteInitializer:540] 
	java.lang.RuntimeException: com.liferay.object.exception.NoSuchObjectFieldException: 
	No ObjectField exists with the key ...
	```


### Steps to Reproduce (Master)

1. Download the file `objlayout.zip` from [LPP-60902](https://liferay.atlassian.net/browse/LPP-60902) and unzip it.
2. Inside the extracted folder, open the file `client-extensions/sample-site-initializer/client-extension.yaml` and update it with the following content:
	```yaml
	samplesite-initializer:
	    name: Sample.COM Site Initializer
	    oAuthApplicationHeadlessServer: sample-site-initializer-oauth-application-headless-server
	    siteExternalReferenceCode: sample
	    siteName:
	        en_US: Sample.COM
	    type: siteInitializer
	sample-site-initializer-oauth-application-headless-server:
	    .serviceAddress: localhost:8080
	    .serviceScheme: http
	    name: Sample.COM Site Initializer CX
	    scopes:
	        -   Liferay.Headless.Site.everything
	        -   Liferay.Headless.Admin.User.everything
	    type: oAuthApplicationHeadlessServer
	```
	> Note: On master, the Site Initializer parses this YAML into JSON using a **localized** `siteName`, whereas in 2025.Q2.10 the YAML is parsed as a plain string. This difference is why the updated format is required for master testing.
3. Open a bash command line and navigate to the `testit` folder inside the extracted files.
4. Since this is a git repository, switch to the layout branch using: `git checkout layout`
5. Run `gw deploy`. This will generate the file `bundles/osgi/client-extensions/sample-site-initializer.zip` inside the `testit` folder.
6. Spin up a vanilla Liferay portal on the **2025.Q2.10** tag using a MySQL database.
7. Copy the generated `bundles/osgi/client-extensions/sample-site-initializer.zip` from `testit` and paste it into the portal build directory under `/osgi/client-extensions`.

Desired Behavior

- The object definitions, relationships, and layout are created successfully without errors.

Current Behavior

- The initialization fails with errors such as:
	```bash
	2025-09-22 20:58:22.228 ERROR [fileinstall-directory-watcher][BundleSiteInitializer:540] 
	java.lang.RuntimeException: com.liferay.object.exception.NoSuchObjectFieldException: 
	No ObjectField exists with the key ...
	```
## Testing Proposed PR Fix with Corrected `objlayout-corrected.zip`

1. Deploy the proposed PR fix on the Liferay portal version you intend to test (2025.Q2.10 or master).
2. In the reproduction steps, use the corrected file `objlayout-corrected.zip` instead of the original `objlayout.zip`.
3. Follow the remaining reproduction steps as described previously.
4. Start the portal and monitor the server logs for errors.

Verify that:

- Object definitions are created successfully.
- Object relationships are correctly established.
- Object layouts reference the relationship fields without errors.

Expected Result:
- All objects, relationships, and layouts are created automatically during Site Initializer execution without any NoSuchObjectFieldException or race-condition-related errors.