### PR TITLE
LPD-80287 Add text-uppercase to Enterprise badge

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/EnterpriseFeatureIndicator.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/EnterpriseFeatureIndicator.tsx
@@ -56,7 +56,9 @@ export default function EnterpriseFeatureIndicator({
 
 		return (
 			<ClayButton {...props} ref={ref} style={styles} translucent>
-				<span>{Liferay.Language.get('enterprise')}</span>
+				<span className="text-uppercase">
+					{Liferay.Language.get('enterprise')}
+				</span>
 
 				<ClayIcon className="ml-2" symbol="crown" />
 			</ClayButton>


### PR DESCRIPTION
## Summary
- Add `text-uppercase` CSS class to the Enterprise badge text in `EnterpriseFeatureIndicator` component
- Matches the pattern already used in `EnterpriseOnlyPlaceholder` which uses `text-uppercase` on its badge

## Test plan
- [ ] Navigate to CMS Dashboard (free tier) — Enterprise badge should display in uppercase
- [ ] Check CMS "Get More With Enterprise" banner — badge should be uppercase
- [ ] Check CMS "Customize Editor" feature indicator — badge should be uppercase

Fix for CMS 2.0 Bug Board.