### PR TITLE
LPD-83746 Add tooltip to task status button in control menu

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/BulkActionsMonitor.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/BulkActionsMonitor.tsx
@@ -312,13 +312,14 @@ function BulkActionsMonitor() {
 			trigger={
 				<div>
 					<ClayButtonWithIcon
-						aria-label={Liferay.Language.get('task-status-toggle')}
+						aria-label={Liferay.Language.get('task-status')}
 						borderless
 						className={classnames('task-status-toggle', {
 							'task-status-toggle-show': !processingTasks,
 						})}
 						displayType="secondary"
 						symbol="forms"
+						title={Liferay.Language.get('task-status')}
 					/>
 
 					{processingTasks > 0 ? (


### PR DESCRIPTION
## Summary
- Add `title` prop to the task status toggle `ClayButtonWithIcon` so a tooltip appears on hover
- Also cleaned up the aria-label from "task-status-toggle" to "task-status" for better screen reader experience

## Test plan
- [ ] Trigger a bulk action in CMS (e.g., bulk delete from recycle bin)
- [ ] After the task completes, hover over the task status button (forms icon) in the control menu
- [ ] Verify a "Task Status" tooltip appears on hover

Fix for CMS 2.0 Bug Board.