### PR TITLE
LPD-85013 Support Manual Collections in Site Initializers

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/asset-list-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/asset-list-entries.json
@@ -43,5 +43,31 @@
 		"unicodeProperties": {
 			"classNameIds": "[$OBJECT_DEFINITION_CLASS_NAME:TestObjectDefinition1$]"
 		}
+	},
+	{
+		"assetListEntries": [
+			{
+				"className": "[$OBJECT_DEFINITION_CLASS_NAME:TestObjectDefinition1$]",
+				"classPK": "[#TestObjectDefinition#TEST_OBJECT_ENTRY_1#]"
+			},
+			{
+				"className": "com.liferay.journal.model.JournalArticle",
+				"classPK": "[#JOURNAL_ARTICLE_ID:TEST-JOURNAL-ARTICLE-1#]"
+			}
+		],
+		"title": "Test Asset List Entry 5",
+		"type": "manual",
+		"unicodeProperties": {
+			"orderBy": [
+				{
+					"key": "orderByColumn1",
+					"value": "modifiedDate"
+				},
+				{
+					"key": "orderByColumn2",
+					"value": "title"
+				}
+			]
+		}
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -656,7 +656,7 @@ public class BundleSiteInitializerTest {
 				_group.getGroupId());
 
 		Assert.assertEquals(
-			assetListEntries.toString(), 4, assetListEntries.size());
+			assetListEntries.toString(), 5, assetListEntries.size());
 
 		AssetListEntry assetListEntry = assetListEntries.get(0);
 
@@ -714,6 +714,30 @@ public class BundleSiteInitializerTest {
 				assetListEntry.getAssetEntryType(),
 				ObjectDefinitionConstants.
 					CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION));
+
+		assetListEntry = assetListEntries.get(4);
+
+		Assert.assertEquals(
+			"Test Asset List Entry 5", assetListEntry.getTitle());
+
+		assetListEntrySegmentsEntryRel =
+			_assetListEntrySegmentsEntryRelLocalService.
+				fetchAssetListEntrySegmentsEntryRel(
+					assetListEntry.getAssetListEntryId(), 0);
+
+		typeSettings = assetListEntrySegmentsEntryRel.getTypeSettings();
+
+		Assert.assertEquals("manual", assetListEntry.getTypeLabel());
+		Assert.assertTrue(
+			typeSettings.contains(
+				"classNameIds=" +
+					_portal.getClassNameId(JournalArticle.class.getName())));
+		Assert.assertTrue(
+			typeSettings.contains(
+				"classTypeIdsJournalArticleAssetRendererFactory"));
+		Assert.assertFalse(
+			typeSettings.contains(
+				"classTypeIdsObjectEntryAssetRendererFactory"));
 	}
 
 	private void _assertAssetVocabularies() throws Exception {

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -1572,15 +1572,45 @@ public class BundleSiteInitializer implements SiteInitializer {
 			}
 		}
 
+		String type = assetListJSONObject.getString("type");
+
 		if (assetListEntry == null) {
-			_assetListEntryLocalService.addDynamicAssetListEntry(
-				assetListJSONObject.getString("externalReferenceCode"),
-				serviceContext.getUserId(), serviceContext.getScopeGroupId(),
-				assetListJSONObject.getString("title"),
-				UnicodePropertiesBuilder.create(
-					map, true
-				).buildString(),
-				serviceContext);
+			if (StringUtil.equals(type, "manual")) {
+				List<Long> assetEntryIds = new ArrayList<>();
+
+				Object[] assetListEntryObjects = JSONUtil.toObjectArray(
+					assetListJSONObject.getJSONArray("assetListEntries"));
+
+				for (Object assetListEntryObject : assetListEntryObjects) {
+					JSONObject assetListEntryJSONObject = (JSONObject)assetListEntryObject;
+
+					AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+						_portal.getClassNameId(assetListEntryJSONObject.getString("className")),
+						assetListEntryJSONObject.getLong("classPK"));
+
+					if (assetEntry != null) {
+						assetEntryIds.add(assetEntry.getEntryId());
+					}
+				}
+
+				_assetListEntryLocalService.addManualAssetListEntry(
+					assetListJSONObject.getString("externalReferenceCode"),
+					serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+					assetListJSONObject.getString("title"),
+					ArrayUtil.toLongArray(assetEntryIds),
+					serviceContext);
+			}
+			else {
+				_assetListEntryLocalService.addDynamicAssetListEntry(
+					assetListJSONObject.getString("externalReferenceCode"),
+					serviceContext.getUserId(),
+					serviceContext.getScopeGroupId(),
+					assetListJSONObject.getString("title"),
+					UnicodePropertiesBuilder.create(
+						map, true
+					).buildString(),
+					serviceContext);
+			}
 		}
 		else {
 			_assetListEntryLocalService.updateAssetListEntry(
@@ -2513,6 +2543,10 @@ public class BundleSiteInitializer implements SiteInitializer {
 							JournalArticle.class.getName());
 					}
 				});
+
+			stringUtilReplaceValues.put(
+				"JOURNAL_ARTICLE_ID:" + finalJournalArticle.getArticleId(),
+				String.valueOf(finalJournalArticle.getResourcePrimKey()));
 		}
 	}
 
@@ -5305,7 +5339,11 @@ public class BundleSiteInitializer implements SiteInitializer {
 			addAccountsR, _dependsOn(addOrUpdateExpandoColumnsR)
 		).put(
 			addAssetListEntriesR,
-			_dependsOn(addOrUpdateDDMStructuresR, publishObjectDefinitionsR)
+			_dependsOn(
+				addOrUpdateBlogPostingsR, addOrUpdateDDMStructuresR,
+				addOrUpdateDocumentsR, addOrUpdateJournalArticlesR,
+				addOrUpdateKnowledgeBaseArticlesR, addOrUpdateObjectEntriesR,
+				publishObjectDefinitionsR)
 		).put(
 			addCPDefinitionsR,
 			_dependsOn(addOrUpdateLayoutsR, addOrUpdateObjectEntriesR)

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -1572,33 +1572,84 @@ public class BundleSiteInitializer implements SiteInitializer {
 			}
 		}
 
-		String type = assetListJSONObject.getString("type");
-
 		if (assetListEntry == null) {
+			String type = assetListJSONObject.getString("type");
+
 			if (StringUtil.equals(type, "manual")) {
 				List<Long> assetEntryIds = new ArrayList<>();
+				Set<Long> assetEntryClassNameIds = new HashSet<>();
+				Map<String, Set<Long>> classTypeIdsMap = new HashMap<>();
 
 				Object[] assetListEntryObjects = JSONUtil.toObjectArray(
 					assetListJSONObject.getJSONArray("assetListEntries"));
 
 				for (Object assetListEntryObject : assetListEntryObjects) {
-					JSONObject assetListEntryJSONObject = (JSONObject)assetListEntryObject;
+					JSONObject assetListEntryJSONObject =
+						(JSONObject)assetListEntryObject;
 
 					AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-						_portal.getClassNameId(assetListEntryJSONObject.getString("className")),
+						_portal.getClassNameId(
+							assetListEntryJSONObject.getString("className")),
 						assetListEntryJSONObject.getLong("classPK"));
 
-					if (assetEntry != null) {
+					if (assetEntry == null) {
+						continue;
+					}
+
+					AssetRendererFactory<?> assetRendererFactory =
+						AssetRendererFactoryRegistryUtil.
+							getAssetRendererFactoryByClassNameId(
+								assetEntry.getClassNameId());
+
+					if ((assetRendererFactory != null) &&
+						assetRendererFactory.isSelectable()) {
+
 						assetEntryIds.add(assetEntry.getEntryId());
+						assetEntryClassNameIds.add(assetEntry.getClassNameId());
+
+						if (assetRendererFactory.isSupportsClassTypes()) {
+							String manualAssetRendererFactoryName =
+								_getAssetRendererFactoryName(
+									assetRendererFactory.getClassName());
+
+							classTypeIdsMap.computeIfAbsent(
+								manualAssetRendererFactoryName,
+								k -> new HashSet<>()
+							).add(
+								assetEntry.getClassTypeId()
+							);
+						}
 					}
 				}
 
-				_assetListEntryLocalService.addManualAssetListEntry(
-					assetListJSONObject.getString("externalReferenceCode"),
-					serviceContext.getUserId(), serviceContext.getScopeGroupId(),
-					assetListJSONObject.getString("title"),
-					ArrayUtil.toLongArray(assetEntryIds),
-					serviceContext);
+				Map<String, String> typeSettings = new HashMap<>(map);
+
+				typeSettings.put("anyAssetType", String.valueOf(Boolean.FALSE));
+				typeSettings.put(
+					"classNameIds", StringUtil.merge(assetEntryClassNameIds));
+				typeSettings.put(
+					"groupIds",
+					String.valueOf(serviceContext.getScopeGroupId()));
+
+				classTypeIdsMap.forEach(
+					(manualAssetRendererFactoryName, assetEntryClassTypeId) ->
+						typeSettings.put(
+							"classTypeIds" + manualAssetRendererFactoryName,
+							StringUtil.merge(assetEntryClassTypeId)));
+
+				assetListEntry =
+					_assetListEntryLocalService.addManualAssetListEntry(
+						assetListJSONObject.getString("externalReferenceCode"),
+						serviceContext.getUserId(),
+						serviceContext.getScopeGroupId(),
+						assetListJSONObject.getString("title"),
+						ArrayUtil.toLongArray(assetEntryIds), serviceContext);
+
+				_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+					assetListEntry.getAssetListEntryId(), 0,
+					UnicodePropertiesBuilder.create(
+						typeSettings, true
+					).buildString());
 			}
 			else {
 				_assetListEntryLocalService.addDynamicAssetListEntry(


### PR DESCRIPTION
# What is this trying to solve?
   https://liferay.atlassian.net/browse/LPD-85013

   # How am I fixing it?
   This pull request introduces support for Manual Asset Collections within Site Initializers.

   1. **JSON Parsing & Persistence:** `BundleSiteInitializer` now parses `"type": "manual"` definitions from `asset-list-entries.json`. It fetches the corresponding `AssetEntry` records based on the defined `className` and `classPK` and persists the collection using
   `_assetListEntryLocalService.addManualAssetListEntry`.
   2. **Dynamic Scoping & `typeSettings`:** Generates the correct `classNameIds` and `classTypeIds` settings required by the Asset Publisher/Collection Display to scope the manual collection UI.
   3. **Data Cleanliness:** Includes an `isSupportsClassTypes()` check to ensure generic assets (like Blogs or Wiki Pages) do not pollute the database with generic `0` class type IDs.
   4. **Resiliency:** Added NPE prevention via null checks on `AssetRendererFactory` lookups and strict adherence to `isSelectable()` to silently skip non-selectable entities like company-scoped object definitions.
   5. **Execution Order:** Expanded the `addAssetListEntriesR` dependencies to ensure it waits for all potential content-creation runnables (e.g., Blog Postings, Journal Articles, Documents, Knowledge Base Articles, Object Entries, Layouts) to finish before the manual collection attempts to bundle them.

   # How can you verify that it works?
   In `modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test` run:
   `gw testIntegration --tests BundleSiteInitializerTest._assertAssetListEntries`