### PR TITLE
LPD-88209 Always reindex CTEntry on update

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/CTEntryModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/CTEntryModelListener.java
@@ -57,12 +57,7 @@ public class CTEntryModelListener extends BaseModelListener<CTEntry> {
 			_updateCTScore(ctEntry, true);
 		}
 
-		if ((originalCTEntry.getCtCollectionId() !=
-				ctEntry.getCtCollectionId()) ||
-			(originalCTEntry.getUserId() != ctEntry.getUserId())) {
-
-			_reindexCTEntry(ctEntry, "reindex");
-		}
+		_reindexCTEntry(ctEntry, "reindex");
 
 		_ctClosureFactory.clearCache(ctEntry.getCtCollectionId());
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88209

## What Changed

CTEntrySearcherTest#testSearchByStatus and testSortByStatus have been failing since build 468092310 (2026-04-17). The tests update a JournalFolder's status inside a CT collection and expect the CTEntry search index to reflect the new status, but the index retains the stale status.

## Root Cause

LPD-84671 (commit d0481be66c590, April 2, 2026) changed CTPersistenceHelperImpl.isInsert() to call `_ctEntryLocalService.updateUserId()` instead of `_ctEntryLocalService.updateCTEntry()` to bypass the synchronous @Indexable reindexing.

The new path goes through CTEntryModelListener.onAfterUpdate(), but that method only triggered a reindex when ctCollectionId or userId changed:

```java
if ((originalCTEntry.getCtCollectionId() != ctEntry.getCtCollectionId()) ||
    (originalCTEntry.getUserId() != ctEntry.getUserId())) {
    _reindexCTEntry(ctEntry, "reindex");
}
```

When the same user updates a model's attributes (like status) inside a CT collection, neither condition is true, so the CTEntry is not reindexed. The index document retains the status from when the CTEntry was first created.

## Fix

Remove the condition in onAfterUpdate() so CTEntry is always reindexed asynchronously via the CT_ENTRY_REINDEX destination whenever it is updated. This restores the behavioral intent of the pre-LPD-84671 code (always reindex on model update) while keeping the async reindexing approach introduced by LPD-84671.