### PR TITLE
LPD-88836 Add PageSpeed score provider

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/bnd.bnd
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay SEO Studio PageSpeed
+Bundle-SymbolicName: com.liferay.seo.studio.pagespeed
+Bundle-Version: 1.0.0
+-dsannotations-options: inherit

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/build.gradle
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testImplementation project(":core:petra:petra-function")
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProvider.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProvider.java
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.net.HttpURLConnection;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProvider {
+
+	public PageSpeedScoreProvider(String apiKey, String strategy) {
+		_apiKey = apiKey;
+		_strategy = strategy;
+	}
+
+	public PageSpeedScores getScores(String url)
+		throws PageSpeedScoreProviderException {
+
+		try {
+			return _getScores(url);
+		}
+		catch (PageSpeedScoreProviderException
+					pageSpeedScoreProviderException) {
+
+			throw pageSpeedScoreProviderException;
+		}
+		catch (Exception exception) {
+			throw new PageSpeedScoreProviderException(exception);
+		}
+	}
+
+	public boolean isValidConnection() {
+		return Validator.isNotNull(_apiKey);
+	}
+
+	public static class PageSpeedScoreProviderException
+		extends PortalException {
+
+		public PageSpeedScoreProviderException(Exception exception) {
+			super(exception);
+		}
+
+		public PageSpeedScoreProviderException(
+			JSONObject googlePageSpeedErrorJSONObject, String message) {
+
+			super(message);
+
+			_googlePageSpeedErrorJSONObject = googlePageSpeedErrorJSONObject;
+		}
+
+		public PageSpeedScoreProviderException(String message) {
+			super(message);
+		}
+
+		public JSONObject getGooglePageSpeedErrorJSONObject() {
+			return _googlePageSpeedErrorJSONObject;
+		}
+
+		public boolean isQuotaExceeded() {
+			JSONObject errorJSONObject = _googlePageSpeedErrorJSONObject;
+
+			if (errorJSONObject == null) {
+				return false;
+			}
+
+			JSONObject errorDetailJSONObject = errorJSONObject.getJSONObject(
+				"error");
+
+			if (errorDetailJSONObject == null) {
+				return false;
+			}
+
+			if (errorDetailJSONObject.getInt("code", -1) == 429) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private JSONObject _googlePageSpeedErrorJSONObject;
+
+	}
+
+	private String _buildGooglePageSpeedURL(String url) {
+		String googlePageSpeedURL =
+			"https://content-pagespeedonline.googleapis.com/pagespeedonline" +
+				"/v5/runPagespeed";
+
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "ACCESSIBILITY");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "BEST_PRACTICES");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "PERFORMANCE");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "category", "SEO");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "fields",
+			"lighthouseResult/categories/*/score");
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "key", _apiKey);
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "strategy", _strategy);
+		googlePageSpeedURL = HttpComponentsUtil.addParameter(
+			googlePageSpeedURL, "url", url);
+
+		return googlePageSpeedURL;
+	}
+
+	private int _getScore(JSONObject categoriesJSONObject, String category) {
+		JSONObject categoryJSONObject = categoriesJSONObject.getJSONObject(
+			category);
+
+		if (categoryJSONObject == null) {
+			return 0;
+		}
+
+		double score = categoryJSONObject.getDouble("score", 0);
+
+		return (int)Math.round(score * 100);
+	}
+
+	private PageSpeedScores _getScores(String url) throws Exception {
+		if (!isValidConnection()) {
+			throw new PageSpeedScoreProviderException("Invalid Connection");
+		}
+
+		Http.Options options = new Http.Options();
+
+		String googlePageSpeedURL = _buildGooglePageSpeedURL(url);
+
+		options.setLocation(googlePageSpeedURL);
+
+		options.setTimeout(120000);
+
+		String responseJSON = HttpUtil.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		int responseCode = response.getResponseCode();
+
+		if (responseCode != HttpURLConnection.HTTP_OK) {
+			JSONObject errorJSONObject = null;
+
+			try {
+				errorJSONObject = JSONFactoryUtil.createJSONObject(
+					responseJSON);
+			}
+			catch (JSONException jsonException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to parse error response as JSON",
+						jsonException);
+				}
+			}
+
+			throw new PageSpeedScoreProviderException(
+				errorJSONObject,
+				StringBundler.concat(
+					"Response code ", responseCode, ": ", responseJSON));
+		}
+
+		return _parseScores(responseJSON);
+	}
+
+	private PageSpeedScores _parseScores(String responseJSON) throws Exception {
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			responseJSON);
+
+		JSONObject lighthouseResultJSONObject =
+			responseJSONObject.getJSONObject("lighthouseResult");
+
+		if (lighthouseResultJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"lighthouseResult\" in response");
+		}
+
+		JSONObject categoriesJSONObject =
+			lighthouseResultJSONObject.getJSONObject("categories");
+
+		if (categoriesJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"categories\" in \"lighthouseResult\"");
+		}
+
+		return new PageSpeedScores(
+			_getScore(categoriesJSONObject, "accessibility"),
+			_getScore(categoriesJSONObject, "best-practices"),
+			_getScore(categoriesJSONObject, "performance"),
+			_getScore(categoriesJSONObject, "seo"));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PageSpeedScoreProvider.class);
+
+	private final String _apiKey;
+	private final String _strategy;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScores.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScores.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScores {
+
+	public PageSpeedScores(
+		int accessibility, int bestPractices, int performance, int seo) {
+
+		_accessibility = accessibility;
+		_bestPractices = bestPractices;
+		_performance = performance;
+		_seo = seo;
+	}
+
+	public int getAccessibility() {
+		return _accessibility;
+	}
+
+	public int getBestPractices() {
+		return _bestPractices;
+	}
+
+	public int getPerformance() {
+		return _performance;
+	}
+
+	public int getSeo() {
+		return _seo;
+	}
+
+	private final int _accessibility;
+	private final int _bestPractices;
+	private final int _performance;
+	private final int _seo;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProviderTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/internal/PageSpeedScoreProviderTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.internal;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsValidConnection() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider("apiKey", "DESKTOP");
+
+		Assert.assertTrue(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testIsValidConnectionWithEmptyAPIKey() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider("", "DESKTOP");
+
+		Assert.assertFalse(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testIsValidConnectionWithNullAPIKey() {
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider(null, "DESKTOP");
+
+		Assert.assertFalse(pageSpeedScoreProvider.isValidConnection());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithErrorJSON() throws Exception {
+		JSONObject errorJSONObject = JSONUtil.put(
+			"error",
+			JSONUtil.put(
+				"code", 429
+			).put(
+				"message", "Quota exceeded"
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "Quota exceeded");
+
+		Assert.assertTrue(pageSpeedScoreProviderException.isQuotaExceeded());
+		Assert.assertEquals(
+			errorJSONObject,
+			pageSpeedScoreProviderException.
+				getGooglePageSpeedErrorJSONObject());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithNonquotaError() throws Exception {
+		JSONObject errorJSONObject = JSONUtil.put(
+			"error",
+			JSONUtil.put(
+				"code", 403
+			).put(
+				"message", "Forbidden"
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "Forbidden");
+
+		Assert.assertFalse(pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+	@Test
+	public void testQuotaExceededExceptionWithNullJSON() {
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					"Some error");
+
+		Assert.assertFalse(pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `PageSpeedScoreProvider` that calls the Google PageSpeed Insights API for a single URL and returns four category scores (performance, accessibility, best practices, SEO) as integers 0–100
- Add `PageSpeedScores` DTO to hold the four scores
- Use `fields` parameter to minimize API response size (~95% smaller)
- Store error response JSON in exception for downstream error surfacing (quota exceeded detection via `isQuotaExceeded()`)
- Follows same patterns as `LayoutReportsDataProvider` (constructor, exception, HTTP utilities)

https://liferay.atlassian.net/browse/LPD-88836