### PR TITLE
LPD-87839 Job schedule list shows empty when a trigger references a removed feature flag

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking Service
 Bundle-SymbolicName: com.liferay.change.tracking.service
 Bundle-Version: 3.0.132
-Liferay-Require-SchemaVersion: 2.13.1
+Liferay-Require-SchemaVersion: 2.14.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
@@ -8,6 +8,7 @@ package com.liferay.change.tracking.internal.upgrade.registry;
 import com.liferay.change.tracking.internal.upgrade.v2_10_0.CTCollectionUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_12_3.CTMessageCompanyIdUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_12_4.CTProcessResourceUpgradeProcess;
+import com.liferay.change.tracking.internal.upgrade.v2_14_0.CTConflictCheckerDispatchTriggerUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_3_0.UpgradeCompanyId;
 import com.liferay.change.tracking.internal.upgrade.v2_4_0.CTSchemaVersionUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_7_0.CTProcessUpgradeProcess;
@@ -151,6 +152,10 @@ public class ChangeTrackingServiceUpgradeStepRegistrator
 			new com.liferay.change.tracking.internal.upgrade.v2_13_1.
 				CTConflictConfigurationUpgradeProcess(
 					_configurationAdmin, _configurationProvider));
+
+		registry.register(
+			"2.13.1", "2.14.0",
+			new CTConflictCheckerDispatchTriggerUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_14_0;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Objects;
+
+/**
+ * @author Pei-Jung Lan
+ */
+public class CTConflictCheckerDispatchTriggerUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select dispatchTriggerId, dispatchTaskSettings from " +
+					"DispatchTrigger where dispatchTaskSettings like " +
+						"'%featureFlagKey=LPD-11018%'");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DispatchTrigger set dispatchTaskSettings = ? " +
+						"where dispatchTriggerId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			while (resultSet.next()) {
+				UnicodeProperties unicodeProperties =
+					UnicodePropertiesBuilder.create(
+						true
+					).fastLoad(
+						resultSet.getString("dispatchTaskSettings")
+					).build();
+
+				if (!Objects.equals(
+						unicodeProperties.getProperty("featureFlagKey"),
+						"LPD-11018")) {
+
+					continue;
+				}
+
+				unicodeProperties.remove("featureFlagKey");
+
+				preparedStatement2.setString(1, unicodeProperties.toString());
+				preparedStatement2.setLong(
+					2, resultSet.getLong("dispatchTriggerId"));
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/test/CTConflictCheckerDispatchTriggerUpgradeProcessTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/test/CTConflictCheckerDispatchTriggerUpgradeProcessTest.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_14_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@RunWith(Arquillian.class)
+public class CTConflictCheckerDispatchTriggerUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.change.tracking.internal.upgrade.v2_14_0." +
+				"CTConflictCheckerDispatchTriggerUpgradeProcess");
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				"scheduled-publications-conflict-checks",
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"featureFlagKey", "LPD-11018"
+				).build(),
+				RandomTestUtil.randomString(), false);
+
+		UnicodeProperties unicodeProperties =
+			dispatchTrigger.getDispatchTaskSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"LPD-11018", unicodeProperties.getProperty("featureFlagKey"));
+
+		_upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		dispatchTrigger = _dispatchTriggerLocalService.getDispatchTrigger(
+			dispatchTrigger.getDispatchTriggerId());
+
+		unicodeProperties =
+			dispatchTrigger.getDispatchTaskSettingsUnicodeProperties();
+
+		Assert.assertNull(unicodeProperties.getProperty("featureFlagKey"));
+	}
+
+	@Inject
+	private static DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	private static UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.change.tracking.internal.upgrade.registry.ChangeTrackingServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
@@ -14,6 +14,7 @@ import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -32,11 +33,14 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -121,6 +125,45 @@ public class DispatchTriggerDisplayContextTest {
 				dispatchTaskExecutorTypeHiddenInUILabel,
 				dropdownItem.get("label"));
 		}
+	}
+
+	@Test
+	public void testGetSearchContainer() throws Exception {
+		DispatchTrigger dispatchTrigger1 =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				SingleNodeClusterModeDispatchTaskExecutor.
+					DISPATCH_TASK_EXECUTOR_TYPE_SINGLE_NODE,
+				null, RandomTestUtil.randomString(), false);
+
+		DispatchTrigger dispatchTrigger2 =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(),
+				SingleNodeClusterModeDispatchTaskExecutor.
+					DISPATCH_TASK_EXECUTOR_TYPE_SINGLE_NODE,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"featureFlagKey", RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(), false);
+
+		User user = TestPropsValues.getUser();
+
+		SearchContainer<DispatchTrigger> searchContainer =
+			ReflectionTestUtil.invoke(
+				_getDispatchTriggerDisplayContext(
+					_getMockHttpServletRequest(
+						_companyLocalService.getCompany(
+							TestPropsValues.getCompanyId()),
+						LayoutTestUtil.addTypePortletLayout(user.getGroupId()),
+						user)),
+				"getSearchContainer", new Class<?>[0], null);
+
+		List<DispatchTrigger> dispatchTriggers = searchContainer.getResults();
+
+		Assert.assertTrue(dispatchTriggers.contains(dispatchTrigger1));
+		Assert.assertTrue(dispatchTriggers.contains(dispatchTrigger2));
 	}
 
 	@Test
@@ -222,6 +265,10 @@ public class DispatchTriggerDisplayContextTest {
 			new MockLiferayPortletRenderRequest(mockHttpServletRequest);
 		MockLiferayPortletRenderResponse mockLiferayPortletRenderResponse =
 			new MockLiferayPortletRenderResponse();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
 
 		mockLiferayPortletRenderRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_RESPONSE,

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/DispatchTriggerDisplayContext.java
@@ -15,11 +15,9 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
@@ -27,10 +25,8 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FastDateFormatConstants;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.portlet.PortletURL;
@@ -229,24 +225,11 @@ public class DispatchTriggerDisplayContext extends BaseDisplayContext {
 		_searchContainer.setOrderByComparator(null);
 		_searchContainer.setOrderByType(getOrderByType());
 		_searchContainer.setResultsAndTotal(
-			ListUtil.filter(
-				_dispatchTriggerLocalService.getDispatchTriggers(
-					dispatchRequestHelper.getCompanyId(), QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS),
-				dispatchTrigger -> {
-					UnicodeProperties unicodeProperties =
-						dispatchTrigger.
-							getDispatchTaskSettingsUnicodeProperties();
-
-					if (!unicodeProperties.containsKey("featureFlagKey") ||
-						FeatureFlagManagerUtil.isEnabled(
-							unicodeProperties.getProperty("featureFlagKey"))) {
-
-						return true;
-					}
-
-					return false;
-				}));
+			() -> _dispatchTriggerLocalService.getDispatchTriggers(
+				dispatchRequestHelper.getCompanyId(),
+				_searchContainer.getStart(), _searchContainer.getEnd()),
+			_dispatchTriggerLocalService.getDispatchTriggersCount(
+				dispatchRequestHelper.getCompanyId()));
 		_searchContainer.setRowChecker(getRowChecker());
 
 		return _searchContainer;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87839

**What is being fixed:** The job schedule list could appear empty in
environments where a dispatch trigger for scheduled publications conflict
checks was stored with a `featureFlagKey=LPD-11018` setting.
`DispatchTriggerDisplayContext` was filtering out any trigger whose
`featureFlagKey` referenced a disabled or removed feature flag; since the
LPD-11018 flag was removed in LPD-29701, those triggers were always hidden.

**How it is being fixed:** The stale feature-flag filter is removed from
`DispatchTriggerDisplayContext.getSearchContainer` so that all dispatch
triggers are returned regardless of their settings properties. A new
upgrade process (`CTConflictCheckerDispatchTriggerUpgradeProcess`, schema
2.13.1 → 2.14.0) cleans up the lingering `featureFlagKey` property from
existing `DispatchTrigger` rows in the database. Integration tests cover
both the upgrade step and the updated display-context behavior.