### PR TITLE
LPD-83001 Make tag names clickable to open edit modal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -4,6 +4,7 @@
  */
 
 import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayLink from '@clayui/link';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import {navigate, sub} from 'frontend-js-web';
 import React, {ComponentProps} from 'react';
@@ -35,6 +36,7 @@ export default function ViewTags({
 	tagsURL: string;
 	vocabulariesURL: string;
 }) {
+	const NAME_TABLE_CELL_RENDERER_NAME = 'NameTableCellRenderer';
 	const VIEWS_SPACE_TABLE_CELL_RENDERER_NAME = 'ViewsSpaceTableCellRenderer';
 
 	const creationMenu = {
@@ -83,6 +85,7 @@ export default function ViewTags({
 			schema: {
 				fields: [
 					{
+						contentRenderer: NAME_TABLE_CELL_RENDERER_NAME,
 						fieldName: 'name',
 						label: Liferay.Language.get('title'),
 						sortable: true,
@@ -237,6 +240,35 @@ export default function ViewTags({
 				creationMenu={creationMenu}
 				customRenderers={{
 					tableCell: [
+						{
+							component: ({
+								itemData,
+								loadData,
+								value,
+							}: {
+								itemData: any;
+								loadData: () => {};
+								value: string;
+							}) => (
+								<div className="table-list-title">
+									<ClayLink
+										data-senna-off
+										href="#"
+										onClick={(
+											event: React.MouseEvent
+										) => {
+											event.preventDefault();
+
+											editTag({itemData, loadData});
+										}}
+									>
+										{value}
+									</ClayLink>
+								</div>
+							),
+							name: NAME_TABLE_CELL_RENDERER_NAME,
+							type: 'internal',
+						},
 						{
 							component: MultipleSpacesRenderer,
 							name: VIEWS_SPACE_TABLE_CELL_RENDERER_NAME,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -254,9 +254,7 @@ export default function ViewTags({
 									<ClayLink
 										data-senna-off
 										href="#"
-										onClick={(
-											event: React.MouseEvent
-										) => {
+										onClick={(event: React.MouseEvent) => {
 											event.preventDefault();
 
 											editTag({itemData, loadData});


### PR DESCRIPTION
## Summary
- Add a custom name renderer to the CMS Tags table that makes tag names clickable
- Clicking a tag name opens the Edit Tag modal, consistent with how category names work
- Uses the existing `editTag` function that is already wired to the dropdown "Edit" action

## Test plan
- [ ] Go to CMS > Categorization > Tags
- [ ] Click on a tag name — Edit Tag modal should open
- [ ] Verify the modal allows editing the tag and saves correctly
- [ ] Verify the dropdown "Edit" action still works as before

Fix for CMS 2.0 Bug Board.