### PR TITLE
LPD-86446 Remove apiHelpers.headlessSite calls for Headless

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminSiteApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminSiteApiHelper.ts
@@ -42,7 +42,7 @@ export type TSite = {
 	membershipType?: string;
 	name: string;
 	parentSiteExternalReferenceCode?: string;
-	templateKey?: number;
+	templateKey?: string;
 	templateType?: string;
 };
 

--- a/modules/test/playwright/tests/batch-planner/main/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/main/import.spec.ts
@@ -507,11 +507,9 @@ test('Admin users can see all site scopes regardless of site membership', async 
 	let site: Site;
 
 	await test.step('Setup Site, site scoped object and admin user', async () => {
-		site = await apiHelpers.headlessSite.createSite({
+		site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const objectDefinitionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);

--- a/modules/test/playwright/tests/export-import-service/main/remoteStaging.spec.ts
+++ b/modules/test/playwright/tests/export-import-service/main/remoteStaging.spec.ts
@@ -60,11 +60,9 @@ test(
 	}) => {
 		test.slow();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site Name',
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -74,13 +72,8 @@ test(
 			title: 'Staging Test Page',
 		});
 
-		const remoteSite = await remoteApiHelpers.headlessSite.createSite({
+		const remoteSite = await remoteApiHelpers.headlessAdminSite.postSite({
 			name: 'Remote Site Name',
-		});
-
-		remoteApiHelpers.data.push({
-			id: remoteSite.externalReferenceCode,
-			type: 'site',
 		});
 
 		await apiHelpers.jsonWebServicesStaging.enableRemoteStaging({

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -754,9 +754,11 @@ testWithDeprecationFF(
 			);
 		}
 
-		const site = await virtualInstanceApiHelpers.headlessSite.createSite({
-			name: getRandomString(),
-		});
+		const site = await virtualInstanceApiHelpers.headlessAdminSite.postSite(
+			{
+				name: getRandomString(),
+			}
+		);
 
 		await page.goto(
 			`http://www.able.com:8080/group${site.friendlyUrlPath}${PORTLET_URLS.import}`

--- a/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
@@ -59,15 +59,13 @@ const testWithClaritySiteInitializerFF = mergeTests(
 		page,
 		stagingPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name,
 			templateKey: name,
 			templateType: 'site-initializer',
 		});
 
 		expect(site.name).toBeDefined();
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await stagingPage.goto(site.name);
 
@@ -116,15 +114,10 @@ const testWithClaritySiteInitializerFF = mergeTests(
 		let site2: Site;
 
 		await test.step('Create the site 1 from the template', async () => {
-			site1 = await apiHelpers.headlessSite.createSite({
+			site1 = await apiHelpers.headlessAdminSite.postSite({
 				name: getRandomString(),
 				templateKey: name,
 				templateType: 'site-initializer',
-			});
-
-			apiHelpers.data.push({
-				id: site1.externalReferenceCode,
-				type: 'site',
 			});
 		});
 
@@ -137,13 +130,8 @@ const testWithClaritySiteInitializerFF = mergeTests(
 		});
 
 		await test.step('Create the site 2', async () => {
-			site2 = await apiHelpers.headlessSite.createSite({
+			site2 = await apiHelpers.headlessAdminSite.postSite({
 				name: getRandomString(),
-			});
-
-			apiHelpers.data.push({
-				id: site2.externalReferenceCode,
-				type: 'site',
 			});
 		});
 
@@ -304,16 +292,11 @@ testWithClaritySiteInitializerFF(
 			await testWithClaritySiteInitializerFF.step(
 				'Create the site 1 from the template',
 				async () => {
-					site1 = await apiHelpers.headlessSite.createSite({
+					site1 = await apiHelpers.headlessAdminSite.postSite({
 						name: getRandomString(),
 						templateKey:
 							'com.liferay.site.initializer.teaser.showcase',
 						templateType: 'site-initializer',
-					});
-
-					apiHelpers.data.push({
-						id: site1.externalReferenceCode,
-						type: 'site',
 					});
 				}
 			);
@@ -371,13 +354,8 @@ testWithClaritySiteInitializerFF(
 			await testWithClaritySiteInitializerFF.step(
 				'Create the site 2',
 				async () => {
-					site2 = await apiHelpers.headlessSite.createSite({
+					site2 = await apiHelpers.headlessAdminSite.postSite({
 						name: getRandomString(),
-					});
-
-					apiHelpers.data.push({
-						id: site2.externalReferenceCode,
-						type: 'site',
 					});
 				}
 			);

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -74,13 +74,8 @@ test(
 			type: 'objectDefinition',
 		});
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		await apiHelpers.objectEntry.postObjectEntry(
@@ -103,13 +98,8 @@ test(
 	'Taxonomy Categories can be staged through batch',
 	{tag: ['@LPD-76007']},
 	async ({apiHelpers, stagingPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		const taxonomyVocabularyAPIClient = await apiHelpers.buildRestClient(
@@ -153,9 +143,10 @@ test(
 			stagedPortlets: [StageableEntities.CATEGORIES],
 		});
 
-		const stagingSite = await apiHelpers.headlessSite.getSite(
-			`${site.key}-staging`
-		);
+		const stagingSite =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+				`${site.friendlyUrlPath}-staging`
+			);
 
 		expect(
 			(
@@ -208,13 +199,8 @@ test(
 	'Taxonomy Categories display controls on staging page',
 	{tag: ['@LPD-78848']},
 	async ({apiHelpers, page, stagingPage, uiElementsPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		await stagingPage.goto(site.key);
@@ -222,9 +208,10 @@ test(
 			stagedPortlets: [StageableEntities.CATEGORIES],
 		});
 
-		const stagingSite = await apiHelpers.headlessSite.getSite(
-			`${site.key}-staging`
-		);
+		const stagingSite =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+				`${site.friendlyUrlPath}-staging`
+			);
 
 		const taxonomyVocabularyAPIClient = await apiHelpers.buildRestClient(
 			TaxonomyVocabularyAPI
@@ -277,11 +264,9 @@ test('Staging only approved content goes to live', async ({
 	workflowPage,
 	workflowTasksPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: `site-${getRandomString()}`,
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout1 = await apiHelpers.jsonWebServicesLayout.addLayout({
 		groupId: site.id,
@@ -437,11 +422,9 @@ test(
 		pageEditorPage,
 		uiElementsPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'site-' + getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -561,11 +544,9 @@ test(
 	'Non modified referred content cannot publish to live when enable include if modified option',
 	{tag: '@LPS-167777'},
 	async ({apiHelpers, stagingConfigurationPage, stagingPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'site-' + getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -647,11 +628,9 @@ test(
 		page,
 		webContentDisplayPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const document = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -701,11 +680,9 @@ test('Staging publish template with smoke', async ({
 	webContentDisplayPage,
 	widgetPagePage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 		groupId: site.id,
@@ -769,11 +746,9 @@ test('A page created in staging is published to live', async ({
 	page,
 	stagingPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'site-' + getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await stagingPage.goto(site.name);
 	await stagingPage.enableLocalStaging();
@@ -825,11 +800,9 @@ test('Content selection is empty after initial publication to live when using th
 	apiHelpers,
 	stagingPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'site-' + getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await apiHelpers.headlessAdminSite.createPage(site.externalReferenceCode, {
 		name_i18n: {en_US: getRandomString()},

--- a/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
@@ -75,11 +75,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -134,11 +132,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -191,7 +187,7 @@ test('Check if local staging can be enabled', async ({
 
 	await globalMenuPage.goToControlPanel('Sites');
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 	});
 
@@ -214,11 +210,9 @@ test(
 		productMenuPage,
 		stagingConfigurationPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await globalMenuPage.goToSite(site.name);
 		await productMenuPage.goToPages();
@@ -275,11 +269,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -394,11 +386,9 @@ testFlagsEnabled(
 		const layoutName = getRandomString();
 		const webContentName = getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,

--- a/modules/test/playwright/types/site.d.ts
+++ b/modules/test/playwright/types/site.d.ts
@@ -9,6 +9,6 @@ type Site = {
 	id: string;
 	key: string;
 	name?: string;
-	templateKey?: number;
+	templateKey?: string;
 	templateType?: string;
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86446

**What is being fixed:** Playwright tests across batch-planner, export-import, and staging-configuration modules were calling the legacy `apiHelpers.headlessSite` helpers (`createSite`, `getSite`) and manually registering created sites for cleanup via `apiHelpers.data.push(...)`. This duplicated the behavior already provided by the `apiHelpers.headlessAdminSite` helpers and left two parallel paths for exercising the Headless Admin Site API from tests.

**How it is being fixed:** Every call to `apiHelpers.headlessSite.createSite` has been migrated to `apiHelpers.headlessAdminSite.postSite`, and `apiHelpers.headlessSite.getSite` to `apiHelpers.headlessAdminSite.getSite`. Because the `headlessAdminSite` helper registers the created site for automatic teardown, the now-redundant `apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'})` calls have been removed at each migration site. The `templateKey` field on `TSite` in `HeadlessAdminSiteApiHelper.ts` has also been corrected from `number` to `string` to match the values the tests were already passing.