### PR TITLE
LPD-69463 Fix ARIA role violations in CMS info panel tabs

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/AssetTypeInfoPanelFilesView.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/AssetTypeInfoPanelFilesView.tsx
@@ -41,7 +41,11 @@ const AssetTypeInfoPanelFilesView = () => {
 							<Tabs.Item
 								active={active >= MAIN_TABS.length}
 								innerProps={{
-									'aria-controls': 'tabpanel-4',
+									'aria-controls': `tabpanel-${
+										active >= MAIN_TABS.length
+											? ALL_TABS[active]?.id
+											: DROPDOWN_TABS[0]?.id
+									}`,
 								}}
 							>
 								{Liferay.Language.get('more')}
@@ -62,7 +66,6 @@ const AssetTypeInfoPanelFilesView = () => {
 									active={active === tabIndex}
 									key={tab.id}
 									onClick={() => setActive(tabIndex)}
-									role="tab"
 								>
 									{tab.name}
 								</DropDown.Item>


### PR DESCRIPTION
## Summary
- Remove invalid `role="tab"` from dropdown menu items in the info panel "More" tab dropdown — dropdown items should not have tab roles as they are not inside a tablist
- Fix hardcoded `aria-controls="tabpanel-4"` on the "More" tab trigger to dynamically reference the correct tab panel ID

## Test plan
- [ ] Go to CMS > Files, select a file, click three-dot menu > Show Details
- [ ] Run axe DevTools scan (best practices OFF)
- [ ] Verify "Certain ARIA roles must contain particular children" issue is resolved
- [ ] Verify "Ensure all ARIA attributes have valid values" issue is resolved
- [ ] Verify tab navigation still works correctly (Details, Categorization, Performance, More > Versions/Comments)

Fix for CMS 2.0 Bug Board.