### PR TITLE
LPD-86964 Declare Company/Group parents in TRDs missing them

### DIFF
--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsAssociationTableReferenceDefinition.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsAssociationTableReferenceDefinition.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.message.storage.service.persistence.AnalyticsAssoci
 import com.liferay.change.tracking.spi.reference.TableReferenceDefinition;
 import com.liferay.change.tracking.spi.reference.builder.ChildTableReferenceInfoBuilder;
 import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInfoBuilder;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +33,10 @@ public class AnalyticsAssociationTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<AnalyticsAssociationTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			AnalyticsAssociationTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsDeleteMessageTableReferenceDefinition.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsDeleteMessageTableReferenceDefinition.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.message.storage.service.persistence.AnalyticsDelete
 import com.liferay.change.tracking.spi.reference.TableReferenceDefinition;
 import com.liferay.change.tracking.spi.reference.builder.ChildTableReferenceInfoBuilder;
 import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInfoBuilder;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +33,10 @@ public class AnalyticsDeleteMessageTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<AnalyticsDeleteMessageTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			AnalyticsDeleteMessageTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsMessageTableReferenceDefinition.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/change/tracking/spi/reference/AnalyticsMessageTableReferenceDefinition.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.message.storage.service.persistence.AnalyticsMessag
 import com.liferay.change.tracking.spi.reference.TableReferenceDefinition;
 import com.liferay.change.tracking.spi.reference.builder.ChildTableReferenceInfoBuilder;
 import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInfoBuilder;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +33,10 @@ public class AnalyticsMessageTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<AnalyticsMessageTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			AnalyticsMessageTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/change/tracking/spi/reference/AssetListEntryUsageTableReferenceDefinition.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/change/tracking/spi/reference/AssetListEntryUsageTableReferenceDefinition.java
@@ -32,6 +32,9 @@ public class AssetListEntryUsageTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<AssetListEntryUsageTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.groupedModel(
+			AssetListEntryUsageTable.INSTANCE);
 	}
 
 	@Override

--- a/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/reference/TableReferenceInfoFactoryTest.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/reference/TableReferenceInfoFactoryTest.java
@@ -25,6 +25,8 @@ import com.liferay.petra.sql.dsl.spi.ast.DefaultASTNodeListener;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.ClassNameTable;
+import com.liferay.portal.kernel.model.CompanyTable;
+import com.liferay.portal.kernel.model.GroupTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -168,6 +170,94 @@ public class TableReferenceInfoFactoryTest {
 		new TableReferenceInfoFactory();
 
 		new TableJoinHolderFactory();
+	}
+
+	@Test
+	public void testGroupedModelAddsCompanyAndGroupParents() {
+		TableReferenceDefinition<GroupedModelExampleTable>
+			tableReferenceDefinition =
+				new TestTableReferenceDefinition<GroupedModelExampleTable>(
+					GroupedModelExampleTable.INSTANCE) {
+
+					@Override
+					public void defineChildTableReferences(
+						ChildTableReferenceInfoBuilder<GroupedModelExampleTable>
+							childTableReferenceInfoBuilder) {
+					}
+
+					@Override
+					public void defineParentTableReferences(
+						ParentTableReferenceInfoBuilder
+							<GroupedModelExampleTable>
+								parentTableReferenceInfoBuilder) {
+
+						parentTableReferenceInfoBuilder.groupedModel(
+							GroupedModelExampleTable.INSTANCE);
+					}
+
+				};
+
+		TableReferenceInfo<GroupedModelExampleTable> tableReferenceInfo =
+			TableReferenceInfoFactory.create(
+				GroupedModelExampleTable.CLASS_NAME_ID,
+				GroupedModelExampleTable.INSTANCE.groupedModelExampleIdColumn,
+				tableReferenceDefinition);
+
+		Map<Table<?>, List<TableJoinHolder>> parentTableJoinHoldersMap =
+			tableReferenceInfo.getParentTableJoinHoldersMap();
+
+		Assert.assertEquals(
+			parentTableJoinHoldersMap.toString(), 2,
+			parentTableJoinHoldersMap.size());
+
+		List<TableJoinHolder> groupTableJoinHolders =
+			parentTableJoinHoldersMap.get(GroupTable.INSTANCE);
+
+		Assert.assertEquals(
+			groupTableJoinHolders.toString(), 1, groupTableJoinHolders.size());
+
+		List<TableJoinHolder> companyTableJoinHolders =
+			parentTableJoinHoldersMap.get(CompanyTable.INSTANCE);
+
+		Assert.assertEquals(
+			companyTableJoinHolders.toString(), 1,
+			companyTableJoinHolders.size());
+	}
+
+	@Test
+	public void testGroupedModelOmittedProducesEmptyParents() {
+		TableReferenceDefinition<GroupedModelExampleTable>
+			tableReferenceDefinition =
+				new TestTableReferenceDefinition<GroupedModelExampleTable>(
+					GroupedModelExampleTable.INSTANCE) {
+
+					@Override
+					public void defineChildTableReferences(
+						ChildTableReferenceInfoBuilder<GroupedModelExampleTable>
+							childTableReferenceInfoBuilder) {
+					}
+
+					@Override
+					public void defineParentTableReferences(
+						ParentTableReferenceInfoBuilder
+							<GroupedModelExampleTable>
+								parentTableReferenceInfoBuilder) {
+					}
+
+				};
+
+		TableReferenceInfo<GroupedModelExampleTable> tableReferenceInfo =
+			TableReferenceInfoFactory.create(
+				GroupedModelExampleTable.CLASS_NAME_ID,
+				GroupedModelExampleTable.INSTANCE.groupedModelExampleIdColumn,
+				tableReferenceDefinition);
+
+		Map<Table<?>, List<TableJoinHolder>> parentTableJoinHoldersMap =
+			tableReferenceInfo.getParentTableJoinHoldersMap();
+
+		Assert.assertTrue(
+			parentTableJoinHoldersMap.toString(),
+			parentTableJoinHoldersMap.isEmpty());
 	}
 
 	@Test
@@ -915,6 +1005,34 @@ public class TableReferenceInfoFactoryTest {
 
 		private BridgeJoinExampleTable() {
 			super("BridgeJoinExample", BridgeJoinExampleTable::new);
+		}
+
+	}
+
+	private static class GroupedModelExampleTable
+		extends BaseTable<GroupedModelExampleTable> {
+
+		public static final long CLASS_NAME_ID = 3;
+
+		public static final GroupedModelExampleTable INSTANCE =
+			new GroupedModelExampleTable();
+
+		public final Column<GroupedModelExampleTable, Long> companyIdColumn =
+			createColumn(
+				"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+		public final Column<GroupedModelExampleTable, Long>
+			groupedModelExampleIdColumn = createColumn(
+				"groupedModelExampleId", Long.class, Types.BIGINT,
+				Column.FLAG_PRIMARY);
+		public final Column<GroupedModelExampleTable, Long> groupIdColumn =
+			createColumn(
+				"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+		public final Column<GroupedModelExampleTable, Long> mvccVersionColumn =
+			createColumn(
+				"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+
+		private GroupedModelExampleTable() {
+			super("GroupedModelExample", GroupedModelExampleTable::new);
 		}
 
 	}

--- a/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/reference/TableReferenceInfoFactoryTest.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/reference/TableReferenceInfoFactoryTest.java
@@ -166,6 +166,89 @@ public class TableReferenceInfoFactoryTest {
 	}
 
 	@Test
+	public void testCompanyModelAddsCompanyParent() {
+		TableReferenceDefinition<CompanyModelExampleTable>
+			tableReferenceDefinition =
+				new TestTableReferenceDefinition<CompanyModelExampleTable>(
+					CompanyModelExampleTable.INSTANCE) {
+
+					@Override
+					public void defineChildTableReferences(
+						ChildTableReferenceInfoBuilder<CompanyModelExampleTable>
+							childTableReferenceInfoBuilder) {
+					}
+
+					@Override
+					public void defineParentTableReferences(
+						ParentTableReferenceInfoBuilder
+							<CompanyModelExampleTable>
+								parentTableReferenceInfoBuilder) {
+
+						parentTableReferenceInfoBuilder.singleColumnReference(
+							CompanyModelExampleTable.INSTANCE.companyIdColumn,
+							CompanyTable.INSTANCE.companyId);
+					}
+
+				};
+
+		TableReferenceInfo<CompanyModelExampleTable> tableReferenceInfo =
+			TableReferenceInfoFactory.create(
+				CompanyModelExampleTable.CLASS_NAME_ID,
+				CompanyModelExampleTable.INSTANCE.companyModelExampleIdColumn,
+				tableReferenceDefinition);
+
+		Map<Table<?>, List<TableJoinHolder>> parentTableJoinHoldersMap =
+			tableReferenceInfo.getParentTableJoinHoldersMap();
+
+		Assert.assertEquals(
+			parentTableJoinHoldersMap.toString(), 1,
+			parentTableJoinHoldersMap.size());
+
+		List<TableJoinHolder> companyTableJoinHolders =
+			parentTableJoinHoldersMap.get(CompanyTable.INSTANCE);
+
+		Assert.assertEquals(
+			companyTableJoinHolders.toString(), 1,
+			companyTableJoinHolders.size());
+	}
+
+	@Test
+	public void testCompanyModelOmittedProducesEmptyParents() {
+		TableReferenceDefinition<CompanyModelExampleTable>
+			tableReferenceDefinition =
+				new TestTableReferenceDefinition<CompanyModelExampleTable>(
+					CompanyModelExampleTable.INSTANCE) {
+
+					@Override
+					public void defineChildTableReferences(
+						ChildTableReferenceInfoBuilder<CompanyModelExampleTable>
+							childTableReferenceInfoBuilder) {
+					}
+
+					@Override
+					public void defineParentTableReferences(
+						ParentTableReferenceInfoBuilder
+							<CompanyModelExampleTable>
+								parentTableReferenceInfoBuilder) {
+					}
+
+				};
+
+		TableReferenceInfo<CompanyModelExampleTable> tableReferenceInfo =
+			TableReferenceInfoFactory.create(
+				CompanyModelExampleTable.CLASS_NAME_ID,
+				CompanyModelExampleTable.INSTANCE.companyModelExampleIdColumn,
+				tableReferenceDefinition);
+
+		Map<Table<?>, List<TableJoinHolder>> parentTableJoinHoldersMap =
+			tableReferenceInfo.getParentTableJoinHoldersMap();
+
+		Assert.assertTrue(
+			parentTableJoinHoldersMap.toString(),
+			parentTableJoinHoldersMap.isEmpty());
+	}
+
+	@Test
 	public void testConstructors() {
 		new TableReferenceInfoFactory();
 
@@ -1005,6 +1088,31 @@ public class TableReferenceInfoFactoryTest {
 
 		private BridgeJoinExampleTable() {
 			super("BridgeJoinExample", BridgeJoinExampleTable::new);
+		}
+
+	}
+
+	private static class CompanyModelExampleTable
+		extends BaseTable<CompanyModelExampleTable> {
+
+		public static final long CLASS_NAME_ID = 4;
+
+		public static final CompanyModelExampleTable INSTANCE =
+			new CompanyModelExampleTable();
+
+		public final Column<CompanyModelExampleTable, Long> companyIdColumn =
+			createColumn(
+				"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+		public final Column<CompanyModelExampleTable, Long>
+			companyModelExampleIdColumn = createColumn(
+				"companyModelExampleId", Long.class, Types.BIGINT,
+				Column.FLAG_PRIMARY);
+		public final Column<CompanyModelExampleTable, Long> mvccVersionColumn =
+			createColumn(
+				"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+
+		private CompanyModelExampleTable() {
+			super("CompanyModelExample", CompanyModelExampleTable::new);
 		}
 
 	}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/change/tracking/spi/reference/ClientExtensionEntryRelTableReferenceDefinition.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/change/tracking/spi/reference/ClientExtensionEntryRelTableReferenceDefinition.java
@@ -32,6 +32,9 @@ public class ClientExtensionEntryRelTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<ClientExtensionEntryRelTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.groupedModel(
+			ClientExtensionEntryRelTable.INSTANCE);
 	}
 
 	@Override

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/change/tracking/spi/reference/ClientExtensionEntryTableReferenceDefinition.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/change/tracking/spi/reference/ClientExtensionEntryTableReferenceDefinition.java
@@ -10,6 +10,7 @@ import com.liferay.change.tracking.spi.reference.builder.ChildTableReferenceInfo
 import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInfoBuilder;
 import com.liferay.client.extension.model.ClientExtensionEntryTable;
 import com.liferay.client.extension.service.persistence.ClientExtensionEntryPersistence;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +33,10 @@ public class ClientExtensionEntryTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<ClientExtensionEntryTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			ClientExtensionEntryTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/internal/change/tracking/spi/reference/CommercePricingClassTableReferenceDefinition.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/internal/change/tracking/spi/reference/CommercePricingClassTableReferenceDefinition.java
@@ -11,6 +11,7 @@ import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInf
 import com.liferay.commerce.pricing.model.CommercePricingClass;
 import com.liferay.commerce.pricing.model.CommercePricingClassTable;
 import com.liferay.commerce.pricing.service.persistence.CommercePricingClassPersistence;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -37,6 +38,10 @@ public class CommercePricingClassTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<CommercePricingClassTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			CommercePricingClassTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramEntryTableReferenceDefinition.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramEntryTableReferenceDefinition.java
@@ -13,6 +13,7 @@ import com.liferay.commerce.product.model.CPInstanceTable;
 import com.liferay.commerce.product.model.CProductTable;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramEntryTable;
 import com.liferay.commerce.shop.by.diagram.service.persistence.CSDiagramEntryPersistence;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -46,6 +47,10 @@ public class CSDiagramEntryTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<CSDiagramEntryTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			CSDiagramEntryTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramPinTableReferenceDefinition.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramPinTableReferenceDefinition.java
@@ -11,6 +11,7 @@ import com.liferay.change.tracking.spi.reference.builder.ParentTableReferenceInf
 import com.liferay.commerce.product.model.CPDefinitionTable;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramPinTable;
 import com.liferay.commerce.shop.by.diagram.service.persistence.CSDiagramPinPersistence;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -37,6 +38,10 @@ public class CSDiagramPinTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<CSDiagramPinTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			CSDiagramPinTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramSettingTableReferenceDefinition.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/internal/change/tracking/spi/reference/CSDiagramSettingTableReferenceDefinition.java
@@ -12,6 +12,7 @@ import com.liferay.commerce.product.model.CPAttachmentFileEntryTable;
 import com.liferay.commerce.product.model.CPDefinitionTable;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramSettingTable;
 import com.liferay.commerce.shop.by.diagram.service.persistence.CSDiagramSettingPersistence;
+import com.liferay.portal.kernel.model.CompanyTable;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
 import org.osgi.service.component.annotations.Component;
@@ -42,6 +43,10 @@ public class CSDiagramSettingTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<CSDiagramSettingTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.singleColumnReference(
+			CSDiagramSettingTable.INSTANCE.companyId,
+			CompanyTable.INSTANCE.companyId);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/reference/KBTemplateTableReferenceDefinition.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/reference/KBTemplateTableReferenceDefinition.java
@@ -54,6 +54,8 @@ public class KBTemplateTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<KBTemplateTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.groupedModel(KBTemplateTable.INSTANCE);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/security/change/tracking/spi/reference/LayoutUtilityPageEntryTableReferenceDefinition.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/security/change/tracking/spi/reference/LayoutUtilityPageEntryTableReferenceDefinition.java
@@ -32,6 +32,9 @@ public class LayoutUtilityPageEntryTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<LayoutUtilityPageEntryTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.groupedModel(
+			LayoutUtilityPageEntryTable.INSTANCE);
 	}
 
 	@Override

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/change/tracking/spi/reference/TranslationEntryTableReferenceDefinition.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/change/tracking/spi/reference/TranslationEntryTableReferenceDefinition.java
@@ -37,6 +37,9 @@ public class TranslationEntryTableReferenceDefinition
 	public void defineParentTableReferences(
 		ParentTableReferenceInfoBuilder<TranslationEntryTable>
 			parentTableReferenceInfoBuilder) {
+
+		parentTableReferenceInfoBuilder.groupedModel(
+			TranslationEntryTable.INSTANCE);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86964

**What is being fixed:** Thirteen `TableReferenceDefinition` (TRD) implementations on GroupedModel or company-scoped tables have empty `defineParentTableReferences` bodies. Because `CTClosureFactoryImpl` walks only the declared parent edges when computing the publication closure — it does not inspect the table schema for `groupId`/`companyId` columns — these entities are invisible to Group/Company exclusion cascades. Their rows can leak into the target environment under the wrong Company/Group scope, and conflict/dependency detection loses the Group/Company edge entirely.

**How it is being fixed:** Each affected TRD now declares its Company (and Group, where applicable) as parents. Tables that have both `groupId` and `companyId` (AssetListEntryUsage, LayoutUtilityPageEntry, KBTemplate, TranslationEntry, ClientExtensionEntryRel) call `parentTableReferenceInfoBuilder.groupedModel(TABLE.INSTANCE)`, which is the existing shortcut for the Group + Company pair. Tables that have only `companyId` (CommercePricingClass, ClientExtensionEntry, CSDiagramEntry/Pin/Setting, AnalyticsMessage/Association/DeleteMessage) use `singleColumnReference` against `CompanyTable.INSTANCE.companyId`, matching the convention already established by peers such as `VirtualHostTableReferenceDefinition` and `PortletTableReferenceDefinition`.

To guard against this class of omission in the future, two unit tests were added to `TableReferenceInfoFactoryTest` (`testGroupedModelOmittedProducesEmptyParents` and `testGroupedModelAddsCompanyAndGroupParents`) backed by a new `GroupedModelExampleTable` fixture. They empirically confirm that the framework does not auto-infer Company/Group parents from column presence — when `groupedModel()` is omitted the parent join holders map is empty, and when it is called the map contains exactly the expected `GroupTable` and `CompanyTable` entries. KBComment was initially considered but excluded as a false positive: it already declares parents via `classNameReference`.