### PR TITLE
LPD-87322 Fix search bar locator

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/updatePublicationsPermissions.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/updatePublicationsPermissions.spec.ts
@@ -209,7 +209,7 @@ test.describe('Add Search Bar for the Regular Roles Permissions Tab', () => {
 	test('LPD-57648 Filter Permission Roles with search bar', async ({
 		page,
 	}) => {
-		const searchBar = page.getByLabel('Search');
+		const searchBar = page.getByRole('textbox', {name: 'Search'});
 
 		await expect(searchBar).toBeVisible();
 
@@ -242,7 +242,7 @@ test.describe('Add Search Bar for the Regular Roles Permissions Tab', () => {
 	});
 
 	test('LPD-57648 Show empty search results', async ({page}) => {
-		const searchBar = page.getByLabel('Search');
+		const searchBar = page.getByRole('textbox', {name: 'Search'});
 
 		await expect(searchBar).toBeVisible();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87322

**What is being fixed:** Two Playwright tests in `updatePublicationsPermissions.spec.ts` under the `Add Search Bar for the Regular Roles Permissions Tab` describe block were failing because `page.getByLabel('Search')` no longer resolves to a single element on the Publications Permissions Regular Roles tab.

**How it is being fixed:** Switched the search-bar locator from `page.getByLabel('Search')` to `page.getByRole('textbox', { name: 'Search' })` so the query disambiguates to the input element. The change applies to both failing tests: `LPD-57648 Filter Permission Roles with search bar` and `LPD-57648 Show empty search results`.