### PR TITLE
LPD-87850 Implement instant publishing for Publications

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTPublishBackgroundTaskExecutor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTPublishBackgroundTaskExecutor.java
@@ -15,11 +15,14 @@ import com.liferay.change.tracking.internal.helper.CTTableMapperHelper;
 import com.liferay.change.tracking.internal.helper.CTUserNotificationHelper;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.model.CTEntry;
+import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTEntryLocalService;
+import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.service.CTSchemaVersionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
@@ -34,6 +37,7 @@ import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -44,15 +48,14 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-
-import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -85,17 +88,118 @@ public class CTPublishBackgroundTaskExecutor
 	}
 
 	@Override
-	@Transactional(
-		propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class
-	)
 	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
 		throws Exception {
 
-		Map<String, Serializable> taskContextMap =
-			backgroundTask.getTaskContextMap();
-
 		long ctCollectionId = GetterUtil.getLong(
-			taskContextMap.get("ctCollectionId"));
+			backgroundTask.getTaskContextMap(
+			).get(
+				"ctCollectionId"
+			));
+
+		try {
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					_publishCTCollection(backgroundTask, ctCollectionId);
+
+					return null;
+				});
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
+
+		return BackgroundTaskResult.SUCCESS;
+	}
+
+	@Override
+	public Class<?>[] getAopInterfaces() {
+		return new Class<?>[] {BackgroundTaskExecutor.class};
+	}
+
+	@Override
+	public BackgroundTaskDisplay getBackgroundTaskDisplay(
+		BackgroundTask backgroundTask) {
+
+		return new CTPublishBackgroundTaskDisplay(backgroundTask);
+	}
+
+	@Override
+	public String handleException(
+		BackgroundTask backgroundTask, Exception exception) {
+
+		boolean showConflicts = false;
+
+		if (exception instanceof CTPublishConflictException) {
+			showConflicts = true;
+		}
+
+		long ctCollectionId = MapUtil.getLong(
+			backgroundTask.getTaskContextMap(), "ctCollectionId");
+
+		_resetInstantPublishPreferences(ctCollectionId);
+
+		try {
+			CTCollection ctCollection =
+				_ctCollectionLocalService.getCTCollection(ctCollectionId);
+
+			_ctUserNotificationHelper.sendUserNotificationEvents(
+				ctCollection,
+				JSONUtil.put(
+					"backgroundTaskId", backgroundTask.getBackgroundTaskId()
+				).put(
+					"ctCollectionId", ctCollectionId
+				).put(
+					"ctCollectionName", HtmlUtil.escape(ctCollection.getName())
+				).put(
+					"notificationType",
+					UserNotificationDefinition.NOTIFICATION_TYPE_REVIEW_ENTRY
+				).put(
+					"showConflicts", showConflicts
+				),
+				_getPublicationRolesUserIds(ctCollection, showConflicts));
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return super.handleException(backgroundTask, exception);
+	}
+
+	@Override
+	public void setAopProxy(Object aopProxy) {
+		_backgroundTaskExecutor = (BackgroundTaskExecutor)aopProxy;
+	}
+
+	private long[] _getPublicationRolesUserIds(
+		CTCollection ctCollection, boolean showConflicts) {
+
+		Set<Long> userIds = SetUtil.fromArray(
+			_ctUserNotificationHelper.getPublicationRoleUserIds(
+				ctCollection, true, PublicationRoleConstants.NAME_ADMIN,
+				PublicationRoleConstants.NAME_EDITOR,
+				PublicationRoleConstants.NAME_PUBLISHER));
+
+		if (!showConflicts) {
+			Role role = _roleLocalService.fetchRole(
+				ctCollection.getCompanyId(), RoleConstants.ADMINISTRATOR);
+
+			for (long userId :
+					_userLocalService.getRoleUserIds(role.getRoleId())) {
+
+				userIds.add(userId);
+			}
+		}
+
+		return ArrayUtil.toLongArray(userIds);
+	}
+
+	private void _publishCTCollection(
+			BackgroundTask backgroundTask, long ctCollectionId)
+		throws Exception {
 
 		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
 			ctCollectionId);
@@ -212,94 +316,57 @@ public class CTPublishBackgroundTaskExecutor
 		_ctCollectionLocalService.updateCTCollection(latestCTCollection);
 
 		_ctServiceRegistry.onAfterPublish(ctCollectionId);
-
-		return BackgroundTaskResult.SUCCESS;
 	}
 
-	@Override
-	public Class<?>[] getAopInterfaces() {
-		return new Class<?>[] {BackgroundTaskExecutor.class};
-	}
-
-	@Override
-	public BackgroundTaskDisplay getBackgroundTaskDisplay(
-		BackgroundTask backgroundTask) {
-
-		return new CTPublishBackgroundTaskDisplay(backgroundTask);
-	}
-
-	@Override
-	public String handleException(
-		BackgroundTask backgroundTask, Exception exception) {
-
-		boolean showConflicts = false;
-
-		if (exception instanceof CTPublishConflictException) {
-			showConflicts = true;
-		}
-
-		long ctCollectionId = MapUtil.getLong(
-			backgroundTask.getTaskContextMap(), "ctCollectionId");
-
+	private void _resetInstantPublishPreferences(long ctCollectionId) {
 		try {
 			CTCollection ctCollection =
-				_ctCollectionLocalService.getCTCollection(ctCollectionId);
+				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
 
-			_ctUserNotificationHelper.sendUserNotificationEvents(
-				ctCollection,
-				JSONUtil.put(
-					"backgroundTaskId", backgroundTask.getBackgroundTaskId()
-				).put(
-					"ctCollectionId", ctCollectionId
-				).put(
-					"ctCollectionName", HtmlUtil.escape(ctCollection.getName())
-				).put(
-					"notificationType",
-					UserNotificationDefinition.NOTIFICATION_TYPE_REVIEW_ENTRY
-				).put(
-					"showConflicts", showConflicts
-				),
-				_getPublicationRolesUserIds(ctCollection, showConflicts));
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
+			if ((ctCollection == null) ||
+				!FeatureFlagManagerUtil.isEnabled(
+					ctCollection.getCompanyId(), "LPD-39203")) {
+
+				return;
+			}
+
+			CTPreferences guestCTPreferences =
+				_ctPreferencesLocalService.fetchCTPreferences(
+					ctCollection.getCompanyId(),
+					_userLocalService.getGuestUserId(
+						ctCollection.getCompanyId()));
+
+			if ((guestCTPreferences != null) &&
+				(guestCTPreferences.getCtCollectionId() == ctCollectionId)) {
+
+				guestCTPreferences.setCtCollectionId(
+					CTConstants.CT_COLLECTION_ID_PRODUCTION);
+
+				_ctPreferencesLocalService.updateCTPreferences(
+					guestCTPreferences);
 			}
 		}
-
-		return super.handleException(backgroundTask, exception);
-	}
-
-	@Override
-	public void setAopProxy(Object aopProxy) {
-		_backgroundTaskExecutor = (BackgroundTaskExecutor)aopProxy;
-	}
-
-	private long[] _getPublicationRolesUserIds(
-		CTCollection ctCollection, boolean showConflicts) {
-
-		Set<Long> userIds = SetUtil.fromArray(
-			_ctUserNotificationHelper.getPublicationRoleUserIds(
-				ctCollection, true, PublicationRoleConstants.NAME_ADMIN,
-				PublicationRoleConstants.NAME_EDITOR,
-				PublicationRoleConstants.NAME_PUBLISHER));
-
-		if (!showConflicts) {
-			Role role = _roleLocalService.fetchRole(
-				ctCollection.getCompanyId(), RoleConstants.ADMINISTRATOR);
-
-			for (long userId :
-					_userLocalService.getRoleUserIds(role.getRoleId())) {
-
-				userIds.add(userId);
-			}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to reset instant publish preferences for publication " +
+					ctCollectionId,
+				exception);
 		}
-
-		return ArrayUtil.toLongArray(userIds);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CTPublishBackgroundTaskExecutor.class);
+
+	private static final TransactionConfig _transactionConfig;
+
+	static {
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setPropagation(Propagation.REQUIRES_NEW);
+		builder.setRollbackForClasses(Exception.class);
+
+		_transactionConfig = builder.build();
+	}
 
 	private BackgroundTaskExecutor _backgroundTaskExecutor;
 
@@ -311,6 +378,9 @@ public class CTPublishBackgroundTaskExecutor
 
 	@Reference
 	private CTEntryLocalService _ctEntryLocalService;
+
+	@Reference
+	private CTPreferencesLocalService _ctPreferencesLocalService;
 
 	@Reference
 	private CTSchemaVersionLocalService _ctSchemaVersionLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/servlet/filter/CTCollectionPreviewFilter.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/servlet/filter/CTCollectionPreviewFilter.java
@@ -11,6 +11,7 @@ import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.portal.kernel.change.tracking.CTCollectionPreviewThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -108,8 +109,17 @@ public class CTCollectionPreviewFilter extends BasePortalFilter {
 				PermissionThreadLocal.getPermissionChecker();
 
 			if (permissionChecker == null) {
-				permissionChecker = permissionCheckerFactory.create(
-					_portal.getUser(httpServletRequest));
+				User user = _portal.getUser(httpServletRequest);
+
+				if (user == null) {
+					processFilter(
+						CTCollectionPreviewFilter.class.getName(),
+						httpServletRequest, httpServletResponse, filterChain);
+
+					return;
+				}
+
+				permissionChecker = permissionCheckerFactory.create(user);
 			}
 
 			if (!_modelResourcePermission.contains(

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/spi/listener/CTPreferencesEventListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/spi/listener/CTPreferencesEventListener.java
@@ -24,26 +24,23 @@ public class CTPreferencesEventListener implements CTEventListener {
 
 	@Override
 	public void onAfterPublish(long ctCollectionId) {
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-39203")) {
+		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
+			ctCollectionId);
+
+		if ((ctCollection == null) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				ctCollection.getCompanyId(), "LPD-39203")) {
+
 			return;
 		}
 
 		_ctPreferencesLocalService.resetCTPreferences(ctCollectionId);
 
-		if (!_log.isInfoEnabled()) {
-			return;
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Publication " + ctCollection.getName() +
+					" was published. Production is live.");
 		}
-
-		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
-			ctCollectionId);
-
-		if (ctCollection == null) {
-			return;
-		}
-
-		_log.info(
-			"Publication " + ctCollection.getName() +
-				" was published. Production is live.");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
@@ -5,8 +5,10 @@
 
 package com.liferay.change.tracking.service.impl;
 
+import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.internal.background.task.CTPublishBackgroundTaskExecutor;
 import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.model.CTProcess;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
@@ -20,12 +22,15 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -73,11 +78,30 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 		ctCollection = _ctCollectionLocalService.updateCTCollection(
 			ctCollection);
 
-		if (!FeatureFlagManagerUtil.isEnabled(
+		_ctPreferencesLocalService.resetCTPreferences(
+			ctCollection.getCtCollectionId());
+
+		if (FeatureFlagManagerUtil.isEnabled(
 				ctCollection.getCompanyId(), "LPD-39203")) {
 
-			_ctPreferencesLocalService.resetCTPreferences(
+			CTPreferences guestCTPreferences =
+				_ctPreferencesLocalService.getCTPreferences(
+					ctCollection.getCompanyId(),
+					_userLocalService.getGuestUserId(
+						ctCollection.getCompanyId()));
+
+			guestCTPreferences.setCtCollectionId(
 				ctCollection.getCtCollectionId());
+			guestCTPreferences.setPreviousCtCollectionId(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION);
+
+			_ctPreferencesLocalService.updateCTPreferences(guestCTPreferences);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Using publication " + ctCollection.getCtCollectionId() +
+						" temporarily in place of production");
+			}
 		}
 
 		long ctProcessId = counterLocalService.increment(
@@ -176,6 +200,9 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 		return ctProcessPersistence.findByCtCollectionId(ctCollectionId);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		CTProcessLocalServiceImpl.class);
+
 	@Reference
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
@@ -190,5 +217,8 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/change-tracking/change-tracking-test/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-test/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationImplementation project(":apps:feature-flag:feature-flag-test-util")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTProcessLocalServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTProcessLocalServiceTest.java
@@ -6,10 +6,14 @@
 package com.liferay.change.tracking.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.model.CTProcess;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.service.CTProcessLocalService;
+import com.liferay.feature.flag.test.util.FeatureFlagTestHelper;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.test.util.JournalFolderFixture;
@@ -21,6 +25,7 @@ import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -35,6 +40,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -59,8 +65,195 @@ public class CTProcessLocalServiceTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
+		_featureFlagTestHelper = new FeatureFlagTestHelper();
+
+		_guestUserId = _userLocalService.getGuestUserId(
+			TestPropsValues.getCompanyId());
+
 		_journalFolderClassNameId = _classNameLocalService.getClassNameId(
 			JournalFolder.class);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_featureFlagTestHelper.setFeatureFlagValue(
+			TestPropsValues.getCompanyId(), _FEATURE_FLAG_KEY, false);
+
+		_featureFlagTestHelper.tearDown();
+
+		CTPreferences guestPreferences =
+			_ctPreferencesLocalService.fetchCTPreferences(
+				TestPropsValues.getCompanyId(), _guestUserId);
+
+		if (guestPreferences != null) {
+			guestPreferences.setCtCollectionId(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION);
+
+			_ctPreferencesLocalService.updateCTPreferences(guestPreferences);
+		}
+	}
+
+	@Test
+	public void testAddCTProcessWithInstantPublish() throws Exception {
+		_featureFlagTestHelper.setFeatureFlagValue(
+			TestPropsValues.getCompanyId(), _FEATURE_FLAG_KEY, true);
+
+		CTCollection ctCollection = _addCTCollectionWithContent();
+
+		try (LogCapture ctProcessLogCapture =
+				LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.change.tracking.service.impl." +
+						"CTProcessLocalServiceImpl",
+					LoggerTestUtil.DEBUG);
+			LogCapture ctPreferencesLogCapture =
+				LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.change.tracking.internal.spi.listener." +
+						"CTPreferencesEventListener",
+					LoggerTestUtil.INFO)) {
+
+			_ctProcessLocalService.addCTProcess(
+				TestPropsValues.getUserId(), ctCollection.getCtCollectionId());
+
+			List<LogEntry> ctProcessLogEntries =
+				ctProcessLogCapture.getLogEntries();
+
+			Assert.assertEquals(
+				ctProcessLogEntries.toString(), 1, ctProcessLogEntries.size());
+
+			LogEntry ctProcessLogEntry = ctProcessLogEntries.get(0);
+
+			Assert.assertEquals(
+				"Using publication " + ctCollection.getCtCollectionId() +
+					" temporarily in place of production",
+				ctProcessLogEntry.getMessage());
+
+			CTPreferences userPreferences =
+				_ctPreferencesLocalService.getCTPreferences(
+					TestPropsValues.getCompanyId(),
+					TestPropsValues.getUserId());
+
+			Assert.assertEquals(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION,
+				userPreferences.getCtCollectionId());
+
+			BackgroundTask backgroundTask =
+				_backgroundTaskLocalService.getBackgroundTask(
+					_ctProcessLocalService.getCTProcesses(
+						ctCollection.getCtCollectionId()
+					).get(
+						0
+					).getBackgroundTaskId());
+
+			Assert.assertEquals(
+				BackgroundTaskConstants.STATUS_SUCCESSFUL,
+				backgroundTask.getStatus());
+
+			List<LogEntry> ctPreferencesLogEntries =
+				ctPreferencesLogCapture.getLogEntries();
+
+			Assert.assertEquals(
+				ctPreferencesLogEntries.toString(), 1,
+				ctPreferencesLogEntries.size());
+
+			LogEntry ctPreferencesLogEntry = ctPreferencesLogEntries.get(0);
+
+			Assert.assertTrue(
+				ctPreferencesLogEntry.getMessage(
+				).contains(
+					"was published. Production is live."
+				));
+
+			CTPreferences guestPreferences =
+				_ctPreferencesLocalService.getCTPreferences(
+					TestPropsValues.getCompanyId(), _guestUserId);
+
+			Assert.assertEquals(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION,
+				guestPreferences.getCtCollectionId());
+		}
+	}
+
+	@Test
+	public void testAddCTProcessWithInstantPublishConflict() throws Exception {
+		_featureFlagTestHelper.setFeatureFlagValue(
+			TestPropsValues.getCompanyId(), _FEATURE_FLAG_KEY, true);
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		String conflictingFolderName = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			_journalFolderFixture.addFolder(
+				_group.getGroupId(), conflictingFolderName);
+		}
+
+		_journalFolderFixture.addFolder(
+			_group.getGroupId(), conflictingFolderName);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.background.task.internal.messaging." +
+					"BackgroundTaskMessageListener",
+				LoggerTestUtil.ERROR)) {
+
+			CTProcess ctProcess = _ctProcessLocalService.addCTProcess(
+				TestPropsValues.getUserId(), ctCollection.getCtCollectionId());
+
+			BackgroundTask backgroundTask =
+				_backgroundTaskLocalService.getBackgroundTask(
+					ctProcess.getBackgroundTaskId());
+
+			Assert.assertEquals(
+				BackgroundTaskConstants.STATUS_FAILED,
+				backgroundTask.getStatus());
+		}
+
+		CTPreferences guestPreferences =
+			_ctPreferencesLocalService.getCTPreferences(
+				TestPropsValues.getCompanyId(), _guestUserId);
+
+		Assert.assertEquals(
+			CTConstants.CT_COLLECTION_ID_PRODUCTION,
+			guestPreferences.getCtCollectionId());
+	}
+
+	@Test
+	public void testAddCTProcessWithInstantPublishUserInOtherPublication()
+		throws Exception {
+
+		_featureFlagTestHelper.setFeatureFlagValue(
+			TestPropsValues.getCompanyId(), _FEATURE_FLAG_KEY, true);
+
+		CTCollection otherCTCollection =
+			_ctCollectionLocalService.addCTCollection(
+				null, TestPropsValues.getCompanyId(),
+				TestPropsValues.getUserId(), 0, RandomTestUtil.randomString(),
+				null);
+
+		CTPreferences userPreferences =
+			_ctPreferencesLocalService.getCTPreferences(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		userPreferences.setCtCollectionId(
+			otherCTCollection.getCtCollectionId());
+
+		_ctPreferencesLocalService.updateCTPreferences(userPreferences);
+
+		CTCollection ctCollection = _addCTCollectionWithContent();
+
+		_ctProcessLocalService.addCTProcess(
+			TestPropsValues.getUserId(), ctCollection.getCtCollectionId());
+
+		userPreferences = _ctPreferencesLocalService.getCTPreferences(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		Assert.assertEquals(
+			otherCTCollection.getCtCollectionId(),
+			userPreferences.getCtCollectionId());
 	}
 
 	@Test
@@ -165,6 +358,24 @@ public class CTProcessLocalServiceTest {
 		}
 	}
 
+	private CTCollection _addCTCollectionWithContent() throws Exception {
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			_journalFolderFixture.addFolder(
+				_group.getGroupId(), RandomTestUtil.randomString());
+		}
+
+		return ctCollection;
+	}
+
+	private static final String _FEATURE_FLAG_KEY = "LPD-39203";
+
 	@Inject
 	private static JournalFolderLocalService _journalFolderLocalService;
 
@@ -178,13 +389,22 @@ public class CTProcessLocalServiceTest {
 	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Inject
+	private CTPreferencesLocalService _ctPreferencesLocalService;
+
+	@Inject
 	private CTProcessLocalService _ctProcessLocalService;
+
+	private FeatureFlagTestHelper _featureFlagTestHelper;
 
 	@DeleteAfterTestRun
 	private Group _group;
 
+	private long _guestUserId;
 	private long _journalFolderClassNameId;
 	private final JournalFolderFixture _journalFolderFixture =
 		new JournalFolderFixture(_journalFolderLocalService);
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/PublishCTCollectionMVCActionCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/PublishCTCollectionMVCActionCommand.java
@@ -5,24 +5,15 @@
 
 package com.liferay.change.tracking.web.internal.portlet.action;
 
-import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.constants.CTPortletKeys;
-import com.liferay.change.tracking.model.CTCollection;
-import com.liferay.change.tracking.model.CTPreferences;
-import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTCollectionService;
-import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -60,43 +51,6 @@ public class PublishCTCollectionMVCActionCommand extends BaseMVCActionCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (FeatureFlagManagerUtil.isEnabled(
-				themeDisplay.getCompanyId(), "LPD-39203")) {
-
-			try {
-				_ctPreferencesLocalService.resetCTPreferences(ctCollectionId);
-
-				CTCollection ctCollection =
-					_ctCollectionLocalService.getCTCollection(ctCollectionId);
-
-				CTPreferences ctPreferences =
-					_ctPreferencesLocalService.getCTPreferences(
-						ctCollection.getCompanyId(),
-						_userLocalService.getGuestUserId(
-							ctCollection.getCompanyId()));
-
-				ctPreferences.setCtCollectionId(ctCollectionId);
-				ctPreferences.setPreviousCtCollectionId(
-					CTConstants.CT_COLLECTION_ID_PRODUCTION);
-
-				_ctPreferencesLocalService.updateCTPreferences(ctPreferences);
-
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						"Using publication " + ctCollection.getName() +
-							" temporarily in place of production");
-				}
-			}
-			catch (PortalException portalException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to instantly publish publication. Attempting " +
-							"to publish normally.",
-						portalException);
-				}
-			}
-		}
-
 		String name = ParamUtil.getString(actionRequest, "name");
 
 		try {
@@ -129,17 +83,8 @@ public class PublishCTCollectionMVCActionCommand extends BaseMVCActionCommand {
 			).buildString());
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		PublishCTCollectionMVCActionCommand.class);
-
-	@Reference
-	private CTCollectionLocalService _ctCollectionLocalService;
-
 	@Reference
 	private CTCollectionService _ctCollectionService;
-
-	@Reference
-	private CTPreferencesLocalService _ctPreferencesLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;
@@ -149,8 +94,5 @@ public class PublishCTCollectionMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -177,13 +177,19 @@ public class WebServerServlet extends HttpServlet {
 				return true;
 			}
 			else if (Validator.isNumber(pathArray[0])) {
-				try (SafeCloseable safeCloseable =
-						CTCollectionThreadLocal.
-							setCTCollectionIdWithSafeCloseable(
-								ParamUtil.getLong(
-									httpServletRequest,
-									"previewCTCollectionId"))) {
+				long previewCTCollectionId = ParamUtil.getLong(
+					httpServletRequest, "previewCTCollectionId", -1);
 
+				if (previewCTCollectionId > -1) {
+					try (SafeCloseable safeCloseable =
+							CTCollectionThreadLocal.
+								setCTCollectionIdWithSafeCloseable(
+									previewCTCollectionId)) {
+
+						_checkFileEntry(pathArray);
+					}
+				}
+				else {
 					_checkFileEntry(pathArray);
 				}
 			}
@@ -1583,16 +1589,25 @@ public class WebServerServlet extends HttpServlet {
 
 		User user = _getUser(httpServletRequest);
 
-		try (SafeCloseable safeCloseable =
-				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-					ParamUtil.getLong(
-						httpServletRequest, "previewCTCollectionId"))) {
+		long previewCTCollectionId = ParamUtil.getLong(
+			httpServletRequest, "previewCTCollectionId", -1);
 
-			Group group = _getGroup(user.getCompanyId(), pathArray[1]);
+		if (previewCTCollectionId > -1) {
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						previewCTCollectionId)) {
 
-			return fileEntryFriendlyURLResolver.resolveFriendlyURL(
-				group.getGroupId(), pathArray[2]);
+				Group group = _getGroup(user.getCompanyId(), pathArray[1]);
+
+				return fileEntryFriendlyURLResolver.resolveFriendlyURL(
+					group.getGroupId(), pathArray[2]);
+			}
 		}
+
+		Group group = _getGroup(user.getCompanyId(), pathArray[1]);
+
+		return fileEntryFriendlyURLResolver.resolveFriendlyURL(
+			group.getGroupId(), pathArray[2]);
 	}
 
 	private void _checkCompanyAndGroup(


### PR DESCRIPTION
## Summary

- Centralize instant swap in `CTProcessLocalServiceImpl.addCTProcess` — when feature flag `LPD-39203` is enabled, guest user CTPreferences are pointed to the publication being published, making content changes appear instant to end users
- Add swap-back transaction in `CTPublishBackgroundTaskExecutor` — a finally block resets guest preferences to production after publish succeeds or fails, independent of the publish transaction
- Remove POC instant swap logic from `PublishCTCollectionMVCActionCommand`
- Fix null user NPE in `CTCollectionPreviewFilter` for unauthenticated requests with preview parameters
- Fix document resolution in `WebServerServlet` to use the current CT context instead of forcing production mode when `previewCTCollectionId` is absent

## Test plan

- [ ] `liferay test-integration change-tracking-test --tests CTProcessLocalServiceTest` — 5 tests pass (3 new instant publish tests)
- [ ] Enable feature flag `LPD-39203`, create a publication with content, publish — guest browser sees content instantly
- [ ] Verify guest preferences reset to production after publish completes
- [ ] Verify documents/images load during the instant publish window
- [ ] Publish with flag off — traditional publish behavior unchanged