### PR TITLE
LPD-83775 Add missing icons to CMS Categorization dropdown menus

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
@@ -179,7 +179,7 @@ public class ViewCategoriesDisplayContext {
 								_themeDisplay),
 							"parentCategoryId", "{id}", "vocabularyId",
 							"{taxonomyVocabularyId}"),
-						null, "add-subcategory",
+						"plus", "add-subcategory",
 						_language.get(_httpServletRequest, "add-subcategory"),
 						"get", "update", null),
 					new FDSActionDropdownItem(
@@ -191,7 +191,7 @@ public class ViewCategoriesDisplayContext {
 								_themeDisplay),
 							"categoryId", "{id}", "vocabularyId",
 							"{taxonomyVocabularyId}"),
-						null, "view-categories",
+						"categories", "view-categories",
 						_language.get(
 							_httpServletRequest, "view-subcategories"),
 						"get", null, null),
@@ -203,7 +203,7 @@ public class ViewCategoriesDisplayContext {
 									"/categorization/view-category-usages"),
 								_themeDisplay),
 							"categoryId", "{id}"),
-						null, "view-category-usages",
+						"list-ul", "view-category-usages",
 						_language.get(_httpServletRequest, "view-usages"),
 						"get", null, null))
 			).setSeparator(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
@@ -106,7 +106,7 @@ public class ViewVocabulariesDisplayContext {
 									"/categorization/view-categories"),
 								_themeDisplay),
 							"vocabularyId", "{id}"),
-						null, "view-categories",
+						"categories", "view-categories",
 						LanguageUtil.get(
 							_httpServletRequest, "view-categories"),
 						"get", null, null))

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -261,7 +261,7 @@ export default function ViewTags({
 						data: {
 							permissionKey: 'get',
 						},
-						icon: 'null',
+						icon: 'list-ul',
 						id: 'viewUsages',
 						label: Liferay.Language.get('view-usages'),
 					},


### PR DESCRIPTION
## Summary
- Add missing icons to dropdown menu items in CMS Categorization views
- Vocabulary menu: added `categories` icon for "View Categories"
- Category menu: added `plus` icon for "Add Subcategory", `categories` icon for "View Subcategories", `list-ul` icon for "View Usages"
- Tags menu: fixed `'null'` string icon to `list-ul` for "View Usages"

## Test plan
- [ ] Navigate to CMS > Categorization > Vocabularies, click three-dot menu on a vocabulary — "View Categories" should show an icon
- [ ] Navigate to a vocabulary's categories, click three-dot menu on a category — "Add Subcategory", "View Subcategories", and "View Usages" should all show icons
- [ ] Navigate to CMS > Categorization > Tags, click three-dot menu on a tag — "View Usages" should show an icon

Fix for CMS 2.0 Bug Board.