### PR TITLE
LPD-2329 Detect and auto-resolve duplicate DLFileEntry name conflicts

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
@@ -671,13 +671,18 @@ public class CTConflictChecker<T extends CTModel<T>> {
 		Set<Long> ignorablePrimaryKeys = new HashSet<>();
 
 		for (CTEntry ctEntry : _ctEntries) {
-			if (ctEntry.getChangeType() !=
-					CTConstants.CT_CHANGE_TYPE_ADDITION) {
+			int changeType = ctEntry.getChangeType();
+			long modelClassPK = ctEntry.getModelClassPK();
 
-				ignorablePrimaryKeys.add(ctEntry.getModelClassPK());
+			if (changeType == CTConstants.CT_CHANGE_TYPE_ADDITION) {
+				verifyPrimaryKeys.add(modelClassPK);
+			}
+			else if (changeType == CTConstants.CT_CHANGE_TYPE_MODIFICATION) {
+				ignorablePrimaryKeys.add(modelClassPK);
+				verifyPrimaryKeys.add(modelClassPK);
 			}
 			else {
-				verifyPrimaryKeys.add(ctEntry.getModelClassPK());
+				ignorablePrimaryKeys.add(modelClassPK);
 			}
 		}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/resolver/DLFileEntryFileNameConstraintResolver.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/resolver/DLFileEntryFileNameConstraintResolver.java
@@ -8,12 +8,21 @@ package com.liferay.document.library.internal.change.tracking.spi.resolver;
 import com.liferay.change.tracking.spi.resolver.ConstraintResolver;
 import com.liferay.change.tracking.spi.resolver.context.ConstraintResolverContext;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
+import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.language.LanguageResources;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Samuel Trong Tran
@@ -49,7 +58,48 @@ public class DLFileEntryFileNameConstraintResolver
 
 	@Override
 	public void resolveConflict(
-		ConstraintResolverContext<DLFileEntry> constraintResolverContext) {
+			ConstraintResolverContext<DLFileEntry> constraintResolverContext)
+		throws PortalException {
+
+		DLFileEntry sourceDLFileEntry =
+			constraintResolverContext.getSourceCTModel();
+
+		String uniqueFileName = constraintResolverContext.getInTarget(
+			() -> DLUtil.getUniqueFileName(
+				sourceDLFileEntry.getGroupId(), sourceDLFileEntry.getFolderId(),
+				sourceDLFileEntry.getFileName(), true));
+
+		sourceDLFileEntry.setFileName(uniqueFileName);
+
+		_dlFileEntryLocalService.updateDLFileEntry(sourceDLFileEntry);
+
+		DLFileVersion latestDLFileVersion;
+
+		try (SafeCloseable safeCloseable1 =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					sourceDLFileEntry.getCtCollectionId());
+			SafeCloseable safeCloseable2 =
+				CTSQLModeThreadLocal.setCTSQLModeWithSafeCloseable(
+					CTSQLModeThreadLocal.CTSQLMode.CT_ONLY)) {
+
+			latestDLFileVersion =
+				_dlFileVersionLocalService.fetchLatestFileVersion(
+					sourceDLFileEntry.getFileEntryId(), false);
+		}
+
+		if ((latestDLFileVersion != null) &&
+			constraintResolverContext.isSourceCTModel(latestDLFileVersion)) {
+
+			latestDLFileVersion.setFileName(uniqueFileName);
+
+			_dlFileVersionLocalService.updateDLFileVersion(latestDLFileVersion);
+		}
 	}
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/resolver/DLFileEntryTitleConstraintResolver.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/resolver/DLFileEntryTitleConstraintResolver.java
@@ -8,12 +8,21 @@ package com.liferay.document.library.internal.change.tracking.spi.resolver;
 import com.liferay.change.tracking.spi.resolver.ConstraintResolver;
 import com.liferay.change.tracking.spi.resolver.context.ConstraintResolverContext;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
+import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.language.LanguageResources;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Samuel Trong Tran
@@ -49,7 +58,48 @@ public class DLFileEntryTitleConstraintResolver
 
 	@Override
 	public void resolveConflict(
-		ConstraintResolverContext<DLFileEntry> constraintResolverContext) {
+			ConstraintResolverContext<DLFileEntry> constraintResolverContext)
+		throws PortalException {
+
+		DLFileEntry sourceDLFileEntry =
+			constraintResolverContext.getSourceCTModel();
+
+		String uniqueTitle = constraintResolverContext.getInTarget(
+			() -> DLUtil.getUniqueTitle(
+				sourceDLFileEntry.getGroupId(), sourceDLFileEntry.getFolderId(),
+				sourceDLFileEntry.getTitle()));
+
+		sourceDLFileEntry.setTitle(uniqueTitle);
+
+		_dlFileEntryLocalService.updateDLFileEntry(sourceDLFileEntry);
+
+		DLFileVersion latestDLFileVersion;
+
+		try (SafeCloseable safeCloseable1 =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					sourceDLFileEntry.getCtCollectionId());
+			SafeCloseable safeCloseable2 =
+				CTSQLModeThreadLocal.setCTSQLModeWithSafeCloseable(
+					CTSQLModeThreadLocal.CTSQLMode.CT_ONLY)) {
+
+			latestDLFileVersion =
+				_dlFileVersionLocalService.fetchLatestFileVersion(
+					sourceDLFileEntry.getFileEntryId(), false);
+		}
+
+		if ((latestDLFileVersion != null) &&
+			constraintResolverContext.isSourceCTModel(latestDLFileVersion)) {
+
+			latestDLFileVersion.setTitle(uniqueTitle);
+
+			_dlFileVersionLocalService.updateDLFileVersion(latestDLFileVersion);
+		}
 	}
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/spi/resolver/test/DLFileEntryFileNameConstraintResolverTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/spi/resolver/test/DLFileEntryFileNameConstraintResolverTest.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.change.tracking.spi.resolver.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.conflict.ConflictInfo;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTCollectionService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Noor Najjar
+ */
+@RunWith(Arquillian.class)
+public class DLFileEntryFileNameConstraintResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testResolveConflict() throws Exception {
+		String sharedFileName = RandomTestUtil.randomString() + ".txt";
+
+		FileEntry fileEntry1 = _addFileEntry(
+			RandomTestUtil.randomString() + ".txt",
+			RandomTestUtil.randomString());
+		FileEntry fileEntry2 = _addFileEntry(
+			RandomTestUtil.randomString() + ".txt",
+			RandomTestUtil.randomString());
+
+		CTCollection ctCollection1 = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection1.getCtCollectionId())) {
+
+			_renameFileEntryFileName(fileEntry1, sharedFileName);
+		}
+
+		CTCollection ctCollection2 = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection2.getCtCollectionId())) {
+
+			_renameFileEntryFileName(fileEntry2, sharedFileName);
+		}
+
+		_ctCollectionService.publishCTCollection(
+			TestPropsValues.getUserId(), ctCollection1.getCtCollectionId());
+
+		Map<Long, List<ConflictInfo>> conflictInfoMap =
+			_ctCollectionLocalService.checkConflicts(ctCollection2);
+
+		List<ConflictInfo> conflictInfos = conflictInfoMap.get(
+			_classNameLocalService.getClassNameId(DLFileEntry.class));
+
+		Assert.assertNotNull(
+			"checkConflicts did not detect the duplicate file name",
+			conflictInfos);
+		Assert.assertEquals(conflictInfos.toString(), 1, conflictInfos.size());
+
+		ConflictInfo conflictInfo = conflictInfos.get(0);
+
+		Assert.assertTrue(
+			"File name conflict was detected but not resolved",
+			conflictInfo.isResolved());
+
+		_ctCollectionService.publishCTCollection(
+			TestPropsValues.getUserId(), ctCollection2.getCtCollectionId());
+
+		DLFileEntry publishedDLFileEntry =
+			_dlFileEntryLocalService.getDLFileEntry(
+				fileEntry2.getFileEntryId());
+
+		Assert.assertNotEquals(
+			sharedFileName, publishedDLFileEntry.getFileName());
+	}
+
+	private FileEntry _addFileEntry(String fileName, String title)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		return _dlAppLocalService.addFileEntry(
+			null, serviceContext.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), fileName, ContentTypes.TEXT_PLAIN, title,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			"liferay".getBytes(), null, null, null, serviceContext);
+	}
+
+	private void _renameFileEntryFileName(
+			FileEntry fileEntry, String newFileName)
+		throws Exception {
+
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), newFileName, fileEntry.getMimeType(),
+			fileEntry.getTitle(), newFileName, fileEntry.getDescription(),
+			StringPool.BLANK, DLVersionNumberIncrease.MINOR, null,
+			fileEntry.getSize(), fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			ServiceContextTestUtil.getServiceContext(fileEntry.getGroupId()));
+	}
+
+	@Inject
+	private static ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private CTCollectionService _ctCollectionService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLAppService _dlAppService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	private Folder _folder;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/spi/resolver/test/DLFileEntryTitleConstraintResolverTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/spi/resolver/test/DLFileEntryTitleConstraintResolverTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.change.tracking.spi.resolver.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.conflict.ConflictInfo;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTCollectionService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Noor Najjar
+ */
+@RunWith(Arquillian.class)
+public class DLFileEntryTitleConstraintResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testResolveConflict() throws Exception {
+		String sharedTitle = RandomTestUtil.randomString();
+
+		FileEntry fileEntry1 = _addFileEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+		FileEntry fileEntry2 = _addFileEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		CTCollection ctCollection1 = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection1.getCtCollectionId())) {
+
+			_renameFileEntry(fileEntry1, sharedTitle);
+		}
+
+		CTCollection ctCollection2 = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection2.getCtCollectionId())) {
+
+			_renameFileEntry(fileEntry2, sharedTitle);
+		}
+
+		_ctCollectionService.publishCTCollection(
+			TestPropsValues.getUserId(), ctCollection1.getCtCollectionId());
+
+		Map<Long, List<ConflictInfo>> conflictInfoMap =
+			_ctCollectionLocalService.checkConflicts(ctCollection2);
+
+		List<ConflictInfo> conflictInfos = conflictInfoMap.get(
+			_classNameLocalService.getClassNameId(DLFileEntry.class));
+
+		Assert.assertNotNull(
+			"checkConflicts did not detect the duplicate title", conflictInfos);
+		Assert.assertEquals(conflictInfos.toString(), 1, conflictInfos.size());
+
+		ConflictInfo conflictInfo = conflictInfos.get(0);
+
+		Assert.assertTrue(
+			"Title conflict was detected but not resolved",
+			conflictInfo.isResolved());
+
+		_ctCollectionService.publishCTCollection(
+			TestPropsValues.getUserId(), ctCollection2.getCtCollectionId());
+
+		FileEntry publishedFileEntry2 = _dlAppService.getFileEntry(
+			fileEntry2.getFileEntryId());
+
+		Assert.assertNotEquals(sharedTitle, publishedFileEntry2.getTitle());
+		Assert.assertTrue(
+			"Resolved title should be derived from the original via " +
+				"parenthetical suffix, was: " + publishedFileEntry2.getTitle(),
+			publishedFileEntry2.getTitle(
+			).startsWith(
+				sharedTitle
+			));
+	}
+
+	private FileEntry _addFileEntry(String fileName, String title)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		return _dlAppLocalService.addFileEntry(
+			null, serviceContext.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), fileName, ContentTypes.TEXT_PLAIN, title,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			"liferay".getBytes(), null, null, null, serviceContext);
+	}
+
+	private void _renameFileEntry(FileEntry fileEntry, String newTitle)
+		throws Exception {
+
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), fileEntry.getFileName(),
+			fileEntry.getMimeType(), newTitle, fileEntry.getFileName(),
+			fileEntry.getDescription(), StringPool.BLANK,
+			DLVersionNumberIncrease.MINOR, null, fileEntry.getSize(),
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(),
+			ServiceContextTestUtil.getServiceContext(fileEntry.getGroupId()));
+	}
+
+	@Inject
+	private static ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private CTCollectionService _ctCollectionService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLAppService _dlAppService;
+
+	private Folder _folder;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-2329

**What is being fixed:** Publishing a publication failed with a raw `Duplicate entry '...' for key 'DLFileEntry.IX_EAAB273'` SQL violation when two pre-existing documents were renamed to the same title (or file name) across two separate publications and the publications were published one after the other. `checkConflicts` did not surface the issue because the unique-index scan only verified CT entries with change type ADDITION; modifications of existing rows were silently skipped, so the publish proceeded into `CTRowUtil.copyCTRows` and crashed at the raw SQL layer.

**How it is being fixed:** Extended `CTConflictChecker._getConflictingPrimaryKeys` to also include CT entries with change type MODIFICATION in the verify set, while keeping them in the ignorable set so that a sibling source row whose new unique-index value matches a row this one is overwriting is not falsely flagged. The previously empty `resolveConflict` bodies on `DLFileEntryTitleConstraintResolver` and `DLFileEntryFileNameConstraintResolver` now compute a unique value via `DLUtil.getUniqueTitle` / `DLUtil.getUniqueFileName` inside the target CT context and apply it to the source `DLFileEntry`, cascading the rename to the latest `DLFileVersion` only (older versions are historical snapshots and keep their original title). Two integration tests reproduce the LPD-2329 scenario end-to-end and assert the cross-publication conflict is now detected and auto-resolved.