### PR TITLE
LPD-88390 Validate site friendly URL against site-only keywords

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -57,7 +57,6 @@ import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -123,7 +122,9 @@ import java.util.TreeSet;
 public class LayoutImpl extends LayoutBaseImpl {
 
 	public static boolean hasFriendlyURLKeyword(String friendlyURL) {
-		return FriendlyURLKeywordsUtil.hasFriendlyURLKeyword(friendlyURL);
+		String keyword = _getFriendlyURLKeyword(friendlyURL);
+
+		return Validator.isNotNull(keyword);
 	}
 
 	public static int validateFriendlyURL(String friendlyURL) {
@@ -183,20 +184,17 @@ public class LayoutImpl extends LayoutBaseImpl {
 	public static void validateFriendlyURLKeyword(String friendlyURL)
 		throws LayoutFriendlyURLException {
 
-		String keyword = FriendlyURLKeywordsUtil.getFriendlyURLKeyword(
-			friendlyURL);
+		String keyword = _getFriendlyURLKeyword(friendlyURL);
 
-		if (Validator.isNull(keyword)) {
-			return;
+		if (Validator.isNotNull(keyword)) {
+			LayoutFriendlyURLException layoutFriendlyURLException =
+				new LayoutFriendlyURLException(
+					LayoutFriendlyURLException.KEYWORD_CONFLICT);
+
+			layoutFriendlyURLException.setKeywordConflict(keyword);
+
+			throw layoutFriendlyURLException;
 		}
-
-		LayoutFriendlyURLException layoutFriendlyURLException =
-			new LayoutFriendlyURLException(
-				LayoutFriendlyURLException.KEYWORD_CONFLICT);
-
-		layoutFriendlyURLException.setKeywordConflict(keyword);
-
-		throw layoutFriendlyURLException;
 	}
 
 	@Override
@@ -1650,6 +1648,46 @@ public class LayoutImpl extends LayoutBaseImpl {
 		super.setTypeSettings(_typeSettingsUnicodeProperties.toString());
 	}
 
+	private static String _getFriendlyURLKeyword(String friendlyURL) {
+		friendlyURL = StringUtil.toLowerCase(friendlyURL);
+
+		for (String keyword : _friendlyURLKeywords) {
+			if (friendlyURL.startsWith(keyword)) {
+				return keyword;
+			}
+
+			if (keyword.equals(friendlyURL + StringPool.SLASH)) {
+				return friendlyURL;
+			}
+		}
+
+		return null;
+	}
+
+	private static void _initFriendlyURLKeywords() {
+		_friendlyURLKeywords =
+			new String[PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length];
+
+		for (int i = 0; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
+			 i++) {
+
+			String keyword = PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i];
+
+			keyword = StringPool.SLASH + keyword;
+
+			if (!keyword.contains(StringPool.PERIOD)) {
+				if (keyword.endsWith(StringPool.STAR)) {
+					keyword = keyword.substring(0, keyword.length() - 1);
+				}
+				else {
+					keyword = keyword + StringPool.SLASH;
+				}
+			}
+
+			_friendlyURLKeywords[i] = StringUtil.toLowerCase(keyword);
+		}
+	}
+
 	private ColorScheme _getColorScheme() throws PortalException {
 		if (isInheritLookAndFeel()) {
 			LayoutSet layoutSet = getLayoutSet();
@@ -1922,6 +1960,12 @@ public class LayoutImpl extends LayoutBaseImpl {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(LayoutImpl.class);
+
+	private static String[] _friendlyURLKeywords;
+
+	static {
+		_initFriendlyURLKeywords();
+	}
 
 	private ColorScheme _colorScheme;
 	private String _faviconURL;

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4931,6 +4931,48 @@
         c,\
         combo,\
         delegate,\
+        dtd,\
+        elqNow,\
+        facebook,\
+        google_gadget,\
+        group,\
+        html,\
+        image,\
+        language,\
+        lucene,\
+        netvibes,\
+        o,\
+        osgi,\
+        page,\
+        pbhs,\
+        private,\
+        public,\
+        rest,\
+        robots.txt,\
+        sharepoint*,\
+        sitemap.xml,\
+        tunnel-web,\
+        user,\
+        wap,\
+        web,\
+        webdav*,\
+        widget*,\
+        xmlrpc
+
+    #
+    # Set the reserved keywords that cannot be used in a site's friendly URL.
+    # These conflict with portal-level routing prefixes and would prevent the
+    # site from being reachable.
+    #
+    # Env: LIFERAY_SITES_PERIOD_FRIENDLY_PERIOD_URL_PERIOD_KEYWORDS
+    #
+    sites.friendly.url.keywords=\
+        _vti_*,\
+        a,\
+        api*,\
+        c,\
+        combo,\
+        delegate,\
         documents,\
         dtd,\
         elqNow,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
@@ -38,12 +38,12 @@ public class FriendlyURLKeywordsUtil {
 
 	static {
 		_FRIENDLY_URL_KEYWORDS =
-			new String[PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length];
+			new String[PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length];
 
-		for (int i = 0; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
+		for (int i = 0; i < PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length;
 			 i++) {
 
-			String keyword = PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i];
+			String keyword = PropsValues.SITES_FRIENDLY_URL_KEYWORDS[i];
 
 			keyword = StringPool.SLASH + keyword;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2502,6 +2502,9 @@ public interface PropsKeys {
 
 	public static final String SITES_FORM_UPDATE_SEO = "sites.form.update.seo";
 
+	public static final String SITES_FRIENDLY_URL_KEYWORDS =
+		"sites.friendly.url.keywords";
+
 	public static final String SITES_FRIENDLY_URL_PAGE_NOT_FOUND =
 		"sites.friendly.url.page.not.found";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2134,6 +2134,9 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.SITES_CONTROL_PANEL_MEMBERS_VISIBLE));
 
+	public static final String[] SITES_FRIENDLY_URL_KEYWORDS =
+		PropsUtil.getArray(PropsKeys.SITES_FRIENDLY_URL_KEYWORDS);
+
 	public static final String SITES_FRIENDLY_URL_PAGE_NOT_FOUND =
 		PropsUtil.get(PropsKeys.SITES_FRIENDLY_URL_PAGE_NOT_FOUND);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88390

## What is being fixed

After LPD-85907 added `documents` to `layout.friendly.url.keywords`, upgrades fail with `Detected reserved friendly URL /documents` on sites whose friendly URL is `/documents`. The site friendly URL validator was reusing the layout-level reserved keyword list, so prefixes that only conflict with layout routing (like `documents`) were incorrectly rejected at the site level.

## How it is being fixed

The friendly URL keyword logic that LPD-85907 extracted into `FriendlyURLKeywordsUtil` is moved back into `LayoutImpl`, restoring it as the source of truth for layout-level reserved prefixes. `FriendlyURLKeywordsUtil` is repurposed to back site friendly URL validation, sourcing its keywords from a new `sites.friendly.url.keywords` portal property (initially seeded with the same defaults as `layout.friendly.url.keywords`). Existing callers — `GroupLocalServiceImpl#_validateFriendlyURLKeyword` and `ReservedPathConflictHealthChecker` — now correctly validate site URLs against the site keyword list.

## Why are there no tests?

The `VerifyLayoutTest` case originally added in this branch was already failing on master independent of this change, so it does not exercise the fix. No suitable test was added in its place.