### PR TITLE
LPD-88172 Match site list totalCount to filtered items

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredGroupException;
@@ -44,6 +45,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -71,7 +73,7 @@ import java.io.File;
 import java.io.Serializable;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -313,7 +315,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			_portal.getClassNameId(Company.class.getName()),
 			_portal.getClassNameId(Group.class.getName())
 		};
-		LinkedHashMap<String, Object> params =
+
+		List<Group> groups = _groupService.search(
+			contextCompany.getCompanyId(), classNameIds, search, null,
 			LinkedHashMapBuilder.<String, Object>put(
 				"active",
 				() -> {
@@ -325,7 +329,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				}
 			).put(
 				"site", true
-			).build();
+			).build(),
+			true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			new GroupNameComparator());
 
 		return Page.of(
 			HashMapBuilder.put(
@@ -344,14 +350,11 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					null)
 			).build(),
 			transform(
-				_groupService.search(
-					contextCompany.getCompanyId(), classNameIds, search, null,
-					params, true, pagination.getStartPosition(),
-					pagination.getEndPosition(), new GroupNameComparator()),
+				ListUtil.subList(
+					groups, pagination.getStartPosition(),
+					pagination.getEndPosition()),
 				this::_toSite),
-			pagination,
-			_groupService.searchCount(
-				contextCompany.getCompanyId(), classNameIds, search, params));
+			pagination, groups.size());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -28,16 +28,19 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -173,6 +176,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testGetSitesPageWithActiveOrSiteGroups(true, false);
 		_testGetSitesPageWithDepotEntry();
 		_testGetSitesPageWithInactiveSites();
+		_testGetSitesPageWithoutSiteMembership();
 		_testGetSitesPageWithSearch();
 		_testGetSitesPageWithoutAuthentication();
 	}
@@ -524,6 +528,35 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			Assert.assertEquals("403", problem.getStatus());
 		}
+	}
+
+	private void _testGetSitesPageWithoutSiteMembership() throws Exception {
+		_testPostSite_addSite(randomSite());
+		_testPostSite_addSite(randomSite());
+
+		User user = UserTestUtil.addUser(false);
+
+		user = _userLocalService.updatePassword(
+			user.getUserId(), "test", "test", false, true);
+
+		SiteResource siteResource = SiteResource.builder(
+		).authentication(
+			user.getEmailAddress(), "test"
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		Page<Site> page = siteResource.getSitesPage(
+			null, null, Pagination.of(1, 100));
+
+		Assert.assertEquals(
+			page.getItems(
+			).toString(),
+			page.getItems(
+			).size(),
+			page.getTotalCount());
 	}
 
 	private void _testGetSitesPageWithSearch() throws Exception {
@@ -1541,6 +1574,9 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	private String _originalName;
 	private final List<Site> _sites = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	private class TestSiteInitializer implements SiteInitializer {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88172

## What is being fixed

`GET /o/headless-admin-site/v1.0/sites` returned a `totalCount` that included sites the caller could not see, while `items` was filtered by VIEW permission. For a non-admin user with no membership beyond Guest, `totalCount` could be 3 while `items` contained a single entry. UIs that compute "is there a next page?" from `totalCount / pageSize` keep paging through empty result sets.

The asymmetry sat in `SiteResourceImpl#doGetSitesPage`: `_groupService.search` applies `filterGroups` (VIEW check) after paging, but `_groupService.searchCount` delegates straight to `groupLocalService.searchCount` and never filters.

## How it is being fixed

Compute `totalCount` from the same filtered set used to build `items`. The endpoint now calls `_groupService.search` once with `QueryUtil.ALL_POS`, slices the page with `ListUtil.subList`, and uses `groups.size()` for the total. This matches the established headless convention used in `AssigneeResourceImpl`, `TransitionResourceImpl`, `AssetUsageResourceImpl`, `WorkflowDefinitionLinkResourceImpl`, and `FieldResourceImpl`.

A side benefit: pages are no longer sparse for non-admin users. The previous code paged the unfiltered set then dropped invisible rows from the page, which could yield a 0-item page even when more visible results existed.

The fix is scoped to `SiteResourceImpl` rather than `GroupServiceImpl#searchCount` itself, because the kernel signature change would ripple to every other caller (item-selector, commerce, analytics) where the count semantics may be intentional.