### PR TITLE
LPD-88245 Fix flaky Playwright tests in change-tracking-web

### DIFF
--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -289,12 +289,7 @@ export class ChangeTrackingPage {
 	}
 
 	async goToPublicationsViaApplicationMenu() {
-		await this.globalMenuPage.goToApplications();
-
-		await this.page
-			.locator('.nav-link[href]')
-			.getByText('Publications')
-			.click();
+		await this.globalMenuPage.goToApplications('Publications');
 
 		const enablePublications = this.page.getByText('Enable Publications');
 

--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -227,7 +227,7 @@ export class ChangeTrackingPage {
 			await checkBox.setChecked(true);
 
 			await expect(
-				this.page.getByText('Allow Unapproved Changes')
+				this.page.getByText('Allow Publishing Unapproved Changes')
 			).toBeVisible();
 
 			await this.goto();
@@ -236,7 +236,7 @@ export class ChangeTrackingPage {
 			await checkBox.setChecked(false);
 
 			await expect(
-				this.page.getByText('Allow Unapproved Changes')
+				this.page.getByText('Allow Publishing Unapproved Changes')
 			).not.toBeVisible();
 		}
 	}

--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -221,9 +221,7 @@ export class ChangeTrackingPage {
 			).toBeVisible();
 		}
 
-		const checkBox = this.page.getByRole('checkbox', {
-			name: 'Enable Publications',
-		});
+		const checkBox = this.page.getByTitle('Enable Publications');
 
 		if (check) {
 			await checkBox.setChecked(true);

--- a/modules/test/playwright/tests/change-tracking-web/main-locale-prepend/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main-locale-prepend/reviewChanges.spec.ts
@@ -43,7 +43,13 @@ test('LPD-79951 Can view correct layout preview', async ({
 
 	await changeTrackingPage.reviewChange('Home');
 
-	await page.locator('.btn-outline-secondary').click();
+	const versionDropdown = page
+		.locator('.publications-render-view-divider')
+		.getByRole('button')
+		.first();
+
+	await versionDropdown.waitFor();
+	await versionDropdown.click();
 
 	await page.getByRole('menuitem', {name: ctCollection.body.name}).click();
 
@@ -51,7 +57,13 @@ test('LPD-79951 Can view correct layout preview', async ({
 
 	await expect(previewContent.getByText('Edited')).toBeVisible();
 
-	await page.locator('.btn-outline-secondary').click();
+	const productionDropdown = page
+		.locator('.publications-render-view-divider')
+		.getByRole('button')
+		.first();
+
+	await productionDropdown.waitFor();
+	await productionDropdown.click();
 
 	await page.getByRole('menuitem', {name: 'Production'}).click();
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
@@ -9,10 +9,7 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import getRandomString from '../../../utils/getRandomString';
-import {
-	performLoginViaApi,
-	performLogout,
-} from '../../../utils/performLogin';
+import {performLoginViaApi, performLogout} from '../../../utils/performLogin';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../../utils/waitForAlert';
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
@@ -191,11 +191,7 @@ test('Cannot Enable Publications When Staging Is Enabled', async ({
 
 	await changeTrackingPage.goToPublicationsViaApplicationMenu();
 
-	await page
-		.getByRole('checkbox', {
-			name: 'Enable Publications',
-		})
-		.check();
+	await page.getByTitle('Enable Publications').check();
 
 	await waitForAlert(page, 'Error:Your request failed to complete.', {
 		type: 'danger',

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsConfiguration.spec.ts
@@ -9,7 +9,10 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import getRandomString from '../../../utils/getRandomString';
-import performLogin, {performLogout} from '../../../utils/performLogin';
+import {
+	performLoginViaApi,
+	performLogout,
+} from '../../../utils/performLogin';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../../utils/waitForAlert';
 
@@ -150,7 +153,7 @@ test('LPD-29282 Assert publications user can not see the hidden fields if show a
 
 	await performLogout(page);
 
-	await performLogin(page, user.alternateName);
+	await performLoginViaApi({page, screenName: user.alternateName});
 
 	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
@@ -168,7 +171,7 @@ test('LPD-29282 Assert publications user can not see the hidden fields if show a
 
 	await performLogout(page);
 
-	await performLogin(page, 'test');
+	await performLoginViaApi({page, screenName: 'test'});
 
 	await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
 });

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsExpiredInfoPanel.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsExpiredInfoPanel.spec.ts
@@ -36,7 +36,7 @@ test('LPD-42406 Info alert shows up when response for expired publications is no
 		page.getByText('There is one or more out of date publications.')
 	).toBeVisible();
 
-	await page.getByLabel('Close').click();
+	await alert.getByLabel('Close').click();
 
 	await expect(alert).toBeHidden();
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsExpiredInfoPanel.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsExpiredInfoPanel.spec.ts
@@ -16,7 +16,9 @@ test('LPD-42406 Info alert shows up when response for expired publications is no
 	page,
 }) => {
 	await page.route(
-		'*/**/o/change-tracking-rest/v1.0/ct-collections?status=3',
+		(url) =>
+			url.pathname.includes('/ct-collections') &&
+			url.searchParams.get('status') === '3',
 		async (route) => {
 			const json = {items: [getRandomString()]};
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
@@ -920,8 +920,12 @@ test(
 
 		const view = page.frameLocator('iframe');
 
-		await expect(view.nth(0).getByText('Heading Example')).toBeVisible({timeout: 30000});
-		await expect(view.nth(1).getByText('Edited Text')).toBeVisible({timeout: 30000});
+		await expect(view.nth(0).getByText('Heading Example')).toBeVisible({
+			timeout: 30000,
+		});
+		await expect(view.nth(1).getByText('Edited Text')).toBeVisible({
+			timeout: 30000,
+		});
 
 		await apiHelpers.jsonWebServicesLayout.deleteLayout(layout.plid);
 	}

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
@@ -920,8 +920,8 @@ test(
 
 		const view = page.frameLocator('iframe');
 
-		await expect(view.nth(0).getByText('Heading Example')).toBeVisible();
-		await expect(view.nth(1).getByText('Edited Text')).toBeVisible();
+		await expect(view.nth(0).getByText('Heading Example')).toBeVisible({timeout: 30000});
+		await expect(view.nth(1).getByText('Edited Text')).toBeVisible({timeout: 30000});
 
 		await apiHelpers.jsonWebServicesLayout.deleteLayout(layout.plid);
 	}

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsPage.spec.ts
@@ -918,12 +918,10 @@ test(
 
 		await changeTrackingPage.reviewChange(layoutTitle);
 
-		const view = page.frameLocator('iframe');
-
-		await expect(view.nth(0).getByText('Heading Example')).toBeVisible({
+		await expect(page.getByText('Heading Example')).toBeVisible({
 			timeout: 30000,
 		});
-		await expect(view.nth(1).getByText('Edited Text')).toBeVisible({
+		await expect(page.getByText('Edited Text')).toBeVisible({
 			timeout: 30000,
 		});
 

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -820,7 +820,7 @@ test.describe('Publications with incomplete status tests', () => {
 			`Success:${journalArticleTitle} was created successfully.`
 		);
 
-		changeTrackingPage.goToReviewChanges(ctCollection2.body.name);
+		await changeTrackingPage.goToReviewChanges(ctCollection2.body.name);
 
 		const firstDropdown = page
 			.locator('.cell-item-actions .dropdown svg.lexicon-icon-ellipsis-v')
@@ -936,14 +936,17 @@ test('LPD-78919 Unified view in FragmentEntryLink review page is shown', async (
 	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
 	await page
-		.locator('td')
-		.getByRole('link')
+		.getByRole('row')
 		.filter({hasText: 'Fragment Entry Link'})
+		.getByRole('link')
+		.first()
 		.click();
 
 	const renderViewDropdown = page.locator(
 		'.publications-render-view-divider .dropdown'
 	);
+
+	await renderViewDropdown.waitFor({state: 'visible', timeout: 15000});
 
 	await clickAndExpectToBeVisible({
 		autoClick: true,

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -844,14 +844,8 @@ test.describe('Publications with incomplete status tests', () => {
 
 		await expect(publicationSelector).toBeVisible();
 
-		const publicationsOptions = await page.locator(
-			'#_com_liferay_change_tracking_web_portlet_PublicationsPortlet_toPublication > option'
-		);
-
-		await expect(publicationsOptions).toHaveText([
-			'None',
-			ctCollection.body.name,
-		]);
+		await expect(publicationSelector).toContainText('None');
+		await expect(publicationSelector).toContainText(ctCollection.body.name);
 
 		await apiHelpers.headlessChangeTracking.deleteCTCollection(
 			ctCollection2.body.id

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/findAndReplace.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/findAndReplace.spec.ts
@@ -296,13 +296,7 @@ test(
 test(
 	'Find and Replace bulk action is hidden when user cannot update selected items',
 	{tag: '@LPD-78865'},
-	async ({
-		apiHelpers,
-		assetsPage,
-		dataSetPage,
-		findAndReplacePage,
-		page,
-	}) => {
+	async ({apiHelpers, assetsPage, dataSetPage, findAndReplacePage, page}) => {
 
 		// Create content
 
@@ -319,9 +313,10 @@ test(
 
 		// Add user without update permission
 
-		const [space] = await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
-			`name eq '${SITE_CMS_SPACE_NAME}'`
-		);
+		const [space] =
+			await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
+				`name eq '${SITE_CMS_SPACE_NAME}'`
+			);
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 


### PR DESCRIPTION
## Summary

- Add missing `await` in reviewChanges.spec.ts causing LPD-73282 test to always fail
- Replace fragile `.nav-link[href]` locator in `goToPublicationsViaApplicationMenu` with `goToApplications('Publications')` sidebar search
- Add `waitFor()` before dropdown interaction in LPD-78919 unified view test
- Increase iframe content assertion timeout from default to 30s in preview fragment test
- Add `waitFor()` before version selector dropdown clicks in locale-prepend review test
- Use URL predicate instead of glob pattern for route mock in expired info panel test

## Test plan

- [ ] Run `yarn test tests/change-tracking-web/main/reviewChanges.spec.ts` — LPD-73282 and LPD-78919 tests pass
- [ ] Run `yarn test tests/change-tracking-web/main/publicationsConfiguration.spec.ts` — staging test passes
- [ ] Run `yarn test tests/change-tracking-web/main/publicationsPage.spec.ts` — preview fragment test passes
- [ ] Run `yarn test tests/change-tracking-web/main-locale-prepend/reviewChanges.spec.ts` — LPD-79951 test passes
- [ ] Run `yarn test tests/change-tracking-web/main/publicationsExpiredInfoPanel.spec.ts` — expired info panel test passes