### PR TITLE
LPD-87846 Fix testSitemapWithCleanUrlEnabled to use sitemap XML directly

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -1015,27 +1015,66 @@ public class SitemapManagerTest {
 
 	@Test
 	public void testSitemapWithCleanUrlEnabled() throws Exception {
-		try (SafeCloseable safeCloseable =
+		Group group = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).put(
+							"xmlSitemapIndexEnabled", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
 					false)) {
 
-			Group group = _groupLocalService.getGroup(
-				TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+			Layout layout = _layoutLocalService.fetchFirstLayout(
+				group.getGroupId(), false, 0);
 
-			_setUpThemeDisplay(
-				group,
-				_layoutLocalService.fetchFirstLayout(
-					group.getGroupId(), false, 0),
-				"localhost");
+			_setUpThemeDisplay(group, layout, "localhost");
 
-			String[] guestLayoutURLs = _getSitemapLayoutURLs(
-				group.getGroupId());
+			String xml = _sitemapManager.getSitemap(
+				null, group.getGroupId(), false, _themeDisplay);
 
-			Assert.assertTrue(ArrayUtil.isNotEmpty(guestLayoutURLs));
+			Document document = _saxReader.read(xml);
 
-			for (String guestLayoutURL : guestLayoutURLs) {
-				Assert.assertFalse(guestLayoutURL.contains("/web/"));
+			Element rootElement = document.getRootElement();
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			for (Element element : elements) {
+				Element locElement = element.element("loc");
+
+				if (locElement != null) {
+					Assert.assertFalse(
+						locElement.getData(
+						).toString(
+						).contains(
+							"/web/"
+						));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87846

## What Changed

`testSitemapWithCleanUrlEnabled` in `SitemapManagerTest` has been failing since April 24 because it used `_getSitemapLayoutURLs()` to generate expected URLs. That helper calls `_portal.getAlternateURLs()` which relies on finding `/web/` in the URL via `getGroupFriendlyURLIndex()`. When `LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED=false`, canonical URLs no longer contain `/web/`, so the helper returns an empty array and the `assertTrue(ArrayUtil.isNotEmpty(...))` assertion fails.

## Root Cause

The test was written using a test helper (`_getSitemapLayoutURLs`) that does not correctly handle the clean URL case. When `LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED=false`:

1. `_portal.getLayoutFullURL()` generates URLs without `/web/`
2. `_portal.getAlternateURLs()` calls `getGroupFriendlyURLIndex()` to find the group path in the URL
3. `getGroupFriendlyURLIndex()` only recognizes `/web/`, `/group/`, and `/user/` prefixes, returning `null` for clean URLs
4. With `pos <= 0`, `getAlternateURLs()` still returns correct URLs, but the test helper's internal assertions break

The production sitemap code (`LayoutSitemapURLProvider`) works correctly for clean URLs — it generates valid URLs without `/web/`. Only the test helper was broken.

## Fix

Replace the indirect `_getSitemapLayoutURLs()` approach with a direct call to `_sitemapManager.getSitemap()`. The test now:
1. Configures company and group to include pages in the sitemap
2. Swaps the `LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED` prop to `false`
3. Generates the sitemap XML directly via `SitemapManager`
4. Parses the XML and asserts that `<loc>` elements are present and none contain `/web/`