### PR TITLE
LPD-88235 Wait for tooltip provider to mount before tabbing

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
@@ -482,6 +482,8 @@ test(
 				.getByTitle('Go to Membership Requests')
 		).toBeVisible();
 
+		await page.waitForTimeout(300);
+
 		await page.keyboard.press('Tab');
 
 		await page.keyboard.press('Tab');
@@ -509,6 +511,8 @@ test(
 		).toBeVisible();
 
 		await page.reload();
+
+		await page.waitForTimeout(300);
 
 		await page.keyboard.press('Tab');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88235

## What is being fixed

The `memberships.spec.ts > Confirm that, using Keyboard Navigation...` test was intermittently failing on CI acceptance runs (two days running), but passing locally and in isolated module runs. The two `.tooltip-inner` `toBeVisible` assertions after the post-Reply and post-Save 3-Tab keyboard bursts would time out after 15 seconds, even though the `toBeFocused` assertion immediately before them passed — focus did land on the back button, as confirmed by the failure screenshot.

The root cause is a listener-readiness race. Clicking "Reply" navigates to the standalone reply form, which causes `ClayTooltipProvider` to remount. The three rapid `keyboard.press('Tab')` calls beat the provider's `useEffect`, so the global `keydown` listener that flips `currentInteraction` to `'keyboard'` is not yet registered. The browser still moves focus correctly, but Clay's `onFocus` short-circuits via `isFocusVisible()` because `currentInteraction` is still `'pointer'` from the preceding click — and the tooltip never renders.

## How it is being fixed

Add `await page.waitForTimeout(300)` before each of the two failing Tab bursts (post-Reply and post-page-reload), mirroring the existing settle wait at the top of section 1 of the same test, which already works for the same reason.