### PR TITLE
LPD-86424 Images in pages fail to render in Review Changes view

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/DLFileEntryCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/DLFileEntryCTTest.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFolderService;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
@@ -35,6 +36,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webdav.methods.Method;
 import com.liferay.portal.test.rule.Inject;
@@ -181,30 +183,35 @@ public class DLFileEntryCTTest {
 	public void testHasFiles() throws Exception {
 		String title = RandomTestUtil.randomString();
 
+		FileEntry fileEntry;
+
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					_ctCollection.getCtCollectionId())) {
 
-			_addFileEntry(RandomTestUtil.randomString(), title);
+			fileEntry = _addFileEntry(RandomTestUtil.randomString(), title);
 		}
 
 		String friendlyURL = String.format(
 			"%s%s/%s", FriendlyURLResolverConstants.URL_SEPARATOR_X_FILE_ENTRY,
 			_group.getFriendlyURL(), title);
 
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest(Method.GET, "/documents" + friendlyURL);
+		_assertHasFiles(friendlyURL);
 
-		mockHttpServletRequest.setAttribute(
-			WebKeys.USER, TestPropsValues.getUser());
-		mockHttpServletRequest.setContextPath("/documents");
-		mockHttpServletRequest.setParameter(
-			"previewCTCollectionId",
-			String.valueOf(_ctCollection.getCtCollectionId()));
-		mockHttpServletRequest.setPathInfo(friendlyURL);
-		mockHttpServletRequest.setServletPath(StringPool.BLANK);
+		StringBundler sb = new StringBundler(8);
 
-		Assert.assertTrue(WebServerServlet.hasFiles(mockHttpServletRequest));
+		sb.append(StringPool.SLASH);
+		sb.append(fileEntry.getRepositoryId());
+		sb.append(StringPool.SLASH);
+		sb.append(fileEntry.getFolderId());
+		sb.append(StringPool.SLASH);
+		sb.append(URLCodec.encodeURL(fileEntry.getFileName()));
+		sb.append(StringPool.SLASH);
+		sb.append(URLCodec.encodeURL(fileEntry.getUuid()));
+
+		friendlyURL = sb.toString();
+
+		_assertHasFiles(friendlyURL);
 	}
 
 	@Test
@@ -256,6 +263,22 @@ public class DLFileEntryCTTest {
 			ContentTypes.TEXT_PLAIN, title, StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, "liferay".getBytes(), null, null, null,
 			serviceContext);
+	}
+
+	private void _assertHasFiles(String friendlyURL) throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(Method.GET, "/documents" + friendlyURL);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER, TestPropsValues.getUser());
+		mockHttpServletRequest.setContextPath("/documents");
+		mockHttpServletRequest.setParameter(
+			"previewCTCollectionId",
+			String.valueOf(_ctCollection.getCtCollectionId()));
+		mockHttpServletRequest.setPathInfo(friendlyURL);
+		mockHttpServletRequest.setServletPath(StringPool.BLANK);
+
+		Assert.assertTrue(WebServerServlet.hasFiles(mockHttpServletRequest));
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -177,7 +177,15 @@ public class WebServerServlet extends HttpServlet {
 				return true;
 			}
 			else if (Validator.isNumber(pathArray[0])) {
-				_checkFileEntry(pathArray);
+				try (SafeCloseable safeCloseable =
+						CTCollectionThreadLocal.
+							setCTCollectionIdWithSafeCloseable(
+								ParamUtil.getLong(
+									httpServletRequest,
+									"previewCTCollectionId"))) {
+
+					_checkFileEntry(pathArray);
+				}
 			}
 			else if (_PATH_SEPARATOR_FILE_ENTRY.equals(pathArray[0])) {
 				FileEntry fileEntry = _resolveFileEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86424

I tried to see if I can extract setting the ctCollectionId to the top of hasFiles() to avoid having to set it in multiple areas. However, I found that _resolveFileEntry could potentially be called from other methods. If we removed setting the ThreadLocal there, this issue may occur in other instances that call _resolveFileEntry