### PR TITLE
LPD-88275 Enforce VIEW permission on headless GET sites/{ercode}

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -300,10 +300,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Override
 	protected Site doGetSite(String externalReferenceCode) throws Exception {
-		Group group = _groupLocalService.getGroupByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
-
-		return _toSite(group);
+		return _toSite(
+			_groupService.getGroupByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId()));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -158,6 +158,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.testGetSite();
 
 		_testGetSiteWithDollar();
+		_testGetSiteWithoutViewPermission();
 	}
 
 	@Ignore
@@ -589,6 +590,39 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		assertEquals(postSite, getSite);
 		assertValid(getSite);
+	}
+
+	private void _testGetSiteWithoutViewPermission() throws Exception {
+		User user = UserTestUtil.addUser(false);
+
+		user = _userLocalService.updatePassword(
+			user.getUserId(), "test", "test", false, true);
+
+		SiteResource siteResource = SiteResource.builder(
+		).authentication(
+			user.getEmailAddress(), "test"
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		Site randomSite = randomSite();
+
+		randomSite.setMembershipType(Site.MembershipType.PRIVATE);
+
+		Site postSite = _testPostSite_addSite(randomSite);
+
+		try {
+			siteResource.getSite(postSite.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
 	}
 
 	private Site _testPostSite_addSite(Site site) throws Exception {

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -627,6 +627,16 @@ public class GroupServiceTest {
 	}
 
 	@Test
+	public void testGetGroupByExternalReferenceCode() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		Group group = _groupService.getGroupByExternalReferenceCode(
+			_group.getExternalReferenceCode(), _group.getCompanyId());
+
+		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+	}
+
+	@Test
 	public void testGetGroupsLikeName() throws Exception {
 		List<Group> allChildGroups = new ArrayList<>();
 

--- a/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
@@ -469,6 +469,48 @@ public class GroupServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.model.Group
+			getGroupByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				GroupServiceUtil.class, "getGroupByExternalReferenceCode",
+				_getGroupByExternalReferenceCodeParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, companyId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.Group)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static String getGroupDisplayURL(
 			HttpPrincipal httpPrincipal, long groupId, boolean privateLayout,
 			boolean secureConnection)
@@ -477,7 +519,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroupDisplayURL",
-				_getGroupDisplayURLParameterTypes11);
+				_getGroupDisplayURLParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, secureConnection);
@@ -519,7 +561,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroups",
-				_getGroupsParameterTypes12);
+				_getGroupsParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, parentGroupId, site);
@@ -562,7 +604,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroups",
-				_getGroupsParameterTypes13);
+				_getGroupsParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, parentGroupId, site, start, end);
@@ -605,7 +647,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroups",
-				_getGroupsParameterTypes14);
+				_getGroupsParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, parentGroupId, name, site, start, end);
@@ -647,7 +689,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroupsCount",
-				_getGroupsCountParameterTypes15);
+				_getGroupsCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, parentGroupId, site);
@@ -688,7 +730,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroupsCount",
-				_getGroupsCountParameterTypes16);
+				_getGroupsCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, parentGroupId, name, site);
@@ -729,7 +771,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGroupsCount",
-				_getGroupsCountParameterTypes17);
+				_getGroupsCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, className, parentGroupId);
@@ -771,7 +813,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getGtGroups",
-				_getGtGroupsParameterTypes18);
+				_getGtGroupsParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, gtGroupId, companyId, parentGroupId, site, size);
@@ -816,7 +858,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getManageableSiteGroups",
-				_getManageableSiteGroupsParameterTypes19);
+				_getManageableSiteGroupsParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, portlets, max);
@@ -860,7 +902,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getOrganizationsGroups",
-				_getOrganizationsGroupsParameterTypes20);
+				_getOrganizationsGroupsParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizations);
@@ -901,7 +943,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserGroup",
-				_getUserGroupParameterTypes21);
+				_getUserGroupParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, userId);
@@ -944,7 +986,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserGroupsGroups",
-				_getUserGroupsGroupsParameterTypes22);
+				_getUserGroupsGroupsParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userGroups);
@@ -986,7 +1028,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserOrganizationsGroups",
-				_getUserOrganizationsGroupsParameterTypes23);
+				_getUserOrganizationsGroupsParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, start, end);
@@ -1027,7 +1069,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserSitesGroups",
-				_getUserSitesGroupsParameterTypes24);
+				_getUserSitesGroupsParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -1068,7 +1110,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserSitesGroups",
-				_getUserSitesGroupsParameterTypes25);
+				_getUserSitesGroupsParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, start, end);
@@ -1111,7 +1153,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserSitesGroups",
-				_getUserSitesGroupsParameterTypes26);
+				_getUserSitesGroupsParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, classNames, max);
@@ -1153,7 +1195,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserSitesGroups",
-				_getUserSitesGroupsParameterTypes27);
+				_getUserSitesGroupsParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, classNames, max);
@@ -1193,7 +1235,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "getUserSitesGroupsCount",
-				_getUserSitesGroupsCountParameterTypes28);
+				_getUserSitesGroupsCountParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -1232,7 +1274,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "hasUserGroup",
-				_hasUserGroupParameterTypes29);
+				_hasUserGroupParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, groupId);
@@ -1275,7 +1317,7 @@ public class GroupServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				GroupServiceUtil.class, "search", _searchParameterTypes30);
+				GroupServiceUtil.class, "search", _searchParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, classNameIds, keywords, params, start,
@@ -1321,7 +1363,7 @@ public class GroupServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				GroupServiceUtil.class, "search", _searchParameterTypes31);
+				GroupServiceUtil.class, "search", _searchParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, classNameIds, name, description, params,
@@ -1363,7 +1405,7 @@ public class GroupServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				GroupServiceUtil.class, "search", _searchParameterTypes32);
+				GroupServiceUtil.class, "search", _searchParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, name, description, params, start, end);
@@ -1404,7 +1446,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "searchCount",
-				_searchCountParameterTypes33);
+				_searchCountParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, classNameIds, keywords, params);
@@ -1437,7 +1479,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "searchCount",
-				_searchCountParameterTypes34);
+				_searchCountParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, name, description, params);
@@ -1470,7 +1512,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "setRoleGroups",
-				_setRoleGroupsParameterTypes35);
+				_setRoleGroupsParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, roleId, groupIds);
@@ -1506,7 +1548,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "unsetRoleGroups",
-				_unsetRoleGroupsParameterTypes36);
+				_unsetRoleGroupsParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, roleId, groupIds);
@@ -1542,7 +1584,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "updateFriendlyURL",
-				_updateFriendlyURLParameterTypes37);
+				_updateFriendlyURLParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, friendlyURL);
@@ -1588,7 +1630,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "updateGroup",
-				_updateGroupParameterTypes38);
+				_updateGroupParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentGroupId, nameMap, descriptionMap,
@@ -1630,7 +1672,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "updateGroup",
-				_updateGroupParameterTypes39);
+				_updateGroupParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, typeSettings);
@@ -1671,7 +1713,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				GroupServiceUtil.class, "updateStagedPortlets",
-				_updateStagedPortletsParameterTypes40);
+				_updateStagedPortletsParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, stagedPortletIds);
@@ -1738,88 +1780,92 @@ public class GroupServiceHttp {
 	private static final Class<?>[] _getGroupParameterTypes10 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getGroupDisplayURLParameterTypes11 =
+	private static final Class<?>[]
+		_getGroupByExternalReferenceCodeParameterTypes11 = new Class[] {
+			String.class, long.class
+		};
+	private static final Class<?>[] _getGroupDisplayURLParameterTypes12 =
 		new Class[] {long.class, boolean.class, boolean.class};
-	private static final Class<?>[] _getGroupsParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupsParameterTypes13 = new Class[] {
 		long.class, long.class, boolean.class
 	};
-	private static final Class<?>[] _getGroupsParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupsParameterTypes14 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class
 	};
-	private static final Class<?>[] _getGroupsParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupsParameterTypes15 = new Class[] {
 		long.class, long.class, String.class, boolean.class, int.class,
 		int.class
 	};
-	private static final Class<?>[] _getGroupsCountParameterTypes15 =
-		new Class[] {long.class, long.class, boolean.class};
 	private static final Class<?>[] _getGroupsCountParameterTypes16 =
-		new Class[] {long.class, long.class, String.class, boolean.class};
+		new Class[] {long.class, long.class, boolean.class};
 	private static final Class<?>[] _getGroupsCountParameterTypes17 =
+		new Class[] {long.class, long.class, String.class, boolean.class};
+	private static final Class<?>[] _getGroupsCountParameterTypes18 =
 		new Class[] {long.class, String.class, long.class};
-	private static final Class<?>[] _getGtGroupsParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getGtGroupsParameterTypes19 = new Class[] {
 		long.class, long.class, long.class, boolean.class, int.class
 	};
-	private static final Class<?>[] _getManageableSiteGroupsParameterTypes19 =
+	private static final Class<?>[] _getManageableSiteGroupsParameterTypes20 =
 		new Class[] {java.util.Collection.class, int.class};
-	private static final Class<?>[] _getOrganizationsGroupsParameterTypes20 =
+	private static final Class<?>[] _getOrganizationsGroupsParameterTypes21 =
 		new Class[] {java.util.List.class};
-	private static final Class<?>[] _getUserGroupParameterTypes21 =
+	private static final Class<?>[] _getUserGroupParameterTypes22 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getUserGroupsGroupsParameterTypes22 =
+	private static final Class<?>[] _getUserGroupsGroupsParameterTypes23 =
 		new Class[] {java.util.List.class};
 	private static final Class<?>[]
-		_getUserOrganizationsGroupsParameterTypes23 = new Class[] {
+		_getUserOrganizationsGroupsParameterTypes24 = new Class[] {
 			long.class, int.class, int.class
 		};
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes24 =
-		new Class[] {};
 	private static final Class<?>[] _getUserSitesGroupsParameterTypes25 =
-		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes26 =
-		new Class[] {long.class, String[].class, int.class};
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes27 =
-		new Class[] {String[].class, int.class};
-	private static final Class<?>[] _getUserSitesGroupsCountParameterTypes28 =
 		new Class[] {};
-	private static final Class<?>[] _hasUserGroupParameterTypes29 =
+	private static final Class<?>[] _getUserSitesGroupsParameterTypes26 =
+		new Class[] {long.class, int.class, int.class};
+	private static final Class<?>[] _getUserSitesGroupsParameterTypes27 =
+		new Class[] {long.class, String[].class, int.class};
+	private static final Class<?>[] _getUserSitesGroupsParameterTypes28 =
+		new Class[] {String[].class, int.class};
+	private static final Class<?>[] _getUserSitesGroupsCountParameterTypes29 =
+		new Class[] {};
+	private static final Class<?>[] _hasUserGroupParameterTypes30 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _searchParameterTypes30 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes31 = new Class[] {
 		long.class, long[].class, String.class, java.util.LinkedHashMap.class,
 		int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes31 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes32 = new Class[] {
 		long.class, long[].class, String.class, String.class,
 		java.util.LinkedHashMap.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes32 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes33 = new Class[] {
 		long.class, String.class, String.class, String[].class, int.class,
 		int.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes33 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes34 = new Class[] {
 		long.class, long[].class, String.class, java.util.LinkedHashMap.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes34 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes35 = new Class[] {
 		long.class, String.class, String.class, String[].class
 	};
-	private static final Class<?>[] _setRoleGroupsParameterTypes35 =
+	private static final Class<?>[] _setRoleGroupsParameterTypes36 =
 		new Class[] {long.class, long[].class};
-	private static final Class<?>[] _unsetRoleGroupsParameterTypes36 =
+	private static final Class<?>[] _unsetRoleGroupsParameterTypes37 =
 		new Class[] {long.class, long[].class};
-	private static final Class<?>[] _updateFriendlyURLParameterTypes37 =
+	private static final Class<?>[] _updateFriendlyURLParameterTypes38 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updateGroupParameterTypes38 = new Class[] {
+	private static final Class<?>[] _updateGroupParameterTypes39 = new Class[] {
 		long.class, long.class, java.util.Map.class, java.util.Map.class,
 		int.class, String.class, boolean.class, int.class, String.class,
 		boolean.class, boolean.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateGroupParameterTypes39 = new Class[] {
+	private static final Class<?>[] _updateGroupParameterTypes40 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _updateStagedPortletsParameterTypes40 =
+	private static final Class<?>[] _updateStagedPortletsParameterTypes41 =
 		new Class[] {long.class, java.util.Map.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:732045991
+// LIFERAY-SERVICE-BUILDER-HASH:1684559598

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -293,6 +293,20 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 		return group;
 	}
 
+	@Override
+	public Group getGroupByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		Group group = groupLocalService.getGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), group, ActionKeys.VIEW);
+
+		return group;
+	}
+
 	/**
 	 * Returns the group's display URL.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupService.java
@@ -143,6 +143,11 @@ public interface GroupService extends BaseService {
 	public Group getGroup(long companyId, String groupKey)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Group getGroupByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException;
+
 	/**
 	 * Returns the group's display URL.
 	 *
@@ -564,4 +569,4 @@ public interface GroupService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1957156031
+// LIFERAY-SERVICE-BUILDER-HASH:-215775897

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupServiceUtil.java
@@ -158,6 +158,14 @@ public class GroupServiceUtil {
 		return getService().getGroup(companyId, groupKey);
 	}
 
+	public static Group getGroupByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().getGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+	}
+
 	/**
 	 * Returns the group's display URL.
 	 *
@@ -677,4 +685,4 @@ public class GroupServiceUtil {
 	private static volatile GroupService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1448082115
+// LIFERAY-SERVICE-BUILDER-HASH:545048214

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupServiceWrapper.java
@@ -173,6 +173,15 @@ public class GroupServiceWrapper
 		return _groupService.getGroup(companyId, groupKey);
 	}
 
+	@Override
+	public Group getGroupByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _groupService.getGroupByExternalReferenceCode(
+			externalReferenceCode, companyId);
+	}
+
 	/**
 	 * Returns the group's display URL.
 	 *
@@ -734,4 +743,4 @@ public class GroupServiceWrapper
 	private GroupService _groupService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1247126228
+// LIFERAY-SERVICE-BUILDER-HASH:-370067583


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88275

## What is being fixed

`GET /o/headless-admin-site/v1.0/sites/{externalReferenceCode}` returned the full Site payload to any authenticated user, including users with no membership in private or restricted sites. The list endpoint already filtered those out via `_groupService.search(...)`, but the single-resource GET went through `_groupLocalService.getGroupByExternalReferenceCode(...)`, which performs no permission check.

## How it is being fixed

Added the missing permission-checked counterpart to `GroupService` — `getGroupByExternalReferenceCode(String, long)` — that mirrors the existing `getGroup(long)` and `getGroup(long, String)` siblings: delegate to the local service for lookup, then call `GroupPermissionUtil.check(..., VIEW)`. Routing `SiteResourceImpl.doGetSite` through the new method causes a missing site to surface as `NoSuchGroupException` and a non-VIEW caller to surface as `PrincipalException`, which Vulcan's `PrincipalExceptionMapper` deliberately maps to 404 for GET requests to hide existence. Tests cover the new `GroupService` API directly in `GroupServiceTest` and the bypass regression at the REST layer in `SiteResourceTest._testGetSiteWithoutViewPermission`.