### PR TITLE
LPD-83765 Prevent text selection during FDS column resize

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -529,10 +529,14 @@ function HeadCellResizer({
 	}, [columnName, resizeColumn, updateDraggingColumnName]);
 
 	function initializeDrag() {
+		document.body.style.userSelect = 'none';
+
 		window.addEventListener('mousemove', handleDrag);
 		window.addEventListener(
 			'mouseup',
 			() => {
+				document.body.style.userSelect = '';
+
 				updateDraggingAllowed(true);
 				updateDraggingColumnName(null);
 				window.removeEventListener('mousemove', handleDrag);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -529,13 +529,15 @@ function HeadCellResizer({
 	}, [columnName, resizeColumn, updateDraggingColumnName]);
 
 	function initializeDrag() {
+		const originalUserSelect = document.body.style.userSelect;
+
 		document.body.style.userSelect = 'none';
 
 		window.addEventListener('mousemove', handleDrag);
 		window.addEventListener(
 			'mouseup',
 			() => {
-				document.body.style.userSelect = '';
+				document.body.style.userSelect = originalUserSelect;
 
 				updateDraggingAllowed(true);
 				updateDraggingColumnName(null);


### PR DESCRIPTION
## Summary
- Set `user-select: none` on the document body when column resize starts
- Remove it on mouseup when resize ends
- Prevents text under the cursor from being highlighted during column resize drag

## Test plan
- [ ] Go to any CMS table view (e.g., All Spaces, Contents list, Files list)
- [ ] Resize a column by dragging the column border
- [ ] Verify text in adjacent columns is NOT highlighted during the drag
- [ ] Verify text selection works normally after releasing the mouse

Fix for CMS 2.0 Bug Board.