### PR TITLE
LPD-86559 headless-admin-site-impl: Handle the default experience pri…

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -1206,6 +1206,19 @@ public class LayoutUtil {
 
 					priority = minPriority++;
 				}
+				else if (oldSegmentsExperience == null) {
+					SegmentsExperience defaultSegmentsExperience =
+						SegmentsExperienceLocalServiceUtil.
+							fetchDefaultSegmentsExperience(layout.getPlid());
+
+					if (defaultSegmentsExperience != null) {
+						originalSegmentsExperiencesMap.remove(
+							defaultSegmentsExperience.
+								getExternalReferenceCode());
+
+						oldSegmentsExperience = defaultSegmentsExperience;
+					}
+				}
 
 				if (oldSegmentsExperience == null) {
 					actualSegmentsExperiencesMap.put(


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-86559

This PR is based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210).

## Summary                                                                                                                                                            
                  
During layout import, if the target layout already has a default segments experience (priority 0) with a different ERC than the one being imported,  _updatePageExperiences misses the existing default in its ERC-keyed lookup and takes the "add new" path — which fails with a priority 0 validation error.
                                                                                                                                                                     
 ## Change          

  LayoutUtil._updatePageExperiences: when the imported experience is the default (KEY_DEFAULT) and no ERC match is found, fall back to  fetchDefaultSegmentsExperience(plid) and take the update path. The pre-existing default is removed from the "to-delete" map so it isn't wiped afterwards.
                                                                                                                                                                     
## Test plan       

- Export a site with segments experiences and import into a different site where the target layout already has a default with a different ERC; verify import  succeeds and the default is preserved.
- Re-import the same LAR into the same site; verify idempotent behavior.                                                                                           
                                                                                                                                                                     
## Notes
                                                                                                                                                                     
No automated test is added — from the resource API this branch is unreachable (PageExperienceUtil.validatePageExperiences from LPD-73372 rejects ERC changes on the  default). It guards the LAR-import code path, which isn't currently covered by integration tests in this module.
