### PR TITLE
LPD-88162 Reject site updates from users without UPDATE permission

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -1051,7 +1051,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					site.getExternalReferenceCode());
 			}
 
-			Group updatedGroup = _groupLocalService.updateGroup(
+			Group updatedGroup = _groupService.updateGroup(
 				group.getGroupId(),
 				_getParentGroupId(
 					group, site.getParentSiteExternalReferenceCode()),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -28,16 +28,19 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -220,6 +223,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPutSiteBatchWithParentSiteExternalReferenceCode();
 		_testPutSiteWithExcludedTypeSettings();
 		_testPutSiteWithParentSiteExternalReferenceCode();
+		_testPutSiteWithoutUpdatePermission();
 	}
 
 	@LazyReferencing
@@ -1493,6 +1497,36 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			putSiteUnicodeProperties.get("MAP_PROVIDER_KEY"));
 	}
 
+	private void _testPutSiteWithoutUpdatePermission() throws Exception {
+		User user = UserTestUtil.addUser(false);
+
+		user = _userLocalService.updatePassword(
+			user.getUserId(), "test", "test", false, true);
+
+		SiteResource siteResource = SiteResource.builder(
+		).authentication(
+			user.getEmailAddress(), "test"
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		Site postSite = _testPostSite_addSite(randomSite());
+
+		try {
+			siteResource.putSite(
+				postSite.getExternalReferenceCode(), randomSite());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private void _testPutSiteWithParentSiteExternalReferenceCode()
 		throws Exception {
 
@@ -1541,6 +1575,9 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	private String _originalName;
 	private final List<Site> _sites = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	private class TestSiteInitializer implements SiteInitializer {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88162

## What is being fixed

`PUT /o/headless-admin-site/v1.0/sites/{externalReferenceCode}` accepted updates from any authenticated user. A user holding only the default `User` role could rename a site, change its membership type, or deactivate it. The sibling endpoints (`POST /sites`, `DELETE /sites/{erc}`, `PUT /sites/{erc}/activate`, `PUT /sites/{erc}/deactivate`) correctly rejected the same caller with `403`.

## How it is being fixed

The update path in `SiteResourceImpl#_updateGroup` was the only mutating path on this resource that called `GroupLocalService#updateGroup`. Local services intentionally bypass permission checks. Routing the call through the remote `GroupService#updateGroup` instead — identical signature, already injected — closes the bypass via the `GroupPermissionUtil.check(..., UPDATE)` it performs internally.

The first commit adds a regression test that creates a non-admin user, authenticates a `SiteResource` as that user, and asserts the PUT returns a `Problem` with status `FORBIDDEN`. The second commit applies the one-line fix.