### PR TITLE
LPD-83667 Use consistent status label colors in CMS usages views

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/CategoryUsagesCMSTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/CategoryUsagesCMSTableFDSView.java
@@ -50,7 +50,7 @@ public class CategoryUsagesCMSTableFDSView extends BaseCMSTableFDSView {
 		).add(
 			"embedded.status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"status")
+				"statusTableCellRenderer")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/StructureUsagesCMSTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/StructureUsagesCMSTableFDSView.java
@@ -52,7 +52,7 @@ public class StructureUsagesCMSTableFDSView extends BaseCMSTableFDSView {
 		).add(
 			"embedded.status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"status")
+				"statusTableCellRenderer")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/TagUsagesCMSTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/TagUsagesCMSTableFDSView.java
@@ -50,7 +50,7 @@ public class TagUsagesCMSTableFDSView extends BaseCMSTableFDSView {
 		).add(
 			"embedded.status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"status")
+				"statusTableCellRenderer")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/CategoryUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/CategoryUsagesFDSPropsTransformer.ts
@@ -5,6 +5,7 @@
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
 
+import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
@@ -31,6 +32,11 @@ export default function CategoryUsagesFDSPropsTransformer({
 								getScopeExternalReferenceCode(itemData),
 						}),
 					name: 'spaceTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: ({value}) => StatusLabel(value),
+					name: 'statusTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,
 			],

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
@@ -5,6 +5,7 @@
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
 
+import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
@@ -37,6 +38,11 @@ export default function StructureUsagesFDSPropsTransformer({
 				{
 					component: TypeRenderer,
 					name: 'typeTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: ({value}) => StatusLabel(value),
+					name: 'statusTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,
 			],

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/TagUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/TagUsagesFDSPropsTransformer.ts
@@ -5,6 +5,7 @@
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
 
+import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
@@ -31,6 +32,11 @@ export default function TagUsagesFDSPropsTransformer({
 								getScopeExternalReferenceCode(itemData),
 						}),
 					name: 'spaceTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: ({value}) => StatusLabel(value),
+					name: 'statusTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,
 			],


### PR DESCRIPTION
## Summary
- Structure, category, and tag usages views used the default FDS `status` renderer which has different colors than the custom `StatusLabel` component used in the assets list
- Changed the three usages table views to use `statusTableCellRenderer` and registered the custom renderer in their props transformers
- This ensures Draft, Published, Expired, etc. status labels use the same colors across all CMS screens

## Test plan
- [ ] Go to CMS > Content Structures > three-dot menu on "Basic Web Content" > View Usages — status labels should match the colors in the All/Content views
- [ ] Go to CMS > Categorization > Vocabularies > View Categories > three-dot menu on a category > View Usages — same consistency check
- [ ] Go to CMS > Categorization > Tags > three-dot menu on a tag > View Usages — same consistency check

Fix for CMS 2.0 Bug Board.