### PR TITLE
LPD-86809 Convert shadow root locator failing tests to playwright

### DIFF
--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -449,6 +449,16 @@ export class ChangeTrackingPage {
 		await this.page.locator('h2').filter({hasText: title}).waitFor();
 	}
 
+	async selectRenderView(name: string) {
+		const renderViewDropdown = this.page.locator(
+			'.publications-render-view-divider .dropdown'
+		);
+
+		await renderViewDropdown.click();
+
+		await this.page.getByRole('menuitem', {name}).click();
+	}
+
 	async selectTab(tabLabel: string) {
 		const tabLink = this.tabsContainer.locator('a', {
 			hasText: tabLabel,

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -896,9 +896,93 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 
 	await documentLibraryEditFilePage.publishButton.click();
 
+	await waitForAlert(page, 'Success:Your request completed successfully.');
+
 	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 	await changeTrackingPage.reviewChange('astronaut2');
+
+	const renderViewDropdown = page.locator(
+		'.publications-render-view-divider .dropdown'
+	);
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.locator('img[src*="astronaut"]')})
+			.first()
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Production'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.locator('img[src*="astronaut"]')})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {name: ctCollection.body.name})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.locator('img[src*="astronaut"]')})
+	).toBeVisible();
+
 	await changeTrackingPage.selectTab('Data');
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+
+	await expect(
+		page.locator(
+			'td.publications-key-td:has-text("Title") + td .diff-html-added'
+		)
+	).toHaveText('astronaut2');
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Split View'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Title") + td')
+			.filter({has: page.getByText('astronaut.png', {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Title") + td')
+			.filter({has: page.getByText('astronaut2', {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Production'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Title") + td')
+			.filter({has: page.getByText('astronaut.png', {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {name: ctCollection.body.name})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Title") + td')
+			.filter({has: page.getByText('astronaut2', {exact: true})})
+	).toBeVisible();
 
 	const downloadPromise = page.waitForEvent('download');
 

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -1128,3 +1128,180 @@ test('LPD-82268 FragmentEntryLink change displays the fragment related to the pu
 		page.getByRole('link', {name: `Heading for ${pageTitle}`})
 	).toBeVisible();
 });
+
+test('LPD-86809 Web content change details display diff preview', async ({
+	changeTrackingPage,
+	ctCollection,
+	journalEditArticlePage,
+	page,
+}) => {
+	await changeTrackingPage.workOnProduction();
+
+	await journalEditArticlePage.goto();
+
+	const title = getRandomString();
+
+	await journalEditArticlePage.fillTitle(title);
+
+	const content = getRandomString();
+
+	await journalEditArticlePage.journalPage.fillArticleContent(content);
+
+	await journalEditArticlePage.publishArticle();
+
+	await waitForAlert(page, `Success:${title} was created successfully.`);
+
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	await journalEditArticlePage.editArticle(title);
+
+	const editedTitle = title + ' Edited';
+
+	await journalEditArticlePage.fillTitle(editedTitle);
+
+	const editedContent = content + ' Edited';
+
+	await journalEditArticlePage.journalPage.articleContentTextBox.click();
+	await journalEditArticlePage.journalPage.articleContentTextBox.selectText();
+	await journalEditArticlePage.journalPage.articleContentTextBox.press(
+		'Backspace'
+	);
+	await journalEditArticlePage.journalPage.articleContentTextBox.pressSequentially(
+		editedContent
+	);
+
+	await journalEditArticlePage.publishArticle(true);
+
+	await waitForAlert(
+		page,
+		`Success:${editedTitle} was updated successfully.`
+	);
+
+	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+	await changeTrackingPage.reviewChange(editedTitle);
+
+	const renderViewDropdown = page.locator(
+		'.publications-render-view-divider .dropdown'
+	);
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+
+	await expect(
+		page.locator('.diff-html-added').filter({hasText: 'Edited'})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Split View'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(content, {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(editedContent, {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(content, {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {
+			name: `Version: 1.1 (${ctCollection.body.name})`,
+		})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(editedContent, {exact: true})})
+	).toBeVisible();
+
+	await changeTrackingPage.selectTab('Data');
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+
+	await expect(
+		page.locator(
+			'td.publications-key-td:has-text("Name") + td .diff-html-added'
+		)
+	).toHaveText('Edited');
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Split View'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Name") + td')
+			.filter({has: page.getByText(title, {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Name") + td')
+			.filter({has: page.getByText(editedTitle, {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Name") + td')
+			.filter({has: page.getByText(title, {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {
+			name: `Version: 1.1 (${ctCollection.body.name})`,
+		})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-key-td:has-text("Name") + td')
+			.filter({has: page.getByText(editedTitle, {exact: true})})
+	).toBeVisible();
+
+	await changeTrackingPage.selectTab('Parents');
+
+	await expect(
+		page.locator('tr').filter({hasText: 'Site'}).locator('+ tr')
+	).toHaveText('Guest');
+
+	await changeTrackingPage.selectTab('Children');
+
+	await expect(
+		page
+			.locator('tr')
+			.filter({hasText: 'Web Content Translation'})
+			.locator('+ tr')
+			.getByText(editedTitle, {exact: true})
+	).toBeVisible();
+});

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -902,10 +902,6 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 	await changeTrackingPage.reviewChange('astronaut2');
 
-	const renderViewDropdown = page.locator(
-		'.publications-render-view-divider .dropdown'
-	);
-
 	await expect(
 		page
 			.locator('td.publications-render-view-content')
@@ -913,9 +909,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 			.first()
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Production'}).click();
+	await changeTrackingPage.selectRenderView('Production');
 
 	await expect(
 		page
@@ -923,11 +917,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 			.filter({has: page.locator('img[src*="astronaut"]')})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {name: ctCollection.body.name})
-		.click();
+	await changeTrackingPage.selectRenderView(ctCollection.body.name);
 
 	await expect(
 		page
@@ -937,9 +927,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 
 	await changeTrackingPage.selectTab('Data');
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+	await changeTrackingPage.selectRenderView('Unified View');
 
 	await expect(
 		page.locator(
@@ -947,9 +935,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 		)
 	).toHaveText('astronaut2');
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Split View'}).click();
+	await changeTrackingPage.selectRenderView('Split View');
 
 	await expect(
 		page
@@ -963,9 +949,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 			.filter({has: page.getByText('astronaut2', {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Production'}).click();
+	await changeTrackingPage.selectRenderView('Production');
 
 	await expect(
 		page
@@ -973,11 +957,7 @@ test('LPD-62940 Assert download button is visible and functional in the data tab
 			.filter({has: page.getByText('astronaut.png', {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {name: ctCollection.body.name})
-		.click();
+	await changeTrackingPage.selectRenderView(ctCollection.body.name);
 
 	await expect(
 		page
@@ -1182,21 +1162,13 @@ test('LPD-86809 Web content change details display diff preview', async ({
 
 	await changeTrackingPage.reviewChange(editedTitle);
 
-	const renderViewDropdown = page.locator(
-		'.publications-render-view-divider .dropdown'
-	);
-
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+	await changeTrackingPage.selectRenderView('Unified View');
 
 	await expect(
 		page.locator('.diff-html-added').filter({hasText: 'Edited'})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Split View'}).click();
+	await changeTrackingPage.selectRenderView('Split View');
 
 	await expect(
 		page
@@ -1210,11 +1182,7 @@ test('LPD-86809 Web content change details display diff preview', async ({
 			.filter({has: page.getByText(editedContent, {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
-		.click();
+	await changeTrackingPage.selectRenderView('Version: 1.0 (Production)');
 
 	await expect(
 		page
@@ -1222,13 +1190,9 @@ test('LPD-86809 Web content change details display diff preview', async ({
 			.filter({has: page.getByText(content, {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {
-			name: `Version: 1.1 (${ctCollection.body.name})`,
-		})
-		.click();
+	await changeTrackingPage.selectRenderView(
+		`Version: 1.1 (${ctCollection.body.name})`
+	);
 
 	await expect(
 		page
@@ -1238,9 +1202,7 @@ test('LPD-86809 Web content change details display diff preview', async ({
 
 	await changeTrackingPage.selectTab('Data');
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+	await changeTrackingPage.selectRenderView('Unified View');
 
 	await expect(
 		page.locator(
@@ -1248,9 +1210,7 @@ test('LPD-86809 Web content change details display diff preview', async ({
 		)
 	).toHaveText('Edited');
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Split View'}).click();
+	await changeTrackingPage.selectRenderView('Split View');
 
 	await expect(
 		page
@@ -1264,11 +1224,7 @@ test('LPD-86809 Web content change details display diff preview', async ({
 			.filter({has: page.getByText(editedTitle, {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
-		.click();
+	await changeTrackingPage.selectRenderView('Version: 1.0 (Production)');
 
 	await expect(
 		page
@@ -1276,13 +1232,9 @@ test('LPD-86809 Web content change details display diff preview', async ({
 			.filter({has: page.getByText(title, {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {
-			name: `Version: 1.1 (${ctCollection.body.name})`,
-		})
-		.click();
+	await changeTrackingPage.selectRenderView(
+		`Version: 1.1 (${ctCollection.body.name})`
+	);
 
 	await expect(
 		page
@@ -1364,13 +1316,7 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.reviewChange(wikiPageTitle);
 
-	const renderViewDropdown = page.locator(
-		'.publications-render-view-divider .dropdown'
-	);
-
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+	await changeTrackingPage.selectRenderView('Unified View');
 
 	await expect(
 		page.locator('.diff-html-added').filter({hasText: 'Edited'})
@@ -1380,9 +1326,7 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 		page.locator('.diff-html-added').filter({hasText: 'Attachments'})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page.getByRole('menuitem', {name: 'Split View'}).click();
+	await changeTrackingPage.selectRenderView('Split View');
 
 	await expect(
 		page
@@ -1400,11 +1344,7 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 		page.locator('td.publications-render-view-content .page-attachments')
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
-		.click();
+	await changeTrackingPage.selectRenderView('Version: 1.0 (Production)');
 
 	await expect(
 		page
@@ -1412,13 +1352,9 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 			.filter({has: page.getByText(wikiPageContent, {exact: true})})
 	).toBeVisible();
 
-	await renderViewDropdown.click();
-
-	await page
-		.getByRole('menuitem', {
-			name: `Version: 1.1 (${ctCollection.body.name})`,
-		})
-		.click();
+	await changeTrackingPage.selectRenderView(
+		`Version: 1.1 (${ctCollection.body.name})`
+	);
 
 	await expect(
 		page

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -35,6 +35,7 @@ export const test = mergeTests(
 	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPD-34594': {enabled: true},
+		'LPD-35013': {enabled: true},
 		'LPD-84028': {enabled: true},
 		'LPS-164563': {enabled: true},
 	}),
@@ -1303,5 +1304,129 @@ test('LPD-86809 Web content change details display diff preview', async ({
 			.filter({hasText: 'Web Content Translation'})
 			.locator('+ tr')
 			.getByText(editedTitle, {exact: true})
+	).toBeVisible();
+});
+
+test('LPS-179026 Can preview changes for WikiPages', async ({
+	apiHelpers,
+	changeTrackingPage,
+	ctCollection,
+	page,
+}) => {
+	const site =
+		await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath('guest');
+
+	const wikiNode = await apiHelpers.headlessDelivery.postWikiNode(site.id);
+
+	const wikiPageContent = 'Wiki Page Content';
+	const wikiPageTitle = 'Wiki Page Title';
+
+	const wikiPage = await apiHelpers.headlessDelivery.postWikiPage(
+		wikiNode.id,
+		{
+			content: wikiPageContent,
+			headline: wikiPageTitle,
+		}
+	);
+
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	const wikiPageContentEdited = wikiPageContent + ' Edited';
+
+	await apiHelpers.put(
+		`${apiHelpers.baseUrl}headless-delivery/v1.0/wiki-pages/${wikiPage.id}`,
+		{
+			data: {
+				content: wikiPageContentEdited,
+				encodingFormat: 'plain_text',
+				headline: wikiPageTitle,
+			},
+			failOnStatusCode: true,
+		}
+	);
+
+	await apiHelpers.post(
+		`${apiHelpers.baseUrl}headless-delivery/v1.0/wiki-pages/${wikiPage.id}/wiki-page-attachments`,
+		{
+			failOnStatusCode: true,
+			headers: {
+				...(await apiHelpers.getCSRFTokenHeader()),
+			},
+			multipart: {
+				file: createReadStream(
+					path.join(__dirname, '/dependencies/attachment.txt')
+				),
+			},
+		}
+	);
+
+	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+	await changeTrackingPage.reviewChange(wikiPageTitle);
+
+	const renderViewDropdown = page.locator(
+		'.publications-render-view-divider .dropdown'
+	);
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Unified View'}).click();
+
+	await expect(
+		page.locator('.diff-html-added').filter({hasText: 'Edited'})
+	).toBeVisible();
+
+	await expect(
+		page.locator('.diff-html-added').filter({hasText: 'Attachments'})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page.getByRole('menuitem', {name: 'Split View'}).click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page.locator('td.publications-render-view-content .page-attachments')
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {name: 'Version: 1.0 (Production)'})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+	).toBeVisible();
+
+	await renderViewDropdown.click();
+
+	await page
+		.getByRole('menuitem', {
+			name: `Version: 1.1 (${ctCollection.body.name})`,
+		})
+		.click();
+
+	await expect(
+		page
+			.locator('td.publications-render-view-content')
+			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+	).toBeVisible();
+
+	await expect(
+		page.locator('td.publications-render-view-content .page-attachments')
 	).toBeVisible();
 });

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -1805,65 +1805,6 @@ definition {
 		}
 	}
 
-	@description = "Assert Publications change details on Display Data Parents and Children Tabs"
-	@priority = 4
-	test ViewPublicationsChangeDetails {
-		JSONWebcontent.addWebContent(
-			content = "WC WebContent Content",
-			groupName = "Guest",
-			title = "WC WebContent Title");
-
-		JSONPublications.addPublication(publicationName = "Publication Name");
-
-		JSONPublications.selectPublication(publicationName = "Publication Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		WebContentNavigator.gotoEditCP(webContentTitle = "WC WebContent Title");
-
-		WebContent.editCP(
-			webContentContentEdit = "WC WebContent Content Edited",
-			webContentTitle = "WC WebContent Title",
-			webContentTitleEdit = "WC WebContent Title Edited");
-
-		PublicationsNavigator.gotoReviewChanges(
-			gotoPublicationsAdmin = "true",
-			publicationName = "Publication Name");
-
-		PublicationsNavigator.gotoViewChangeDetails(
-			changeCategory = "Web Content Article",
-			changeTitle = "WC WebContent Title Edited");
-
-		PublicationsChangeDetails.viewChangeDetailsInDisplay(
-			changeType = "Modified",
-			contentValueInProduction = "WC WebContent Content",
-			contentValueInPublication = "WC WebContent Content Edited",
-			diffAddedValue = "Edited",
-			publicationName = "Publication Name");
-
-		PublicationsNavigator.gotoNavbar(navBarTitle = "Data");
-
-		PublicationsChangeDetails.viewChangeDetailsInData(
-			changeType = "Modified",
-			columnName = "Name",
-			columnValueInProduction = "WC WebContent Title",
-			columnValueInPublication = "WC WebContent Title Edited",
-			diffAddedValue = "Edited",
-			publicationName = "Publication Name");
-
-		PublicationsNavigator.gotoNavbar(navBarTitle = "Parents");
-
-		PublicationsChangeDetails.viewChangeDetailsInParents(
-			changeParentsCategory = "Site",
-			changeParentsTitle = "Guest");
-
-		PublicationsNavigator.gotoNavbar(navBarTitle = "Children");
-
-		PublicationsChangeDetails.viewChangeDetailsInChildren(
-			changeChildrenCategory = "Web Content Translation",
-			changeChildrenTitle = "WC WebContent Title Edited");
-	}
-
 	@description = "Can view Published Publications items pagination and order on History Tab."
 	@priority = 4
 	test ViewPublicationsHistoryItemsPaginationAndOrder {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsDM.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsDM.testcase
@@ -354,41 +354,4 @@ definition {
 		DMDocument.viewCP(dmDocumentTitle = "Document_1.jpg");
 	}
 
-	@priority = 4
-	test ViewPublicationsPreviewForAddedDocuments {
-		JSONPublications.addPublication(publicationName = "Publication Name");
-
-		JSONPublications.selectPublication(publicationName = "Publication Name");
-
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Site Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		PublicationsNavigator.gotoReviewChanges(
-			gotoPublicationsAdmin = "true",
-			publicationName = "Publication Name");
-
-		PublicationsNavigator.gotoViewChangeDetails(
-			changeCategory = "Document",
-			changeTitle = "Document_1.jpg");
-
-		PublicationsChangeDetails.viewDocumentChangeDetailsInDisplay(
-			changeType = "Added",
-			keyImage = "Document_1.jpg",
-			publicationName = "Publication Name");
-
-		PublicationsNavigator.gotoNavbar(navBarTitle = "Data");
-
-		PublicationsChangeDetails.viewChangeDetailsInData(
-			changeType = "Added",
-			columnName = "Title",
-			columnValueInPublication = "Document_1.jpg",
-			publicationName = "Publication Name");
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsWiki.testcase
@@ -224,52 +224,6 @@ definition {
 		}
 	}
 
-	@description = "This is the use case for LPS-179026. Can preview changes for WikiPages"
-	@priority = 3
-	test CanPreviewChangesForWikiPages {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONWiki.addWikiPage(
-			groupName = "Site Name",
-			wikiNodeName = "Main",
-			wikiPageContent = "Wiki Page Content",
-			wikiPageName = "Wiki Page Title");
-
-		JSONPublications.addPublication(publicationName = "Publication Name 1");
-
-		JSONPublications.selectPublication(publicationName = "Publication Name 1");
-
-		WikiNavigator.openWikiAdmin(siteURLKey = "site-name");
-
-		JSONWiki.updateWikiPage(
-			groupName = "Site Name",
-			wikiNodeName = "Main",
-			wikiPageContent = "Wiki Page Content Edited",
-			wikiPageName = "Wiki Page Title");
-
-		JSONWiki.addAttachmentToWikiPage(
-			fileName = "Document_1.txt",
-			groupName = "Site Name",
-			mimeType = "text/txt",
-			wikiNodeName = "Main",
-			wikiPageName = "Wiki Page Title");
-
-		task ("View the wiki page change details on Display tab") {
-			PublicationsNavigator.gotoReviewChanges();
-
-			PublicationsNavigator.gotoViewChangeDetails(
-				changeCategory = "Wiki Page",
-				changeTitle = "Wiki Page Title (1.1)");
-
-			PublicationsChangeDetails.viewChangeDetailsInDisplay(
-				changeType = "Modified",
-				contentValueInProduction = "Wiki Page Content",
-				contentValueInPublication = "Wiki Page Content Edited",
-				diffAddedValue = "Attachments",
-				publicationName = "Publication Name 1");
-		}
-	}
-
 	@description = "This is a use case for LPS-174885. Resolve typical conflicts when using wiki with publications"
 	@priority = 3
 	test CanResolveConflictingPublicationsAutomatically {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86809

tests failing due to a locator that's now in shadow DOM and not accessible by poshi converted to playwright tests. playwright can access these locators.