### PR TITLE
LPD-87375 Replace stale Navigator.gotoNavTab with ApplicationsMenu.gotoPanel

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -208,7 +208,7 @@ definition {
 
 		ApplicationsMenu.openApplicationsMenu();
 
-		Navigator.gotoNavTab(navTab = "Applications");
+		ApplicationsMenu.gotoPanel(panel = "Applications");
 
 		PublicationsNavigator.openPublicationsAdmin();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87375

**What is being fixed:** The Poshi test `Publications#BrowsingInPublicationCannotCauseChanges` was failing with `ElementNotFoundPoshiRunnerException` at `Navigator.macro:130`. The call `Navigator.gotoNavTab(navTab = "Applications")` at `Publications.testcase:211` targets the old tabbed Applications Menu UI that was replaced with a panel-based GlobalMenu in LPD-80451. This was the last remaining caller of that pattern; every other testcase already uses `ApplicationsMenu.gotoPanel(panel = "Applications")`.

**How it is being fixed:** Replace the stale `Navigator.gotoNavTab` call at line 211 with the canonical `ApplicationsMenu.gotoPanel(panel = "Applications")`. After the change, every Poshi step in the test reports pass against a running bundle. A separate, unrelated failure in `assertNoPoshiWarnings` from portal-side NPEs in `PublicationsPortlet` is out of scope for this ticket.