### PR TITLE
LPD-84671 Add methods to update CTEntry without triggering reindex

### DIFF
--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalService.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalService.java
@@ -331,6 +331,9 @@ public interface CTEntryLocalService
 	public boolean hasUnpublishedCTEntries(
 		long modelClassNameId, long modelClassPK, int changeType);
 
+	public CTEntry updateChangeType(long ctEntryId, int changeType)
+		throws PortalException;
+
 	/**
 	 * Updates the ct entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -344,8 +347,11 @@ public interface CTEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public CTEntry updateCTEntry(CTEntry ctEntry);
 
-	public CTEntry updateModelMvccVersion(
-		long ctEntryId, long modelMvccVersion);
+	public CTEntry updateModelMvccVersion(long ctEntryId, long modelMvccVersion)
+		throws PortalException;
+
+	public CTEntry updateUserId(long ctEntryId, long userId)
+		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-200155549
+// LIFERAY-SERVICE-BUILDER-HASH:-268891446

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
@@ -403,7 +403,9 @@ public class CTEntryLocalServiceUtil {
 			modelClassNameId, modelClassPK, changeType);
 	}
 
-	public static CTEntry updateChangeType(long ctEntryId, int changeType) {
+	public static CTEntry updateChangeType(long ctEntryId, int changeType)
+		throws PortalException {
+
 		return getService().updateChangeType(ctEntryId, changeType);
 	}
 
@@ -422,12 +424,15 @@ public class CTEntryLocalServiceUtil {
 	}
 
 	public static CTEntry updateModelMvccVersion(
-		long ctEntryId, long modelMvccVersion) {
+			long ctEntryId, long modelMvccVersion)
+		throws PortalException {
 
 		return getService().updateModelMvccVersion(ctEntryId, modelMvccVersion);
 	}
 
-	public static CTEntry updateUserId(long ctEntryId, long userId) {
+	public static CTEntry updateUserId(long ctEntryId, long userId)
+		throws PortalException {
+
 		return getService().updateUserId(ctEntryId, userId);
 	}
 
@@ -440,4 +445,4 @@ public class CTEntryLocalServiceUtil {
 			CTEntryLocalServiceUtil.class, CTEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1850296377
+// LIFERAY-SERVICE-BUILDER-HASH:-968130037

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
@@ -403,6 +403,10 @@ public class CTEntryLocalServiceUtil {
 			modelClassNameId, modelClassPK, changeType);
 	}
 
+	public static CTEntry updateChangeType(long ctEntryId, int changeType) {
+		return getService().updateChangeType(ctEntryId, changeType);
+	}
+
 	/**
 	 * Updates the ct entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -423,6 +427,10 @@ public class CTEntryLocalServiceUtil {
 		return getService().updateModelMvccVersion(ctEntryId, modelMvccVersion);
 	}
 
+	public static CTEntry updateUserId(long ctEntryId, long userId) {
+		return getService().updateUserId(ctEntryId, userId);
+	}
+
 	public static CTEntryLocalService getService() {
 		return _serviceSnapshot.get();
 	}
@@ -432,4 +440,4 @@ public class CTEntryLocalServiceUtil {
 			CTEntryLocalServiceUtil.class, CTEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:388473024
+// LIFERAY-SERVICE-BUILDER-HASH:1850296377

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
@@ -470,7 +470,8 @@ public class CTEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry updateChangeType(
-		long ctEntryId, int changeType) {
+			long ctEntryId, int changeType)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _ctEntryLocalService.updateChangeType(ctEntryId, changeType);
 	}
@@ -494,7 +495,8 @@ public class CTEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry updateModelMvccVersion(
-		long ctEntryId, long modelMvccVersion) {
+			long ctEntryId, long modelMvccVersion)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _ctEntryLocalService.updateModelMvccVersion(
 			ctEntryId, modelMvccVersion);
@@ -502,7 +504,8 @@ public class CTEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry updateUserId(
-		long ctEntryId, long userId) {
+			long ctEntryId, long userId)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _ctEntryLocalService.updateUserId(ctEntryId, userId);
 	}
@@ -525,4 +528,4 @@ public class CTEntryLocalServiceWrapper
 	private CTEntryLocalService _ctEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1428692022
+// LIFERAY-SERVICE-BUILDER-HASH:-684761976

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
@@ -468,6 +468,13 @@ public class CTEntryLocalServiceWrapper
 			modelClassNameId, modelClassPK, changeType);
 	}
 
+	@Override
+	public com.liferay.change.tracking.model.CTEntry updateChangeType(
+		long ctEntryId, int changeType) {
+
+		return _ctEntryLocalService.updateChangeType(ctEntryId, changeType);
+	}
+
 	/**
 	 * Updates the ct entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -494,6 +501,13 @@ public class CTEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.change.tracking.model.CTEntry updateUserId(
+		long ctEntryId, long userId) {
+
+		return _ctEntryLocalService.updateUserId(ctEntryId, userId);
+	}
+
+	@Override
 	public BasePersistence<?> getBasePersistence() {
 		return _ctEntryLocalService.getBasePersistence();
 	}
@@ -511,4 +525,4 @@ public class CTEntryLocalServiceWrapper
 	private CTEntryLocalService _ctEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:981117985
+// LIFERAY-SERVICE-BUILDER-HASH:1428692022

--- a/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/service/packageinfo
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 14.1.0

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTPersistenceHelperImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTPersistenceHelperImpl.java
@@ -66,8 +66,7 @@ public class CTPersistenceHelperImpl implements CTPersistenceHelper {
 				return true;
 			}
 
-			_ctEntryLocalService.updateUserId(
-				ctEntry.getCtEntryId(), userId);
+			_ctEntryLocalService.updateUserId(ctEntry.getCtEntryId(), userId);
 		}
 		catch (PortalException portalException) {
 			throw new SystemException(portalException);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTPersistenceHelperImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTPersistenceHelperImpl.java
@@ -66,11 +66,8 @@ public class CTPersistenceHelperImpl implements CTPersistenceHelper {
 				return true;
 			}
 
-			if (userId != ctEntry.getUserId()) {
-				ctEntry.setUserId(userId);
-			}
-
-			_ctEntryLocalService.updateCTEntry(ctEntry);
+			_ctEntryLocalService.updateUserId(
+				ctEntry.getCtEntryId(), userId);
 		}
 		catch (PortalException portalException) {
 			throw new SystemException(portalException);
@@ -154,14 +151,14 @@ public class CTPersistenceHelperImpl implements CTPersistenceHelper {
 				int changeType = ctEntry.getChangeType();
 
 				if (changeType == CTConstants.CT_CHANGE_TYPE_ADDITION) {
-					_ctEntryLocalService.deleteCTEntry(ctEntry);
+					_ctEntryLocalService.deleteCTEntry(ctEntry, false);
 
 					return true;
 				}
 
-				ctEntry.setChangeType(CTConstants.CT_CHANGE_TYPE_DELETION);
-
-				_ctEntryLocalService.updateCTEntry(ctEntry);
+				_ctEntryLocalService.updateChangeType(
+					ctEntry.getCtEntryId(),
+					CTConstants.CT_CHANGE_TYPE_DELETION);
 
 				if ((changeType == CTConstants.CT_CHANGE_TYPE_MODIFICATION) &&
 					(ctModel.getCtCollectionId() !=

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -1105,6 +1106,9 @@ public class CTConflictChecker<T extends CTModel<T>> {
 						ctEntry.getCtEntryId(), resultSet.getLong(2));
 				}
 			}
+		}
+		catch (PortalException portalException) {
+			throw new SystemException(portalException);
 		}
 		catch (SQLException sqlException) {
 			throw new ORMException(sqlException);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -824,16 +824,12 @@ public class CTCollectionLocalServiceImpl
 				modelClassNameId);
 
 			if (ctService == null) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Unable to check for unapproved changes for ",
-							"change tracking collection ", ctCollectionId,
-							" because the service for ", modelClassNameId,
-							" is missing"));
-				}
-
-				continue;
+				throw new SystemException(
+					StringBundler.concat(
+						"Unable to check for unapproved changes for change ",
+						"tracking collection ", ctCollectionId,
+						" because the service for ", modelClassNameId,
+						" is missing"));
 			}
 
 			CTPersistence<?> ctPersistence = ctService.getCTPersistence();
@@ -892,21 +888,22 @@ public class CTCollectionLocalServiceImpl
 
 		CTClosure ctClosure = _ctClosureFactory.create(ctCollectionId);
 
-		return CTEnclosureUtil.traverseParentEntries(
-			ctClosure,
-			CTEnclosureUtil.getEnclosureMap(
-				ctClosure, modelClassNameId, modelClassPK),
-			parentEntry -> {
-				int count = _ctEntryPersistence.countByC_MCNI_MCPK(
-					ctCollectionId, parentEntry.getKey(),
-					parentEntry.getValue());
+		Map<Long, Set<Long>> enclosureMap = CTEnclosureUtil.getEnclosureMap(
+			ctClosure, modelClassNameId, modelClassPK);
 
-				if (count > 0) {
-					return false;
-				}
+		for (Map.Entry<Long, Long> entry :
+				CTEnclosureUtil.getEnclosureParentEntries(
+					ctClosure, enclosureMap)) {
 
-				return true;
-			});
+			int count = _ctEntryPersistence.countByC_MCNI_MCPK(
+				ctCollectionId, entry.getKey(), entry.getValue());
+
+			if (count > 0) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	@Override
@@ -1104,8 +1101,7 @@ public class CTCollectionLocalServiceImpl
 
 			ctEntry.setChangeType(changeType);
 
-			ctServiceCopier.addCTEntry(
-				_ctEntryLocalService.updateCTEntry(ctEntry));
+			ctServiceCopier.addCTEntry(_ctEntryPersistence.update(ctEntry));
 		}
 
 		try {
@@ -1341,7 +1337,7 @@ public class CTCollectionLocalServiceImpl
 		}
 
 		CTClosure ctClosure = _ctClosureFactory.create(
-			ctCollection.getCtCollectionId());
+			ctCollection.getCtCollectionId(), modelClassNameId);
 
 		Map<Long, Set<Long>> enclosureMap = CTEnclosureUtil.getEnclosureMap(
 			ctClosure, modelClassNameId, modelClassPK);
@@ -1444,7 +1440,7 @@ public class CTCollectionLocalServiceImpl
 
 			ctEntry.setCtCollectionId(toCTCollectionId);
 
-			_ctEntryLocalService.updateCTEntry(ctEntry);
+			_ctEntryPersistence.update(ctEntry);
 		}
 
 		CTPersistence<?> ctPersistence = ctService.getCTPersistence();

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTEntryLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTEntryLocalServiceImpl.java
@@ -293,6 +293,17 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 	}
 
 	@Override
+	public CTEntry updateChangeType(long ctEntryId, int changeType)
+		throws PortalException {
+
+		CTEntry ctEntry = ctEntryPersistence.findByPrimaryKey(ctEntryId);
+
+		ctEntry.setChangeType(changeType);
+
+		return ctEntryPersistence.update(ctEntry);
+	}
+
+	@Override
 	public CTEntry updateCTEntry(CTEntry ctEntry) {
 		CTCollection ctCollection = _ctCollectionPersistence.fetchByPrimaryKey(
 			ctEntry.getCtCollectionId());
@@ -315,12 +326,23 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 	}
 
 	@Override
-	public CTEntry updateModelMvccVersion(
-		long ctEntryId, long modelMvccVersion) {
+	public CTEntry updateModelMvccVersion(long ctEntryId, long modelMvccVersion)
+		throws PortalException {
 
-		CTEntry ctEntry = ctEntryPersistence.fetchByPrimaryKey(ctEntryId);
+		CTEntry ctEntry = ctEntryPersistence.findByPrimaryKey(ctEntryId);
 
 		ctEntry.setModelMvccVersion(modelMvccVersion);
+
+		return ctEntryPersistence.update(ctEntry);
+	}
+
+	@Override
+	public CTEntry updateUserId(long ctEntryId, long userId)
+		throws PortalException {
+
+		CTEntry ctEntry = ctEntryPersistence.findByPrimaryKey(ctEntryId);
+
+		ctEntry.setUserId(userId);
 
 		return ctEntryPersistence.update(ctEntry);
 	}


### PR DESCRIPTION
## Summary
- Add `updateChangeType` and `updateUserId` methods to `CTEntryLocalServiceImpl`
- Bypass `@Indexable` annotation by using alternative means to update/delete CTEntry
- Add null checks to `updateChangeType`, `updateModelMvccVersion`, and `updateUserId`