### PR TITLE
LPD-87426 Fix flaky click-to-chat hide widget test

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/clickToChatInstanceSettings.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/clickToChatInstanceSettings.spec.ts
@@ -170,7 +170,7 @@ test(
 		finally {
 			await page.getByLabel('Hide in Control Panel').uncheck();
 
-			await clickToChatSettingsPage.saveButton.click();
+			await clickToChatSettingsPage.saveConfiguration();
 		}
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87426

**What is being fixed:** The "Can hide chat widget in control panel"
test was flaky in CI with net::ERR_ABORTED on page navigation. The
finally block called saveButton.click() without waiting for the save to
complete, so the in-flight form submission raced with afterEach's
navigation back to instance settings.

**How it is being fixed:** Replace the bare saveButton.click() in the
finally block with saveConfiguration(), which is the same helper
already used in the try block. It waits for the success alert and the
subsequent page reload before returning, ensuring afterEach starts from
a settled page state.