### PR TITLE
LPD-86450 Remove apiHelpers.headlessSite calls for Site Management

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
@@ -5,16 +5,16 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 
 export const test = mergeTests(
-	apiHelpersTest,
 	changeTrackingPagesTest,
+	dataApiHelpersTest,
 	journalPagesTest,
 	loginTest()
 );
@@ -34,7 +34,7 @@ test('LPD-29562 Assert popover only appears when context is changed', async ({
 		page.getByText('Keep working in this publication?', {exact: true})
 	).toBeHidden();
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 
@@ -61,7 +61,7 @@ test('LPD-33582 Assert context change popover buttons behavior', async ({
 }) => {
 	await changeTrackingPage.workOnPublication(ctCollection);
 
-	const site1 = await apiHelpers.headlessSite.createSite({
+	const site1 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 
@@ -77,7 +77,7 @@ test('LPD-33582 Assert context change popover buttons behavior', async ({
 
 	await changeTrackingPage.workOnPublication(ctCollection);
 
-	const site2 = await apiHelpers.headlessSite.createSite({
+	const site2 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 
@@ -120,7 +120,7 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 }) => {
 	await changeTrackingPage.workOnPublication(ctCollection);
 
-	const site1 = await apiHelpers.headlessSite.createSite({
+	const site1 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 
@@ -138,7 +138,7 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 		.getByRole('button', {name: 'Stay in Current Publication'})
 		.click();
 
-	const site2 = await apiHelpers.headlessSite.createSite({
+	const site2 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -204,15 +204,13 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 }) => {
 	await changeTrackingPage.workOnProduction();
 
-	const site1 = await apiHelpers.headlessSite.createSite({
+	const site1 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-	apiHelpers.data.push({id: site1.externalReferenceCode, type: 'site'});
 
-	const site2 = await apiHelpers.headlessSite.createSite({
+	const site2 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-	apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 	await changeTrackingPage.workOnPublication(ctCollection);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86450

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

### Site Cleanup
- Automated: Manual `deleteSite` calls were removed when using `dataApiHelpersTest`, as cleanup is now handled automatically through `ApiHelpers.clearData`.
- Manual: Explicit deletion remains for tests using `apiHelpersTest` (which lacks the automatic registry) or where immediate cleanup is required for state validation.

If you encounter any failures or flakiness related to these changes, please let me know.