### PR TITLE
LPD-89213 CTConflictCheckerDispatchTriggerUpgradeProcess fails on databases without DispatchTrigger table

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_14_0/CTConflictCheckerDispatchTriggerUpgradeProcess.java
@@ -23,6 +23,10 @@ public class CTConflictCheckerDispatchTriggerUpgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		if (!hasTable("DispatchTrigger")) {
+			return;
+		}
+
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				"select dispatchTriggerId, dispatchTaskSettings from " +
 					"DispatchTrigger where dispatchTaskSettings like " +


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89213

**What is being fixed:** CTConflictCheckerDispatchTriggerUpgradeProcess fails with a SQL error on portal instances where the Dispatch module has never been installed and the DispatchTrigger table does not exist. The upgrade process unconditionally queries the table, causing the upgrade to abort on those databases.

**How it is being fixed:** A guard is added at the top of doUpgrade() that calls hasTable("DispatchTrigger") and returns early when the table is absent. This skips the migration entirely on databases where Dispatch was never installed, matching the pattern already used by other upgrade processes that reference optional tables.