### PR TITLE
LPD-83278 Show only final destination URLs (200) in the sitemap XML files

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
@@ -152,7 +152,7 @@ public class AssetCategorySitemapURLProvider implements SitemapURLProvider {
 			_sitemapManager.addURLElement(
 				element, alternateFriendlyURL, typeSettingsUnicodeProperties,
 				layout.getModifiedDate(), categoryFriendlyURL,
-				alternateFriendlyURLs);
+				alternateFriendlyURLs, layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
@@ -167,7 +167,7 @@ public class CPDefinitionSitemapURLProvider implements SitemapURLProvider {
 			_sitemapManager.addURLElement(
 				element, alternateFriendlyURL, typeSettingsUnicodeProperties,
 				layout.getModifiedDate(), productFriendlyURL,
-				alternateFriendlyURLs);
+				alternateFriendlyURLs, layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -333,8 +333,8 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemapManager.addURLElement(
 					element, alternateURL, null,
-					journalArticle.getModifiedDate(), articleURL,
-					alternateURLs);
+					journalArticle.getModifiedDate(), articleURL, alternateURLs,
+					articleLayout.getGroupId());
 			}
 
 			processedArticleIds.add(journalArticle.getArticleId());

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -136,7 +136,8 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		for (String alternateURL : alternateURLs.values()) {
 			_sitemapManager.addURLElement(
 				element, alternateURL, typeSettingsUnicodeProperties,
-				layout.getModifiedDate(), layoutFullURL, alternateURLs);
+				layout.getModifiedDate(), layoutFullURL, alternateURLs,
+				layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -243,7 +243,8 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemapManager.addURLElement(
 					element, alternateURL, typeSettingsUnicodeProperties,
-					objectEntry.getModifiedDate(), canonicalURL, alternateURLs);
+					objectEntry.getModifiedDate(), canonicalURL, alternateURLs,
+					layout.getGroupId());
 			}
 		}
 	}

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -25,10 +25,20 @@ public interface SitemapManager {
 
 	public static final int MAXIMUM_ENTRIES = 50000;
 
+	public default void addURLElement(
+		Element element, String url,
+		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
+		String canonicalURL, Map<Locale, String> alternateURLs) {
+
+		addURLElement(
+			element, url, typeSettingsUnicodeProperties, modifiedDate,
+			canonicalURL, alternateURLs, 0);
+	}
+
 	public void addURLElement(
 		Element element, String url,
 		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
-		String canonicalURL, Map<Locale, String> alternateURLs);
+		String canonicalURL, Map<Locale, String> alternateURLs, long groupId);
 
 	public String encodeXML(String input);
 

--- a/modules/apps/site/site-impl/build.gradle
+++ b/modules/apps/site/site-impl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-seo-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:redirect:redirect-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -431,10 +431,6 @@ public class SitemapManagerImpl implements SitemapManager {
 			_getLayoutSets(groupId, layoutUuid, privateLayout, themeDisplay),
 			layoutUuid, rootElement, themeDisplay);
 
-		if (!rootElement.hasContent()) {
-			return StringPool.BLANK;
-		}
-
 		_removeEntriesAndSize(rootElement);
 
 		return document.asXML();

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -21,12 +21,14 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -41,6 +43,7 @@ import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
+import com.liferay.redirect.provider.RedirectProvider;
 import com.liferay.site.configuration.manager.SitemapConfigurationManager;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.site.provider.SitemapURLProvider;
@@ -55,6 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -73,7 +77,33 @@ public class SitemapManagerImpl implements SitemapManager {
 	public void addURLElement(
 		Element element, String url,
 		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
-		String canonicalURL, Map<Locale, String> alternateURLs) {
+		String canonicalURL, Map<Locale, String> alternateURLs, long groupId) {
+
+		String path = HttpComponentsUtil.getPath(url);
+		String contextPath = _portal.getPathContext();
+
+		if (Validator.isNotNull(contextPath) && path.startsWith(contextPath)) {
+			path = path.substring(contextPath.length());
+		}
+
+		String fullURL = path;
+
+		if (fullURL.startsWith(StringPool.SLASH)) {
+			fullURL = fullURL.substring(1);
+		}
+
+		String friendlyURL = _getFriendlyURL(path, groupId);
+
+		if (friendlyURL.startsWith(StringPool.SLASH)) {
+			friendlyURL = friendlyURL.substring(1);
+		}
+
+		RedirectProvider.Redirect redirect = _redirectProvider.getRedirect(
+			groupId, friendlyURL, fullURL, null);
+
+		if (redirect != null) {
+			return;
+		}
 
 		Element urlElement = element.addElement("url");
 
@@ -223,6 +253,67 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private String _getFriendlyURL(String path, long groupId) {
+		int[] groupFriendlyURLIndex = _portal.getGroupFriendlyURLIndex(path);
+
+		if (groupFriendlyURLIndex != null) {
+			if (groupFriendlyURLIndex[1] < path.length()) {
+				return path.substring(groupFriendlyURLIndex[1]);
+			}
+
+			return StringPool.BLANK;
+		}
+
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId == 0) {
+			companyId = _companyIds.computeIfAbsent(
+				groupId,
+				key -> {
+					try {
+						Group group = _groupLocalService.getGroup(key);
+
+						return group.getCompanyId();
+					}
+					catch (PortalException portalException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(portalException);
+						}
+
+						return 0L;
+					}
+				});
+		}
+
+		for (Locale availableLocale :
+				_language.getAvailableLocales(companyId)) {
+
+			String i18nPath =
+				StringPool.SLASH + LocaleUtil.toLanguageId(availableLocale);
+
+			if (path.startsWith(i18nPath + StringPool.SLASH) ||
+				path.equals(i18nPath)) {
+
+				String pathWithoutLocale = path.substring(i18nPath.length());
+
+				int[] tempIndices = _portal.getGroupFriendlyURLIndex(
+					pathWithoutLocale);
+
+				if (tempIndices != null) {
+					if (tempIndices[1] < pathWithoutLocale.length()) {
+						return pathWithoutLocale.substring(tempIndices[1]);
+					}
+
+					return StringPool.BLANK;
+				}
+
+				return pathWithoutLocale;
+			}
+		}
+
+		return path;
 	}
 
 	private String _getIndexSitemap(
@@ -566,6 +657,8 @@ public class SitemapManagerImpl implements SitemapManager {
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
 
+	private final Map<Long, Long> _companyIds = new ConcurrentHashMap<>();
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
@@ -580,6 +673,9 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RedirectProvider _redirectProvider;
 
 	@Reference
 	private SAXReader _saxReader;

--- a/modules/apps/site/site-test/build.gradle
+++ b/modules/apps/site/site-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal:portal-local-service-tree-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
+	testIntegrationImplementation project(":apps:redirect:redirect-api")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -322,7 +322,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -356,7 +356,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -390,7 +390,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -554,7 +554,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -586,7 +586,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -618,7 +618,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -725,7 +725,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -781,7 +781,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(childLayout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), childLayout.getUuid());
 		}
 	}
 
@@ -821,7 +821,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -861,7 +861,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -901,7 +901,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -1007,7 +1007,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -1071,11 +1071,19 @@ public class SitemapManagerTest {
 		_redirectEntryLocalService.addRedirectEntry(redirectEntry);
 	}
 
-	private void _assertEmptySitemap(String uuid) throws Exception {
-		Assert.assertEquals(
-			StringPool.BLANK,
-			_sitemapManager.getSitemap(
-				uuid, _group.getGroupId(), false, _themeDisplay));
+	private void _assertEmptySitemap(long groupId, String uuid)
+		throws Exception {
+
+		String xml = _sitemapManager.getSitemap(
+			uuid, groupId, false, _themeDisplay);
+
+		Document document = _saxReader.read(xml);
+
+		Element rootElement = document.getRootElement();
+
+		Assert.assertTrue(
+			rootElement.elements(
+			).isEmpty());
 	}
 
 	private void _assertSitemap(
@@ -1338,10 +1346,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			Assert.assertEquals(
-				StringPool.BLANK,
-				_sitemapManager.getSitemap(
-					null, guestGroupId, false, _themeDisplay));
+			_assertEmptySitemap(guestGroupId, null);
 		}
 	}
 
@@ -1373,7 +1378,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(uuid);
+			_assertEmptySitemap(_group.getGroupId(), uuid);
 		}
 	}
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.commerce.product.constants.CPPortletKeys;
 import com.liferay.commerce.product.url.CPFriendlyURL;
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -58,11 +59,13 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
@@ -70,6 +73,8 @@ import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.redirect.model.RedirectEntry;
+import com.liferay.redirect.service.RedirectEntryLocalService;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
@@ -628,6 +633,62 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIncludePagesWithRedirect() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(_layout, _themeDisplay), _themeDisplay,
+				_layout);
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
+
+			if (sourceURL.startsWith(StringPool.SLASH)) {
+				sourceURL = sourceURL.substring(1);
+			}
+
+			RedirectEntry redirectEntry =
+				_redirectEntryLocalService.createRedirectEntry(
+					CounterLocalServiceUtil.increment());
+
+			redirectEntry.setUuid(PortalUUIDUtil.generate());
+			redirectEntry.setGroupId(_group.getGroupId());
+			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+			redirectEntry.setDestinationURL("https://liferay.com");
+			redirectEntry.setPermanent(true);
+			redirectEntry.setSourceURL(sourceURL);
+
+			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+
+			_assertEmptySitemap(_layout.getUuid());
+		}
+	}
+
+	@Test
 	public void testSitemapIncludeWebContentCompanyDisabledGroupDisabled()
 		throws Exception {
 
@@ -794,6 +855,74 @@ public class SitemapManagerTest {
 							URL_SEPARATOR_JOURNAL_ARTICLE,
 						journalArticle.getUrlTitle()),
 					_themeDisplay, _layout));
+		}
+	}
+
+	@Test
+	public void testSitemapIncludeWebContentWithRedirect() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", false
+						).put(
+							"includeWebContent", true
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", false
+						).put(
+							"includeWebContent", true
+						).build())) {
+
+			JournalArticle journalArticle = _addJournalArticle();
+
+			AssetDisplayPageEntry assetDisplayPageEntry =
+				_addJournalArticleAssetDisplayPageEntry(journalArticle);
+
+			Layout layout = _layoutLocalService.getLayout(
+				assetDisplayPageEntry.getPlid());
+
+			_assertSitemap(
+				true, _group.getGroupId(), layout.getUuid(),
+				_portal.getCanonicalURL(
+					StringBundler.concat(
+						_portal.getGroupFriendlyURL(
+							_layout.getLayoutSet(), _themeDisplay, false,
+							false),
+						FriendlyURLResolverConstants.
+							URL_SEPARATOR_JOURNAL_ARTICLE,
+						journalArticle.getUrlTitle()),
+					_themeDisplay, _layout));
+
+			RedirectEntry redirectEntry =
+				_redirectEntryLocalService.createRedirectEntry(
+					CounterLocalServiceUtil.increment());
+
+			redirectEntry.setUuid(PortalUUIDUtil.generate());
+			redirectEntry.setGroupId(_group.getGroupId());
+			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+			redirectEntry.setDestinationURL("https://liferay.com");
+			redirectEntry.setPermanent(true);
+
+			String sourceURL =
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE +
+					journalArticle.getUrlTitle();
+
+			redirectEntry.setSourceURL(sourceURL.substring(1));
+
+			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+
+			_assertEmptySitemap(layout.getUuid());
 		}
 	}
 
@@ -1240,6 +1369,9 @@ public class SitemapManagerTest {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private RedirectEntryLocalService _redirectEntryLocalService;
 
 	@Inject
 	private SAXReader _saxReader;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -62,6 +62,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -633,6 +634,61 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIncludePagesWithLocaleAndRedirect()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			_layout.setTitle("Spanish Title", LocaleUtil.SPAIN);
+
+			_layout = _layoutLocalService.updateLayout(_layout);
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(_layout, _themeDisplay), _themeDisplay,
+				_layout);
+
+			Map<Locale, String> alternateURLs =
+				_sitemapManager.getAlternateURLs(
+					canonicalURL, _themeDisplay, _layout);
+
+			String spanishURL = alternateURLs.get(LocaleUtil.SPAIN);
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL,
+				spanishURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(spanishURL);
+
+			_addRedirectEntry(sourceURL.substring(1));
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL);
+		}
+	}
+
+	@Test
 	public void testSitemapIncludePagesWithRedirect() throws Exception {
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -667,24 +723,65 @@ public class SitemapManagerTest {
 
 			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
 
-			if (sourceURL.startsWith(StringPool.SLASH)) {
-				sourceURL = sourceURL.substring(1);
-			}
-
-			RedirectEntry redirectEntry =
-				_redirectEntryLocalService.createRedirectEntry(
-					CounterLocalServiceUtil.increment());
-
-			redirectEntry.setUuid(PortalUUIDUtil.generate());
-			redirectEntry.setGroupId(_group.getGroupId());
-			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
-			redirectEntry.setDestinationURL("https://liferay.com");
-			redirectEntry.setPermanent(true);
-			redirectEntry.setSourceURL(sourceURL);
-
-			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+			_addRedirectEntry(sourceURL.substring(1));
 
 			_assertEmptySitemap(_layout.getUuid());
+		}
+	}
+
+	@Test
+	public void testSitemapIncludePagesWithVirtualHostAndRedirect()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			String virtualHostname = StringUtil.randomString(8);
+
+			_layoutSetLocalService.updateVirtualHosts(
+				_group.getGroupId(), false,
+				TreeMapBuilder.put(
+					virtualHostname, _layout.getDefaultLanguageId()
+				).build());
+
+			Layout childLayout = LayoutTestUtil.addTypePortletLayout(
+				_group.getGroupId(), _layout.getPlid());
+
+			_setUpThemeDisplay(_group, childLayout, virtualHostname);
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(childLayout, _themeDisplay),
+				_themeDisplay, childLayout);
+
+			_assertSitemap(
+				true, _group.getGroupId(), childLayout.getUuid(), canonicalURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
+
+			_addRedirectEntry(sourceURL.substring(1));
+
+			_assertEmptySitemap(childLayout.getUuid());
 		}
 	}
 
@@ -904,23 +1001,11 @@ public class SitemapManagerTest {
 						journalArticle.getUrlTitle()),
 					_themeDisplay, _layout));
 
-			RedirectEntry redirectEntry =
-				_redirectEntryLocalService.createRedirectEntry(
-					CounterLocalServiceUtil.increment());
-
-			redirectEntry.setUuid(PortalUUIDUtil.generate());
-			redirectEntry.setGroupId(_group.getGroupId());
-			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
-			redirectEntry.setDestinationURL("https://liferay.com");
-			redirectEntry.setPermanent(true);
-
 			String sourceURL =
 				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE +
 					journalArticle.getUrlTitle();
 
-			redirectEntry.setSourceURL(sourceURL.substring(1));
-
-			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+			_addRedirectEntry(sourceURL.substring(1));
 
 			_assertEmptySitemap(layout.getUuid());
 		}
@@ -969,6 +1054,21 @@ public class SitemapManagerTest {
 			journalArticle.getResourcePrimKey(),
 			journalArticle.getDDMStructureKey(),
 			AssetDisplayPageConstants.TYPE_SPECIFIC);
+	}
+
+	private void _addRedirectEntry(String sourceURL) throws Exception {
+		RedirectEntry redirectEntry =
+			_redirectEntryLocalService.createRedirectEntry(
+				CounterLocalServiceUtil.increment());
+
+		redirectEntry.setUuid(PortalUUIDUtil.generate());
+		redirectEntry.setGroupId(_group.getGroupId());
+		redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+		redirectEntry.setDestinationURL("https://liferay.com");
+		redirectEntry.setPermanent(true);
+		redirectEntry.setSourceURL(sourceURL);
+
+		_redirectEntryLocalService.addRedirectEntry(redirectEntry);
 	}
 
 	private void _assertEmptySitemap(String uuid) throws Exception {


### PR DESCRIPTION
   # What is this trying to solve?
   https://liferay.atlassian.net/browse/LPD-83278

   Currently, sitemaps generated by Liferay include URLs that have active redirects configured for them. This can cause search engines to encounter 301/302 redirects when crawling the sitemap, negatively impacting SEO rankings. We need to ensure that only final destination URLs (HTTP 200) are listed in the sitemap
   XML files.

   # How am I fixing it?
   - Updated `SitemapManagerImpl.addURLElement()` to evaluate the primary URL against the `RedirectProvider`. If the URL matches an active redirect, the entire URL entry is omitted from the sitemap.
   - Modified the `SitemapURLProvider` implementations (`Layout`, `JournalArticle`, `ObjectEntry`, etc.) to pass the contextual `groupId` down into `addURLElement`. This ensures redirects can be accurately matched even when a site uses a custom Virtual Host (where the URL path lacks a site identifier).
   - Updated `_getSitemap` to always return a valid XML structure (e.g., an empty `<urlset>`) instead of a blank string when all URLs in a group are redirected.

   # How can you verify that it works?
   In `modules/apps/site/site-test` run:
   `gw testIntegration --tests *.SitemapManagerTest`