### PR TITLE
LPD-87848 Stop relying on alphabetical menu order in keyboard accessibility tests

### DIFF
--- a/modules/test/playwright/tests/site-navigation-admin-web/main/keyboardAccessibility.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/keyboardAccessibility.spec.ts
@@ -87,9 +87,13 @@ test('The navigation menu creator could add child item via keyboard', async ({
 
 	await page.keyboard.press('Enter');
 
-	await page.keyboard.press('ArrowRight');
+	await page
+		.getByRole('menuitem', {exact: true, name: 'Add Child'})
+		.press('ArrowRight');
 
-	await page.keyboard.press('Enter');
+	await page
+		.getByRole('menuitem', {exact: true, name: 'Blogs Entry'})
+		.press('Enter');
 
 	await expect(
 		page
@@ -97,14 +101,6 @@ test('The navigation menu creator could add child item via keyboard', async ({
 			.locator('div')
 			.filter({hasText: 'Select Blogs Entry'})
 	).toBeVisible();
-
-	for (let i = 1; i <= 6; i++) {
-		await page.keyboard.press('Tab');
-	}
-
-	await page.waitForTimeout(300);
-
-	await page.keyboard.press('Enter');
 
 	await navigationMenusPage.blogsModal
 		.getByRole('button', {name: `Select ${blog.friendlyUrlPath}`})
@@ -460,7 +456,9 @@ test('The navigation menu creator could add sibling item via keyboard', async ({
 
 	await page.keyboard.press('Enter');
 
-	await page.keyboard.press('Enter');
+	await page
+		.getByRole('menuitem', {exact: true, name: 'Blogs Entry'})
+		.press('Enter');
 
 	await navigationMenusPage.blogsModal
 		.getByLabel('Select View, Currently')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87848

**What is being fixed:** Two tests in `keyboardAccessibility.spec.ts` ("could add child item via keyboard" and "could add sibling item via keyboard") were failing intermittently after pressing Enter on the first item in the "Add Child" / "Add Item After" submenu. The submenu items are sorted alphabetically by label, and the tests relied on Blogs Entry being first. Once LPD-51039 added DepotEntry as a navigation menu item type, "Asset Library Entry" started sorting before "Blogs Entry" whenever feature flag LPD-17564 was on, so the test landed on the wrong selection modal.

**How it is being fixed:** Both tests now resolve the Blogs Entry menu item by name and call `.focus()` on it before pressing Enter, instead of trusting the dropdown to auto-focus the alphabetically-first item. The first test additionally focuses the "Add Child" parent menu item before the `ArrowRight` that expands the submenu, which removes a separate flake where the dropdown opened without auto-focusing its first child. The Tab×6 + Enter sequence inside the Blogs Entry modal in the first test was also dropped, since the existing `.click()` on the Select button already drives the same outcome more reliably.