### PR TITLE
LPD-85250 Update layout SEO and social meta tags for clean URLs

### DIFF
--- a/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
+++ b/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
@@ -39,6 +39,7 @@ import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
 import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
@@ -60,6 +61,7 @@ import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -1553,19 +1555,51 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 
 	@Test
 	public void testIncludeUrl() throws Exception {
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_dynamicInclude.include(
-			_getHttpServletRequest(), mockHttpServletResponse,
-			RandomTestUtil.randomString());
-
-		Document document = Jsoup.parse(
-			mockHttpServletResponse.getContentAsString());
-
-		_assertMetaTag(
-			document, "og:url",
+		_assertCanonicalLinkAndSocialTags(
+			_getHttpServletRequest(),
 			PortalUtil.getCanonicalURL("", _getThemeDisplay(), _layout));
+	}
+
+	@Test
+	public void testIncludeUrlWithCleanUrlEnabled() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			String canonicalURL = PortalUtil.getCanonicalURL(
+				"", _getThemeDisplay(), _layout);
+
+			Assert.assertFalse(canonicalURL.contains("/web/"));
+
+			_assertCanonicalLinkAndSocialTags(
+				_getHttpServletRequest(), canonicalURL);
+		}
+	}
+
+	@Test
+	public void testIncludeUrlWithCleanUrlEnabledAndLegacyRequestURL()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				(MockHttpServletRequest)_getHttpServletRequest();
+
+			mockHttpServletRequest.setRequestURI(
+				"/web" + _group.getFriendlyURL() + _layout.getFriendlyURL());
+
+			String canonicalURL = PortalUtil.getCanonicalURL(
+				"", _getThemeDisplay(), _layout);
+
+			Assert.assertFalse(canonicalURL.contains("/web/"));
+
+			_assertCanonicalLinkAndSocialTags(
+				mockHttpServletRequest, canonicalURL);
+		}
 	}
 
 	@Test
@@ -1713,6 +1747,27 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		}
 	}
 
+	private void _assertCanonicalLinkAndSocialTags(
+			HttpServletRequest httpServletRequest, String canonicalURL)
+		throws Exception {
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_dynamicInclude.include(
+			httpServletRequest, mockHttpServletResponse,
+			RandomTestUtil.randomString());
+
+		Document document = Jsoup.parse(
+			mockHttpServletResponse.getContentAsString());
+
+		_assertCanonicalLinkTag(document, canonicalURL);
+
+		_assertMetaTag(document, "og:url", canonicalURL);
+
+		_assertTwitterTag(document, "twitter:url", canonicalURL);
+	}
+
 	private void _assertCanonicalLinkTag(Document document, String href) {
 		Elements elements = document.select("link[rel='canonical']");
 
@@ -1827,6 +1882,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Elements elements = document.select("meta[property^='og:']");
 
 		Assert.assertEquals(0, elements.size());
+	}
+
+	private void _assertTwitterTag(
+		Document document, String name, String content) {
+
+		Elements elements = document.select("meta[name='" + name + "']");
+
+		Assert.assertNotNull(elements);
+		Assert.assertEquals(1, elements.size());
+
+		Element element = elements.get(0);
+
+		Assert.assertEquals(content, element.attr("content"));
 	}
 
 	private HttpServletRequest _getAssetDisplayPageHttpServletRequest(

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
@@ -260,6 +260,9 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 			printWriter.println(
 				_getOpenGraphTag("og:url", layoutSEOLink.getHref()));
 
+			printWriter.println(
+				_getTwitterTag("twitter:url", layoutSEOLink.getHref()));
+
 			OpenGraphImageProvider.OpenGraphImage openGraphImage =
 				_openGraphImageProvider.getOpenGraphImage(
 					infoItemFieldValues, layout, layoutSEOEntry, themeDisplay);
@@ -426,14 +429,21 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 			template, infoItemFieldValues, locale);
 	}
 
-	private String _getOpenGraphTag(String property, String content) {
-		if (Validator.isNull(content) || Validator.isNull(property)) {
+	private String _getMetaTag(
+		String attributeName, String attributeValue, String content) {
+
+		if (Validator.isNull(attributeValue) || Validator.isNull(content)) {
 			return StringPool.BLANK;
 		}
 
 		return StringBundler.concat(
-			"<meta property=\"", HtmlUtil.escapeAttribute(property),
-			"\" content=\"", HtmlUtil.escapeAttribute(content), "\">");
+			"<meta ", attributeName, "=\"",
+			HtmlUtil.escapeAttribute(attributeValue), "\" content=\"",
+			HtmlUtil.escapeAttribute(content), "\">");
+	}
+
+	private String _getOpenGraphTag(String property, String content) {
+		return _getMetaTag("property", property, content);
 	}
 
 	private String _getTitle(HttpServletRequest httpServletRequest) {
@@ -443,6 +453,10 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 		catch (PortalException portalException) {
 			return ReflectionUtil.throwException(portalException);
 		}
+	}
+
+	private String _getTwitterTag(String name, String content) {
+		return _getMetaTag("name", name, content);
 	}
 
 	@Reference

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -32,6 +32,7 @@ import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -52,6 +53,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -1008,6 +1010,33 @@ public class SitemapManagerTest {
 			_addRedirectEntry(sourceURL.substring(1));
 
 			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
+		}
+	}
+
+	@Test
+	public void testSitemapWithCleanUrlEnabled() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			Group group = _groupLocalService.getGroup(
+				TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+			_setUpThemeDisplay(
+				group,
+				_layoutLocalService.fetchFirstLayout(
+					group.getGroupId(), false, 0),
+				"localhost");
+
+			String[] guestLayoutURLs = _getSitemapLayoutURLs(
+				group.getGroupId());
+
+			Assert.assertTrue(ArrayUtil.isNotEmpty(guestLayoutURLs));
+
+			for (String guestLayoutURL : guestLayoutURLs) {
+				Assert.assertFalse(guestLayoutURL.contains("/web/"));
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `twitter:url` meta tag to `OpenGraphTopHeadDynamicInclude`, using the same canonical URL as `og:url` — which already respects the clean URL property (`LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED`)
- Adds integration tests covering: clean URL enabled, legacy `/web` request URL edge case, and sitemap URL generation

## Test Plan

- [ ] `OpenGraphTopHeadDynamicIncludeTest#testIncludeUrlWithCleanUrlEnabled` — canonical, og:url, and twitter:url all omit `/web/` when feature is enabled
- [ ] `OpenGraphTopHeadDynamicIncludeTest#testIncludeUrlWithCleanUrlEnabledAndLegacyRequestURL` — same assertions hold even when request URI still contains `/web/`
- [ ] `SitemapManagerTest#testSitemapWithCleanUrlEnabled` — sitemap URLs omit `/web/` when feature is enabled (no production code change needed; sitemap already routes through `PortalImpl._getGroupFriendlyURL()`)