### PR TITLE
LPD-85907 Block reserved keywords on site friendly URLs

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.DuplicateGroupException;
+import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.GroupKeyException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -145,6 +147,19 @@ public class GroupLocalServiceTest {
 	}
 
 	@Test
+	public void testAddGroupWithReservedKeywordFriendlyURL() throws Exception {
+		_assertAddGroupRejectsReservedKeywords();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			_assertAddGroupRejectsReservedKeywords();
+		}
+	}
+
+	@Test
 	public void testCheckSystemGroups() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
 
@@ -206,6 +221,19 @@ public class GroupLocalServiceTest {
 		Assert.assertTrue(groups.toString(), groups.isEmpty());
 	}
 
+	@Test
+	public void testUpdateFriendlyURLWithReservedKeyword() throws Exception {
+		_assertUpdateFriendlyURLRejectsReservedKeywords();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			_assertUpdateFriendlyURLRejectsReservedKeywords();
+		}
+	}
+
 	private Group _addGroup(String name) throws Exception {
 		return _addGroup(StringPool.BLANK, name, null);
 	}
@@ -228,6 +256,43 @@ public class GroupLocalServiceTest {
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name), true,
 			false, true, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private Group _addGroupWithFriendlyURL(String friendlyURL)
+		throws Exception {
+
+		return _groupLocalService.addGroup(
+			StringPool.BLANK, TestPropsValues.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
+			GroupConstants.DEFAULT_LIVE_GROUP_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			GroupConstants.TYPE_SITE_OPEN, null, true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, friendlyURL, true,
+			false, true, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertAddGroupRejectsReservedKeywords() throws Exception {
+		for (String reservedKeyword : _RESERVED_KEYWORDS) {
+			try {
+				_addGroupWithFriendlyURL(reservedKeyword);
+
+				Assert.fail(
+					"Expected GroupFriendlyURLException for friendly URL: " +
+						reservedKeyword);
+			}
+			catch (GroupFriendlyURLException groupFriendlyURLException) {
+				Assert.assertEquals(
+					"Expected KEYWORD_CONFLICT for friendly URL: " +
+						reservedKeyword,
+					GroupFriendlyURLException.KEYWORD_CONFLICT,
+					groupFriendlyURLException.getType());
+			}
+		}
 	}
 
 	private void _assertDescendantGroups(
@@ -259,6 +324,35 @@ public class GroupLocalServiceTest {
 
 		Assert.assertNotNull(_groupLocalService.getCompanyGroup(companyId));
 	}
+
+	private void _assertUpdateFriendlyURLRejectsReservedKeywords()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		for (String reservedKeyword : _RESERVED_KEYWORDS) {
+			try {
+				_groupLocalService.updateFriendlyURL(
+					group.getGroupId(), reservedKeyword);
+
+				Assert.fail(
+					"Expected GroupFriendlyURLException for friendly URL: " +
+						reservedKeyword);
+			}
+			catch (GroupFriendlyURLException groupFriendlyURLException) {
+				Assert.assertEquals(
+					"Expected KEYWORD_CONFLICT for friendly URL: " +
+						reservedKeyword,
+					GroupFriendlyURLException.KEYWORD_CONFLICT,
+					groupFriendlyURLException.getType());
+			}
+		}
+	}
+
+	private static final String[] _RESERVED_KEYWORDS = {
+		"/api", "/c", "/combo", "/documents", "/group", "/html", "/image",
+		"/layouttpl", "/o", "/web", "/webdav"
+	};
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -121,9 +122,7 @@ import java.util.TreeSet;
 public class LayoutImpl extends LayoutBaseImpl {
 
 	public static boolean hasFriendlyURLKeyword(String friendlyURL) {
-		String keyword = _getFriendlyURLKeyword(friendlyURL);
-
-		return Validator.isNotNull(keyword);
+		return FriendlyURLKeywordsUtil.hasFriendlyURLKeyword(friendlyURL);
 	}
 
 	public static int validateFriendlyURL(String friendlyURL) {
@@ -183,17 +182,20 @@ public class LayoutImpl extends LayoutBaseImpl {
 	public static void validateFriendlyURLKeyword(String friendlyURL)
 		throws LayoutFriendlyURLException {
 
-		String keyword = _getFriendlyURLKeyword(friendlyURL);
+		String keyword = FriendlyURLKeywordsUtil.getFriendlyURLKeyword(
+			friendlyURL);
 
-		if (Validator.isNotNull(keyword)) {
-			LayoutFriendlyURLException layoutFriendlyURLException =
-				new LayoutFriendlyURLException(
-					LayoutFriendlyURLException.KEYWORD_CONFLICT);
-
-			layoutFriendlyURLException.setKeywordConflict(keyword);
-
-			throw layoutFriendlyURLException;
+		if (Validator.isNull(keyword)) {
+			return;
 		}
+
+		LayoutFriendlyURLException layoutFriendlyURLException =
+			new LayoutFriendlyURLException(
+				LayoutFriendlyURLException.KEYWORD_CONFLICT);
+
+		layoutFriendlyURLException.setKeywordConflict(keyword);
+
+		throw layoutFriendlyURLException;
 	}
 
 	@Override
@@ -1645,46 +1647,6 @@ public class LayoutImpl extends LayoutBaseImpl {
 		super.setTypeSettings(_typeSettingsUnicodeProperties.toString());
 	}
 
-	private static String _getFriendlyURLKeyword(String friendlyURL) {
-		friendlyURL = StringUtil.toLowerCase(friendlyURL);
-
-		for (String keyword : _friendlyURLKeywords) {
-			if (friendlyURL.startsWith(keyword)) {
-				return keyword;
-			}
-
-			if (keyword.equals(friendlyURL + StringPool.SLASH)) {
-				return friendlyURL;
-			}
-		}
-
-		return null;
-	}
-
-	private static void _initFriendlyURLKeywords() {
-		_friendlyURLKeywords =
-			new String[PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length];
-
-		for (int i = 0; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
-			 i++) {
-
-			String keyword = PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i];
-
-			keyword = StringPool.SLASH + keyword;
-
-			if (!keyword.contains(StringPool.PERIOD)) {
-				if (keyword.endsWith(StringPool.STAR)) {
-					keyword = keyword.substring(0, keyword.length() - 1);
-				}
-				else {
-					keyword = keyword + StringPool.SLASH;
-				}
-			}
-
-			_friendlyURLKeywords[i] = StringUtil.toLowerCase(keyword);
-		}
-	}
-
 	private ColorScheme _getColorScheme() throws PortalException {
 		if (isInheritLookAndFeel()) {
 			LayoutSet layoutSet = getLayoutSet();
@@ -1957,12 +1919,6 @@ public class LayoutImpl extends LayoutBaseImpl {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(LayoutImpl.class);
-
-	private static String[] _friendlyURLKeywords;
-
-	static {
-		_initFriendlyURLKeywords();
-	}
 
 	private ColorScheme _colorScheme;
 	private String _faviconURL;

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -141,6 +141,7 @@ import com.liferay.portal.kernel.tree.TreeModelTasksAdapter;
 import com.liferay.portal.kernel.tree.TreePathUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
@@ -400,6 +401,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		friendlyURL = getFriendlyURL(
 			user.getCompanyId(), groupId, classNameId, classPK, friendlyName,
 			friendlyURL);
+
+		if (site) {
+			_validateFriendlyURLKeyword(friendlyURL);
+		}
 
 		if (staging) {
 			int groupKeyMaxLength = ModelHintsUtil.getMaxLength(
@@ -5038,6 +5043,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			throw new GroupFriendlyURLException(exceptionType);
 		}
 
+		_validateFriendlyURLKeyword(friendlyURL);
+
 		Group group = groupPersistence.fetchByC_F(companyId, friendlyURL);
 
 		if ((group != null) && (group.getGroupId() != groupId)) {
@@ -5575,6 +5582,25 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 	private String _toExternalReferenceCode(String groupKey) {
 		return "L_" + TextFormatter.format(groupKey, TextFormatter.A);
+	}
+
+	private void _validateFriendlyURLKeyword(String friendlyURL)
+		throws PortalException {
+
+		String keyword = FriendlyURLKeywordsUtil.getFriendlyURLKeyword(
+			friendlyURL);
+
+		if (Validator.isNull(keyword)) {
+			return;
+		}
+
+		GroupFriendlyURLException groupFriendlyURLException =
+			new GroupFriendlyURLException(
+				GroupFriendlyURLException.KEYWORD_CONFLICT);
+
+		groupFriendlyURLException.setKeywordConflict(keyword);
+
+		throw groupFriendlyURLException;
 	}
 
 	private void _validateGroupKeyChange(long groupId, String typeSettings)

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4923,6 +4923,7 @@
         c,\
         combo,\
         delegate,\
+        documents,\
         dtd,\
         elqNow,\
         facebook,\
@@ -4931,6 +4932,7 @@
         html,\
         image,\
         language,\
+        layouttpl,\
         lucene,\
         netvibes,\
         o,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.petra.string.StringPool;
+
+/**
+ * @author Dave Truong
+ */
+public class FriendlyURLKeywordsUtil {
+
+	public static String getFriendlyURLKeyword(String friendlyURL) {
+		friendlyURL = StringUtil.toLowerCase(friendlyURL);
+
+		for (String keyword : _FRIENDLY_URL_KEYWORDS) {
+			if (friendlyURL.startsWith(keyword)) {
+				return keyword;
+			}
+
+			if (keyword.equals(friendlyURL + StringPool.SLASH)) {
+				return friendlyURL;
+			}
+		}
+
+		return null;
+	}
+
+	public static boolean hasFriendlyURLKeyword(String friendlyURL) {
+		String keyword = getFriendlyURLKeyword(friendlyURL);
+
+		return Validator.isNotNull(keyword);
+	}
+
+	private static final String[] _FRIENDLY_URL_KEYWORDS;
+
+	static {
+		_FRIENDLY_URL_KEYWORDS =
+			new String[PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length];
+
+		for (int i = 0; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
+			 i++) {
+
+			String keyword = PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i];
+
+			keyword = StringPool.SLASH + keyword;
+
+			if (!keyword.contains(StringPool.PERIOD)) {
+				if (keyword.endsWith(StringPool.STAR)) {
+					keyword = keyword.substring(0, keyword.length() - 1);
+				}
+				else {
+					keyword = keyword + StringPool.SLASH;
+				}
+			}
+
+			_FRIENDLY_URL_KEYWORDS[i] = StringUtil.toLowerCase(keyword);
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85907

**What is being fixed:** Site administrators can save sites with friendly URLs that collide with reserved Liferay paths (`/o`, `/api`, `/documents`, etc.), producing ambiguous URL resolution. The `GroupLocalServiceImpl.validateFriendlyURL` method already validates duplicates, syntax, and i18n language paths but does not consult the `layout.friendly.url.keywords` reserved list — layouts already do via the same property.

**How it is being fixed:** The keyword cache and matching logic previously embedded in `LayoutImpl` are extracted to a new kernel utility `com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil` (so consumers don't depend on a Service Builder model Impl). `LayoutImpl.hasFriendlyURLKeyword` and `LayoutImpl.validateFriendlyURLKeyword` now delegate to the util. A private `_validateFriendlyURLKeyword` helper in `GroupLocalServiceImpl` reads the matched keyword from the util and throws a `GroupFriendlyURLException.KEYWORD_CONFLICT` when present. The helper runs inside `validateFriendlyURL` (covering update flows) and is also invoked early in `addGroup` when `site=true` — the early site check is required because `getValidatedFriendlyURL`'s retry loop silently substitutes `/group-<classPK>` on `KEYWORD_CONFLICT`, hiding the rejection from site callers. Per AC1 verification, only `documents` and `layouttpl` were added to `layout.friendly.url.keywords` (other AC1 candidates `/portal`, `/dxp`, `/openid`, `/opensso` have no top-level routing and were left out — see the LPD-84594 comment). Tests added to `GroupLocalServiceTest` exercise the full reserved set on both add and update.