### PR TITLE
LPD-86116 LPD-86546: Export-import navigation menu dates and UUID

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/NavigationMenu.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/NavigationMenu.java
@@ -231,7 +231,7 @@ public class NavigationMenu implements Serializable {
 	}
 
 	@GraphQLField(description = "The navigation menu's creation date.")
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date dateCreated;
 
 	@JsonIgnore
@@ -274,7 +274,7 @@ public class NavigationMenu implements Serializable {
 	}
 
 	@GraphQLField(description = "The last time the navigation menu changed.")
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date dateModified;
 
 	@JsonIgnore
@@ -609,6 +609,47 @@ public class NavigationMenu implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _siteExternalReferenceCodeSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The UUID of the navigation menu."
+	)
+	public String getUuid() {
+		if (_uuidSupplier != null) {
+			uuid = _uuidSupplier.get();
+
+			_uuidSupplier = null;
+		}
+
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+
+		_uuidSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		_uuidSupplier = () -> {
+			try {
+				return uuidUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The UUID of the navigation menu.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String uuid;
+
+	@JsonIgnore
+	private Supplier<String> _uuidSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -822,6 +863,22 @@ public class NavigationMenu implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(siteExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String uuid = getUuid();
+
+		if (uuid != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(uuid));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/NavigationMenuItem.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/NavigationMenuItem.java
@@ -238,7 +238,7 @@ public class NavigationMenuItem implements Serializable {
 	}
 
 	@GraphQLField(description = "The navigation menu item's creation date.")
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date dateCreated;
 
 	@JsonIgnore
@@ -283,7 +283,7 @@ public class NavigationMenuItem implements Serializable {
 	@GraphQLField(
 		description = "The last time the navigation menu item changed."
 	)
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date dateModified;
 
 	@JsonIgnore
@@ -771,6 +771,47 @@ public class NavigationMenuItem implements Serializable {
 	@JsonIgnore
 	private Supplier<Boolean> _useCustomNameSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The UUID of the navigation menu item."
+	)
+	public String getUuid() {
+		if (_uuidSupplier != null) {
+			uuid = _uuidSupplier.get();
+
+			_uuidSupplier = null;
+		}
+
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+
+		_uuidSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		_uuidSupplier = () -> {
+			try {
+				return uuidUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The UUID of the navigation menu item.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String uuid;
+
+	@JsonIgnore
+	private Supplier<String> _uuidSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -1066,6 +1107,22 @@ public class NavigationMenuItem implements Serializable {
 			sb.append("\"useCustomName\": ");
 
 			sb.append(useCustomName);
+		}
+
+		String uuid = getUuid();
+
+		if (uuid != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(uuid));
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/NavigationMenu.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/NavigationMenu.java
@@ -296,6 +296,25 @@ public class NavigationMenu implements Cloneable, Serializable {
 
 	protected String siteExternalReferenceCode;
 
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		try {
+			uuid = uuidUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String uuid;
+
 	@Override
 	public NavigationMenu clone() throws CloneNotSupportedException {
 		return (NavigationMenu)super.clone();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/NavigationMenuItem.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/NavigationMenuItem.java
@@ -373,6 +373,25 @@ public class NavigationMenuItem implements Cloneable, Serializable {
 
 	protected Boolean useCustomName;
 
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		try {
+			uuid = uuidUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String uuid;
+
 	@Override
 	public NavigationMenuItem clone() throws CloneNotSupportedException {
 		return (NavigationMenuItem)super.clone();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/NavigationMenuItemSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/NavigationMenuItemSerDes.java
@@ -297,6 +297,20 @@ public class NavigationMenuItemSerDes {
 			sb.append(navigationMenuItem.getUseCustomName());
 		}
 
+		if (navigationMenuItem.getUuid() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(navigationMenuItem.getUuid()));
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -459,6 +473,13 @@ public class NavigationMenuItemSerDes {
 				String.valueOf(navigationMenuItem.getUseCustomName()));
 		}
 
+		if (navigationMenuItem.getUuid() == null) {
+			map.put("uuid", null);
+		}
+		else {
+			map.put("uuid", String.valueOf(navigationMenuItem.getUuid()));
+		}
+
 		return map;
 	}
 
@@ -531,6 +552,9 @@ public class NavigationMenuItemSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "useCustomName")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
 				return false;
 			}
 
@@ -668,6 +692,11 @@ public class NavigationMenuItemSerDes {
 				if (jsonParserFieldValue != null) {
 					navigationMenuItem.setUseCustomName(
 						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
+				if (jsonParserFieldValue != null) {
+					navigationMenuItem.setUuid((String)jsonParserFieldValue);
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/NavigationMenuSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/NavigationMenuSerDes.java
@@ -222,6 +222,20 @@ public class NavigationMenuSerDes {
 			sb.append("\"");
 		}
 
+		if (navigationMenu.getUuid() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(navigationMenu.getUuid()));
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -343,6 +357,13 @@ public class NavigationMenuSerDes {
 				String.valueOf(navigationMenu.getSiteExternalReferenceCode()));
 		}
 
+		if (navigationMenu.getUuid() == null) {
+			map.put("uuid", null);
+		}
+		else {
+			map.put("uuid", String.valueOf(navigationMenu.getUuid()));
+		}
+
 		return map;
 	}
 
@@ -401,6 +422,9 @@ public class NavigationMenuSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "siteExternalReferenceCode")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
 				return false;
 			}
 
@@ -513,6 +537,11 @@ public class NavigationMenuSerDes {
 				if (jsonParserFieldValue != null) {
 					navigationMenu.setSiteExternalReferenceCode(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
+				if (jsonParserFieldValue != null) {
+					navigationMenu.setUuid((String)jsonParserFieldValue);
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -2410,14 +2410,12 @@ components:
                     description:
                         The navigation menu's creation date.
                     format: date-time
-                    readOnly: true
                     type: string
                 dateModified:
                     # @review
                     description:
                         The last time the navigation menu changed.
                     format: date-time
-                    readOnly: true
                     type: string
                 externalReferenceCode:
                     description:
@@ -2456,6 +2454,10 @@ components:
                     description:
                         The external reference code of the site to which this navigation menu is scoped.
                     readOnly: true
+                    type: string
+                uuid:
+                    description:
+                        The UUID of the navigation menu.
                     type: string
         NavigationMenuFragmentConfigurationFieldValue:
             allOf:
@@ -2509,14 +2511,12 @@ components:
                     description:
                         The navigation menu item's creation date.
                     format: date-time
-                    readOnly: true
                     type: string
                 dateModified:
                     # @review
                     description:
                         The last time the navigation menu item changed.
                     format: date-time
-                    readOnly: true
                     type: string
                 defaultLanguageId:
                     example: en_US
@@ -2577,6 +2577,10 @@ components:
                     type: string
                 useCustomName:
                     type: boolean
+                uuid:
+                    description:
+                        The UUID of the navigation menu item.
+                    type: string
         NavigationMenuValue:
             # @review
             description:
@@ -4784,7 +4788,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.site.client', and version '1.0.27'."
+        'com.liferay.headless.admin.site.client', and version '1.0.28'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuDTOConverter.java
@@ -140,6 +140,7 @@ public class NavigationMenuDTOConverter
 
 						return StringPool.BLANK;
 					});
+				setUuid(siteNavigationMenu::getUuid);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuItemDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuItemDTOConverter.java
@@ -200,6 +200,7 @@ public class NavigationMenuItemDTOConverter
 				setUseCustomName(
 					() -> Boolean.valueOf(
 						unicodeProperties.getProperty("useCustomName")));
+				setUuid(siteNavigationMenuItem::getUuid);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -400,7 +400,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/navigation-menus' -d $'{"auto": ___, "externalReferenceCode": ___, "name": ___, "navigationMenuItems": ___, "navigationType": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/navigation-menus' -d $'{"auto": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "name": ___, "navigationMenuItems": ___, "navigationType": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Creates a new navigation menu."
@@ -614,7 +614,7 @@ public abstract class BaseNavigationMenuResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/navigation-menus/{navigationMenuExternalReferenceCode}' -d $'{"auto": ___, "externalReferenceCode": ___, "name": ___, "navigationMenuItems": ___, "navigationType": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/navigation-menus/{navigationMenuExternalReferenceCode}' -d $'{"auto": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "name": ___, "navigationMenuItems": ___, "navigationType": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the navigation menu with the given external reference code or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -248,9 +248,7 @@ public class NavigationMenuResourceImpl
 				externalReferenceCode, groupId, navigationMenu.getName(),
 				_getNavigationMenuType(navigationMenu),
 				_isAuto(navigationMenu.getAuto()),
-				ServiceContextBuilder.create(
-					groupId, contextHttpServletRequest, null
-				).build());
+				_createServiceContext(groupId, navigationMenu));
 
 		_createNavigationMenuItems(
 			groupId, navigationMenu.getNavigationMenuItems(), 0,
@@ -280,15 +278,7 @@ public class NavigationMenuResourceImpl
 				siteNavigationMenuId, parentNavigationMenuId,
 				navigationMenuItem.getType(),
 				_getTypeSettings(navigationMenuItem),
-				ServiceContextBuilder.create(
-					groupId, contextHttpServletRequest, null
-				).expandoBridgeAttributes(
-					CustomFieldsUtil.toMap(
-						SiteNavigationMenuItem.class.getName(),
-						contextCompany.getCompanyId(),
-						navigationMenuItem.getCustomFields(),
-						contextAcceptLanguage.getPreferredLocale())
-				).build());
+				_createServiceContext(groupId, navigationMenuItem));
 
 		_createNavigationMenuItems(
 			groupId, navigationMenuItem.getNavigationMenuItems(),
@@ -310,6 +300,40 @@ public class NavigationMenuResourceImpl
 				groupId, navigationMenuItem, parentNavigationMenuId,
 				siteNavigationMenuId);
 		}
+	}
+
+	private ServiceContext _createServiceContext(
+		long groupId, NavigationMenu navigationMenu) {
+
+		ServiceContext serviceContext = ServiceContextBuilder.create(
+			groupId, contextHttpServletRequest, null
+		).build();
+
+		serviceContext.setCreateDate(navigationMenu.getDateCreated());
+		serviceContext.setModifiedDate(navigationMenu.getDateModified());
+		serviceContext.setUuid(navigationMenu.getUuid());
+
+		return serviceContext;
+	}
+
+	private ServiceContext _createServiceContext(
+		long groupId, NavigationMenuItem navigationMenuItem) {
+
+		ServiceContext serviceContext = ServiceContextBuilder.create(
+			groupId, contextHttpServletRequest, null
+		).expandoBridgeAttributes(
+			CustomFieldsUtil.toMap(
+				SiteNavigationMenuItem.class.getName(),
+				contextCompany.getCompanyId(),
+				navigationMenuItem.getCustomFields(),
+				contextAcceptLanguage.getPreferredLocale())
+		).build();
+
+		serviceContext.setCreateDate(navigationMenuItem.getDateCreated());
+		serviceContext.setModifiedDate(navigationMenuItem.getDateModified());
+		serviceContext.setUuid(navigationMenuItem.getUuid());
+
+		return serviceContext;
 	}
 
 	private void _deleteNavigationMenuItems(
@@ -637,9 +661,8 @@ public class NavigationMenuResourceImpl
 			navigationMenu.getNavigationMenuItems(), 0,
 			siteNavigationMenu.getSiteNavigationMenuId());
 
-		ServiceContext serviceContext = ServiceContextBuilder.create(
-			siteNavigationMenu.getGroupId(), contextHttpServletRequest, null
-		).build();
+		ServiceContext serviceContext = _createServiceContext(
+			siteNavigationMenu.getGroupId(), navigationMenu);
 
 		_siteNavigationMenuService.updateSiteNavigationMenu(
 			siteNavigationMenu.getSiteNavigationMenuId(),
@@ -705,15 +728,7 @@ public class NavigationMenuResourceImpl
 					_siteNavigationMenuItemService.updateSiteNavigationMenuItem(
 						siteNavigationMenuItem.getSiteNavigationMenuItemId(),
 						_getTypeSettings(navigationMenuItem),
-						ServiceContextBuilder.create(
-							groupId, contextHttpServletRequest, null
-						).expandoBridgeAttributes(
-							CustomFieldsUtil.toMap(
-								SiteNavigationMenuItem.class.getName(),
-								contextCompany.getCompanyId(),
-								navigationMenuItem.getCustomFields(),
-								contextAcceptLanguage.getPreferredLocale())
-						).build());
+						_createServiceContext(groupId, navigationMenuItem));
 
 				_updateNavigationMenuItems(
 					groupId, navigationMenuItem.getNavigationMenuItems(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.site.client', and version '1.0.27'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Admin Sites Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.site.client', and version '1.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Admin Sites Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -201,6 +201,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		navigationMenu.setExternalReferenceCode(regex);
 		navigationMenu.setName(regex);
 		navigationMenu.setSiteExternalReferenceCode(regex);
+		navigationMenu.setUuid(regex);
 
 		String json = NavigationMenuSerDes.toJSON(navigationMenu);
 
@@ -212,6 +213,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		Assert.assertEquals(regex, navigationMenu.getName());
 		Assert.assertEquals(
 			regex, navigationMenu.getSiteExternalReferenceCode());
+		Assert.assertEquals(regex, navigationMenu.getUuid());
 	}
 
 	@Test
@@ -1138,6 +1140,14 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("uuid", additionalAssertFieldName)) {
+				if (navigationMenu.getUuid() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -1389,6 +1399,16 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				if (!Objects.deepEquals(
 						navigationMenu1.getSiteExternalReferenceCode(),
 						navigationMenu2.getSiteExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("uuid", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						navigationMenu1.getUuid(), navigationMenu2.getUuid())) {
 
 					return false;
 				}
@@ -1735,6 +1755,52 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("uuid")) {
+			Object object = navigationMenu.getUuid();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -1789,6 +1855,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				siteExternalReferenceCode =
 					testGroup.getExternalReferenceCode();
+				uuid = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -83,6 +84,8 @@ import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalService;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 
 import java.io.Serializable;
+
+import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -339,10 +342,12 @@ public class NavigationMenuResourceTest
 		super.testPostSiteNavigationMenu();
 
 		_testPostSiteNavigationMenuBatchWithInvalidItemModel();
+		_testPostSiteNavigationMenuWithCreationAndModificationDate();
 		_testPostSiteNavigationMenuWithCompanyGroup();
 		_testPostSiteNavigationMenuWithInvalidItemModel();
 		_testPostSiteNavigationMenuWithNavigationType();
 		_testPostSiteNavigationMenuWithPermissions();
+		_testPostSiteNavigationMenuWithUuid();
 	}
 
 	@Override
@@ -1259,6 +1264,29 @@ public class NavigationMenuResourceTest
 		assertEquals(navigationMenu, postNavigationMenu);
 	}
 
+	private void _testPostSiteNavigationMenuWithCreationAndModificationDate()
+		throws Exception {
+
+		NavigationMenu navigationMenu = _randomNavigationMenu(false);
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd");
+
+		navigationMenu.setDateCreated(dateFormat.parse("2023-01-01"));
+		navigationMenu.setDateModified(dateFormat.parse("2023-02-02"));
+
+		NavigationMenu postNavigationMenu =
+			navigationMenuResource.postSiteNavigationMenu(
+				testGroup.getExternalReferenceCode(), navigationMenu);
+
+		Assert.assertEquals(
+			navigationMenu.getDateCreated(),
+			postNavigationMenu.getDateCreated());
+		Assert.assertEquals(
+			navigationMenu.getDateModified(),
+			postNavigationMenu.getDateModified());
+	}
+
 	private void _testPostSiteNavigationMenuWithInvalidItemModel()
 		throws Exception {
 
@@ -1358,6 +1386,19 @@ public class NavigationMenuResourceTest
 							   serviceBuilderRole.getExternalReferenceCode(),
 							   permission.getRoleExternalReferenceCode());
 				}));
+	}
+
+	private void _testPostSiteNavigationMenuWithUuid() throws Exception {
+		NavigationMenu navigationMenu = _randomNavigationMenu(false);
+
+		navigationMenu.setUuid(RandomTestUtil.randomString());
+
+		NavigationMenu postNavigationMenu =
+			navigationMenuResource.postSiteNavigationMenu(
+				testGroup.getExternalReferenceCode(), navigationMenu);
+
+		Assert.assertEquals(
+			navigationMenu.getUuid(), postNavigationMenu.getUuid());
 	}
 
 	private void _testPutSiteNavigationMenuWithCompanyGroup() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -342,8 +342,8 @@ public class NavigationMenuResourceTest
 		super.testPostSiteNavigationMenu();
 
 		_testPostSiteNavigationMenuBatchWithInvalidItemModel();
-		_testPostSiteNavigationMenuWithCreationAndModificationDate();
 		_testPostSiteNavigationMenuWithCompanyGroup();
+		_testPostSiteNavigationMenuWithCreationAndModificationDate();
 		_testPostSiteNavigationMenuWithInvalidItemModel();
 		_testPostSiteNavigationMenuWithNavigationType();
 		_testPostSiteNavigationMenuWithPermissions();
@@ -1272,19 +1272,48 @@ public class NavigationMenuResourceTest
 		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
 			"yyyy-MM-dd");
 
-		navigationMenu.setDateCreated(dateFormat.parse("2023-01-01"));
-		navigationMenu.setDateModified(dateFormat.parse("2023-02-02"));
+		Date dateCreated = dateFormat.parse("2023-01-01");
+		Date dateModified = dateFormat.parse("2023-02-02");
+		Date itemDateCreated = dateFormat.parse("2023-03-03");
+		Date itemDateModified = dateFormat.parse("2023-04-04");
+
+		navigationMenu.setDateCreated(dateCreated);
+		navigationMenu.setDateModified(dateModified);
+		navigationMenu.setNavigationMenuItems(
+			new NavigationMenuItem[] {
+				new NavigationMenuItem() {
+					{
+						setDateCreated(itemDateCreated);
+						setDateModified(itemDateModified);
+						setNavigationMenuItemSettings(
+							new URLNavigationMenuItemSettings() {
+								{
+									url = "https://www.liferay.com";
+									useNewTab = false;
+								}
+							});
+						setType("url");
+					}
+				}
+			});
 
 		NavigationMenu postNavigationMenu =
 			navigationMenuResource.postSiteNavigationMenu(
 				testGroup.getExternalReferenceCode(), navigationMenu);
 
+		Assert.assertEquals(dateCreated, postNavigationMenu.getDateCreated());
+		Assert.assertEquals(dateModified, postNavigationMenu.getDateModified());
+
+		NavigationMenuItem[] postNavigationMenuItems =
+			postNavigationMenu.getNavigationMenuItems();
+
 		Assert.assertEquals(
-			navigationMenu.getDateCreated(),
-			postNavigationMenu.getDateCreated());
+			Arrays.toString(postNavigationMenuItems), 1,
+			postNavigationMenuItems.length);
 		Assert.assertEquals(
-			navigationMenu.getDateModified(),
-			postNavigationMenu.getDateModified());
+			itemDateCreated, postNavigationMenuItems[0].getDateCreated());
+		Assert.assertEquals(
+			itemDateModified, postNavigationMenuItems[0].getDateModified());
 	}
 
 	private void _testPostSiteNavigationMenuWithInvalidItemModel()
@@ -1391,14 +1420,40 @@ public class NavigationMenuResourceTest
 	private void _testPostSiteNavigationMenuWithUuid() throws Exception {
 		NavigationMenu navigationMenu = _randomNavigationMenu(false);
 
-		navigationMenu.setUuid(RandomTestUtil.randomString());
+		String itemUuid = RandomTestUtil.randomString();
+		String uuid = RandomTestUtil.randomString();
+
+		navigationMenu.setNavigationMenuItems(
+			new NavigationMenuItem[] {
+				new NavigationMenuItem() {
+					{
+						setNavigationMenuItemSettings(
+							new URLNavigationMenuItemSettings() {
+								{
+									url = "https://www.liferay.com";
+									useNewTab = false;
+								}
+							});
+						setType("url");
+						setUuid(itemUuid);
+					}
+				}
+			});
+		navigationMenu.setUuid(uuid);
 
 		NavigationMenu postNavigationMenu =
 			navigationMenuResource.postSiteNavigationMenu(
 				testGroup.getExternalReferenceCode(), navigationMenu);
 
+		Assert.assertEquals(uuid, postNavigationMenu.getUuid());
+
+		NavigationMenuItem[] postNavigationMenuItems =
+			postNavigationMenu.getNavigationMenuItems();
+
 		Assert.assertEquals(
-			navigationMenu.getUuid(), postNavigationMenu.getUuid());
+			Arrays.toString(postNavigationMenuItems), 1,
+			postNavigationMenuItems.length);
+		Assert.assertEquals(itemUuid, postNavigationMenuItems[0].getUuid());
 	}
 
 	private void _testPutSiteNavigationMenuWithCompanyGroup() throws Exception {


### PR DESCRIPTION
Continues [#3188](https://github.com/liferay-site-management/liferay-portal/pull/3188) (by @peerkar) with an additional commit that extends the integration tests to cover item-level round-trip of `uuid`, `dateCreated`, and `dateModified` on `NavigationMenuItem` (not just `NavigationMenu`).

- https://liferay.atlassian.net/browse/LPD-84210
  - https://liferay.atlassian.net/browse/LPD-86546
  - https://liferay.atlassian.net/browse/LPD-86116

This PR is based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210).

## Test plan

- [ ] `liferay test-integration headless-admin-site-test --tests NavigationMenuResourceTest`