### PR TITLE
LPD-85294 Avoid Elasticsearch request storm during redirect not found cleanup

### DIFF
--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/scheduler/CheckRedirectNotFoundEntriesSchedulerJobConfiguration.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/scheduler/CheckRedirectNotFoundEntriesSchedulerJobConfiguration.java
@@ -10,15 +10,22 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.OrderFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.redirect.internal.configuration.RedirectConfiguration;
 import com.liferay.redirect.model.RedirectNotFoundEntry;
 import com.liferay.redirect.service.RedirectNotFoundEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
@@ -39,8 +46,28 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfiguration
 	@Override
 	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
 		return () -> {
-			_removeMaximumOverflowRedirectNotFoundEntries();
-			_removeOldRedirectNotFoundEntries();
+			Map<Long, List<String>> deletedUidsMap = new HashMap<>();
+
+			boolean indexReadOnly =
+				IndexStatusManagerThreadLocal.isIndexReadOnly();
+
+			try {
+				IndexStatusManagerThreadLocal.setIndexReadOnly(true);
+
+				_removeMaximumOverflowRedirectNotFoundEntries(deletedUidsMap);
+
+				_removeOldRedirectNotFoundEntries(deletedUidsMap);
+			}
+			finally {
+				IndexStatusManagerThreadLocal.setIndexReadOnly(indexReadOnly);
+
+				for (Map.Entry<Long, List<String>> entry :
+						deletedUidsMap.entrySet()) {
+
+					_indexWriterHelper.deleteDocuments(
+						entry.getKey(), entry.getValue(), false);
+				}
+			}
 		};
 	}
 
@@ -59,7 +86,25 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfiguration
 			TimeUnit.HOUR);
 	}
 
-	private void _removeMaximumOverflowRedirectNotFoundEntries()
+	private void _deleteRedirectNotFoundEntry(
+			RedirectNotFoundEntry redirectNotFoundEntry,
+			Map<Long, List<String>> deletedUidsMap)
+		throws PortalException {
+
+		long companyId = redirectNotFoundEntry.getCompanyId();
+		String uid = _uidFactory.getUID(redirectNotFoundEntry);
+
+		_redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntry(
+			redirectNotFoundEntry);
+
+		List<String> uids = deletedUidsMap.computeIfAbsent(
+			companyId, key -> new ArrayList<>());
+
+		uids.add(uid);
+	}
+
+	private void _removeMaximumOverflowRedirectNotFoundEntries(
+			Map<Long, List<String>> deletedUidsMap)
 		throws Exception {
 
 		int redirectNotFoundEntriesCount =
@@ -88,13 +133,16 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfiguration
 				OrderFactoryUtil.desc("modifiedDate")));
 		actionableDynamicQuery.setPerformActionMethod(
 			(ActionableDynamicQuery.PerformActionMethod<RedirectNotFoundEntry>)
-				_redirectNotFoundEntryLocalService::
-					deleteRedirectNotFoundEntry);
+				redirectNotFoundEntry -> _deleteRedirectNotFoundEntry(
+					redirectNotFoundEntry, deletedUidsMap));
 
 		actionableDynamicQuery.performActions();
 	}
 
-	private void _removeOldRedirectNotFoundEntries() throws Exception {
+	private void _removeOldRedirectNotFoundEntries(
+			Map<Long, List<String>> deletedUidsMap)
+		throws Exception {
+
 		ActionableDynamicQuery actionableDynamicQuery =
 			_redirectNotFoundEntryLocalService.getActionableDynamicQuery();
 
@@ -111,11 +159,14 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfiguration
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(ActionableDynamicQuery.PerformActionMethod<RedirectNotFoundEntry>)
-				_redirectNotFoundEntryLocalService::
-					deleteRedirectNotFoundEntry);
+				redirectNotFoundEntry -> _deleteRedirectNotFoundEntry(
+					redirectNotFoundEntry, deletedUidsMap));
 
 		actionableDynamicQuery.performActions();
 	}
+
+	@Reference
+	private IndexWriterHelper _indexWriterHelper;
 
 	private volatile RedirectConfiguration _redirectConfiguration;
 
@@ -124,5 +175,8 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfiguration
 		_redirectNotFoundEntryLocalService;
 
 	private TriggerConfiguration _triggerConfiguration;
+
+	@Reference
+	private UIDFactory _uidFactory;
 
 }

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/internal/scheduler/test/CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/internal/scheduler/test/CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest.java
@@ -10,11 +10,15 @@ import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.redirect.model.RedirectNotFoundEntry;
@@ -73,6 +77,8 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest {
 			redirectNotFoundEntries.toString(), 2,
 			redirectNotFoundEntries.size());
 
+		Assert.assertEquals(2, _getRedirectNotFoundEntryCount());
+
 		UnsafeRunnable<Exception> jobExecutorUnsafeRunnable =
 			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
 
@@ -88,6 +94,8 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest {
 			redirectNotFoundEntries.size());
 		Assert.assertEquals(
 			redirectNotFoundEntry, redirectNotFoundEntries.get(0));
+
+		Assert.assertEquals(1, _getRedirectNotFoundEntryCount());
 	}
 
 	@Test
@@ -101,6 +109,7 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest {
 			1001,
 			_redirectNotFoundEntryLocalService.getRedirectNotFoundEntriesCount(
 				_group.getGroupId()));
+		Assert.assertEquals(1001, _getRedirectNotFoundEntryCount());
 
 		UnsafeRunnable<Exception> jobExecutorUnsafeRunnable =
 			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
@@ -111,6 +120,7 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest {
 			1000,
 			_redirectNotFoundEntryLocalService.getRedirectNotFoundEntriesCount(
 				_group.getGroupId()));
+		Assert.assertEquals(1000, _getRedirectNotFoundEntryCount());
 	}
 
 	private RedirectNotFoundEntry _addOrUpdateRedirectNotFoundEntry(
@@ -124,6 +134,16 @@ public class CheckRedirectNotFoundEntriesSchedulerJobConfigurationTest {
 
 		return _redirectNotFoundEntryLocalService.updateRedirectNotFoundEntry(
 			redirectNotFoundEntry);
+	}
+
+	private int _getRedirectNotFoundEntryCount() throws Exception {
+		Indexer<RedirectNotFoundEntry> indexer = IndexerRegistryUtil.getIndexer(
+			RedirectNotFoundEntry.class);
+
+		Hits hits = indexer.search(
+			SearchContextTestUtil.getSearchContext(_group.getGroupId()));
+
+		return hits.getLength();
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85294

**What is being fixed:** The CheckRedirectNotFoundEntriesSchedulerJob
deleted RedirectNotFoundEntry rows one at a time. Each deletion went
through the @Indexable(type = DELETE) interceptor, which fired its own
Elasticsearch request. When the job had many entries to remove the
result was a storm of individual ES requests and refreshes, making the
job slow and putting needless load on the search engine.

**How it is being fixed:** The job now suppresses the per-entry index
writes by setting IndexStatusManagerThreadLocal.setIndexReadOnly(true)
for the duration of the database pass, while accumulating the UID of
each deleted entry into a map keyed by companyId. The bulk delete and
flag restore both run inside a single finally block, so a partial
failure during the database pass still flushes whatever was deleted to
the index and always restores the read-only flag. The accumulated UIDs
are flushed to the index with a single IndexWriterHelper.deleteDocuments
call per company, collapsing N requests into one bulk request and one
refresh. The integration test now also asserts the indexed document
count alongside the existing database-count assertions, so the bulk
delete path is exercised and verified to keep the index consistent with
the database.