### PR TITLE
LPD-87839 Job schedule list shows empty when a trigger references a removed feature flag

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking Service
 Bundle-SymbolicName: com.liferay.change.tracking.service
 Bundle-Version: 3.0.132
-Liferay-Require-SchemaVersion: 2.13.1
+Liferay-Require-SchemaVersion: 2.14.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
@@ -8,6 +8,7 @@ package com.liferay.change.tracking.internal.upgrade.registry;
 import com.liferay.change.tracking.internal.upgrade.v2_10_0.CTCollectionUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_12_3.CTMessageCompanyIdUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_12_4.CTProcessResourceUpgradeProcess;
+import com.liferay.change.tracking.internal.upgrade.v2_14_0.CTConflictCheckerDispatchTriggerUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_3_0.UpgradeCompanyId;
 import com.liferay.change.tracking.internal.upgrade.v2_4_0.CTSchemaVersionUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_7_0.CTProcessUpgradeProcess;
@@ -151,6 +152,10 @@ public class ChangeTrackingServiceUpgradeStepRegistrator
 			new com.liferay.change.tracking.internal.upgrade.v2_13_1.
 				CTConflictConfigurationUpgradeProcess(
 					_configurationAdmin, _configurationProvider));
+
+		registry.register(
+			"2.13.1", "2.14.0",
+			new CTConflictCheckerDispatchTriggerUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_14_0;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Objects;
+
+/**
+ * @author Pei-Jung Lan
+ */
+public class CTConflictCheckerDispatchTriggerUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select dispatchTriggerId, dispatchTaskSettings from " +
+					"DispatchTrigger where dispatchTaskSettings like " +
+						"'%featureFlagKey=LPD-11018%'");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DispatchTrigger set dispatchTaskSettings = ? " +
+						"where dispatchTriggerId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			while (resultSet.next()) {
+				UnicodeProperties unicodeProperties =
+					UnicodePropertiesBuilder.create(
+						true
+					).fastLoad(
+						resultSet.getString("dispatchTaskSettings")
+					).build();
+
+				if (!Objects.equals(
+						unicodeProperties.getProperty("featureFlagKey"),
+						"LPD-11018")) {
+
+					continue;
+				}
+
+				unicodeProperties.remove("featureFlagKey");
+
+				preparedStatement2.setString(1, unicodeProperties.toString());
+				preparedStatement2.setLong(
+					2, resultSet.getLong("dispatchTriggerId"));
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/test/CTConflictCheckerDispatchTriggerUpgradeProcessTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/test/CTConflictCheckerDispatchTriggerUpgradeProcessTest.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_14_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@RunWith(Arquillian.class)
+public class CTConflictCheckerDispatchTriggerUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.change.tracking.internal.upgrade.v2_14_0." +
+				"CTConflictCheckerDispatchTriggerUpgradeProcess");
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				_CT_CONFLICT_CHECKER_DISPATCH_TASK_EXECUTOR_TYPE,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"featureFlagKey", "LPD-11018"
+				).build(),
+				RandomTestUtil.randomString(), false);
+
+		UnicodeProperties unicodeProperties =
+			dispatchTrigger.getDispatchTaskSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"LPD-11018", unicodeProperties.getProperty("featureFlagKey"));
+
+		_upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		dispatchTrigger = _dispatchTriggerLocalService.getDispatchTrigger(
+			dispatchTrigger.getDispatchTriggerId());
+
+		unicodeProperties =
+			dispatchTrigger.getDispatchTaskSettingsUnicodeProperties();
+
+		Assert.assertNull(unicodeProperties.getProperty("featureFlagKey"));
+	}
+
+	private static final String
+		_CT_CONFLICT_CHECKER_DISPATCH_TASK_EXECUTOR_TYPE =
+			"scheduled-publications-conflict-checks";
+
+	@Inject
+	private static DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	private static UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.change.tracking.internal.upgrade.registry.ChangeTrackingServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
@@ -14,6 +14,8 @@ import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -32,11 +34,15 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -121,6 +127,48 @@ public class DispatchTriggerDisplayContextTest {
 				dispatchTaskExecutorTypeHiddenInUILabel,
 				dropdownItem.get("label"));
 		}
+	}
+
+	@Test
+	public void testGetSearchContainer() throws Exception {
+		DispatchTrigger dispatchTrigger1 =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				SingleNodeClusterModeDispatchTaskExecutor.
+					DISPATCH_TASK_EXECUTOR_TYPE_SINGLE_NODE,
+				null, RandomTestUtil.randomString(), false);
+
+		DispatchTrigger dispatchTrigger2 =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				SingleNodeClusterModeDispatchTaskExecutor.
+					DISPATCH_TASK_EXECUTOR_TYPE_SINGLE_NODE,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"featureFlagKey", RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(), false);
+
+		User user = TestPropsValues.getUser();
+
+		SearchContainer<DispatchTrigger> searchContainer =
+			ReflectionTestUtil.invoke(
+				_getDispatchTriggerDisplayContext(
+					_getMockHttpServletRequest(
+						_companyLocalService.getCompany(
+							TestPropsValues.getCompanyId()),
+						LayoutTestUtil.addTypePortletLayout(user.getGroupId()),
+						user)),
+				"getSearchContainer", new Class<?>[0], null);
+
+		List<DispatchTrigger> dispatchTriggers = searchContainer.getResults();
+
+		Assert.assertTrue(ListUtil.isNotEmpty(dispatchTriggers));
+
+		Assert.assertTrue(dispatchTriggers.contains(dispatchTrigger1));
+
+		Assert.assertFalse(dispatchTriggers.contains(dispatchTrigger2));
 	}
 
 	@Test
@@ -223,6 +271,10 @@ public class DispatchTriggerDisplayContextTest {
 		MockLiferayPortletRenderResponse mockLiferayPortletRenderResponse =
 			new MockLiferayPortletRenderResponse();
 
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
+
 		mockLiferayPortletRenderRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_RESPONSE,
 			mockLiferayPortletRenderResponse);
@@ -278,6 +330,9 @@ public class DispatchTriggerDisplayContextTest {
 
 	@Inject
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Inject
+	private FeatureFlagManager _featureFlagManager;
 
 	@Inject(
 		filter = "component.name=com.liferay.dispatch.web.internal.portlet.action.EditDispatchTriggerMVCActionCommand"

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
@@ -15,12 +15,15 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -238,14 +241,30 @@ public class DispatchTriggerDisplayContext extends BaseDisplayContext {
 						dispatchTrigger.
 							getDispatchTaskSettingsUnicodeProperties();
 
-					if (!unicodeProperties.containsKey("featureFlagKey") ||
-						FeatureFlagManagerUtil.isEnabled(
-							unicodeProperties.getProperty("featureFlagKey"))) {
-
+					if (!unicodeProperties.containsKey("featureFlagKey")) {
 						return true;
 					}
 
-					return false;
+					String featureFlagKey = unicodeProperties.getProperty(
+						"featureFlagKey");
+
+					try {
+						return FeatureFlagManagerUtil.isEnabled(
+							dispatchRequestHelper.getCompanyId(),
+							featureFlagKey);
+					}
+					catch (IllegalStateException illegalStateException) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"Feature flag key ", featureFlagKey,
+									" is not registered for dispatch trigger ",
+									dispatchTrigger.getDispatchTriggerId()),
+								illegalStateException);
+						}
+
+						return false;
+					}
 				}));
 		_searchContainer.setRowChecker(getRowChecker());
 
@@ -269,6 +288,9 @@ public class DispatchTriggerDisplayContext extends BaseDisplayContext {
 	public boolean isClusterModeSingle(String type) {
 		return _dispatchTaskExecutorRegistry.isClusterModeSingle(type);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DispatchTriggerDisplayContext.class);
 
 	private final DispatchTaskExecutorRegistry _dispatchTaskExecutorRegistry;
 	private final DispatchTriggerLocalService _dispatchTriggerLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87839

## What is the issue?

When a dispatch trigger's `featureFlagKey` setting references a feature flag that has been removed, `FeatureFlagManagerUtil.isEnabled()` throws an `IllegalStateException` inside the `ListUtil.filter` predicate in `DispatchTriggerDisplayContext.getSearchContainer()`. This exception propagates out of the filter, causing the entire dispatch trigger list to appear empty in the UI.

## Summary
- Catch `IllegalStateException` in the feature flag check and hide the trigger (return `false`) rather than letting the exception collapse the entire list
- Add upgrade process to remove the stale `featureFlagKey=LPD-11018` property from existing CT conflict-checker dispatch triggers
- Add integration test coverage for both behaviors

## Test plan
- [ ] `DispatchTriggerDisplayContextTest#testGetSearchContainer` passes
- [ ] `CTConflictCheckerDispatchTriggerUpgradeProcessTest#testUpgrade` passes