### PR TITLE
LPD-89418 Pasting an email address in the Invite Users modal does not automatically add the user

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
@@ -765,14 +765,6 @@ const ManageCollaborators = ({
 									loadingState={networkStatus}
 									onChange={handleChange}
 									onItemsChange={handleItemsChange}
-									onPaste={(event) => {
-										event.preventDefault();
-
-										const pastedText =
-											event.clipboardData.getData('Text');
-
-										handleChange(pastedText);
-									}}
 									placeholder={Liferay.Language.get(
 										'enter-name-or-email-address'
 									)}

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
@@ -114,6 +114,47 @@ test('LPD-30098 Invite user as admin', async ({
 	);
 });
 
+test('LPD-89418 Paste email address to automatically add user in Invite Users modal', async ({
+	apiHelpers,
+	changeTrackingPage,
+	ctCollection,
+	page,
+}) => {
+	const user = await changeTrackingPage.addUserWithPublicationsUserRole();
+
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+	await page.getByLabel('View Collaborators').click();
+
+	const input = page.getByPlaceholder('Enter name or email address.');
+
+	await input.click();
+
+	await input.evaluate((element: HTMLInputElement, emailAddress: string) => {
+		const dt = new DataTransfer();
+
+		dt.setData('text/plain', emailAddress);
+
+		element.dispatchEvent(
+			new ClipboardEvent('paste', {
+				bubbles: true,
+				cancelable: true,
+				clipboardData: dt,
+			})
+		);
+	}, user.emailAddress);
+
+	await expect(page.getByText(user.emailAddress)).toBeVisible();
+
+	await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
+
+	await apiHelpers.headlessChangeTracking.deleteCTCollection(
+		ctCollection.body.id
+	);
+});
+
 test('LPD-65173 Assert that the Share Link tab is hidden for Publication Templates', async ({
 	changeTrackingTemplatesPage,
 	page,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89418

**What is being fixed:** When a user pasted an email address into the
Invite Users modal's multi-select input, the matching user was not
automatically surfaced. The custom `onPaste` handler was calling
`event.preventDefault()` and manually invoking `handleChange`, which
overrode ClayMultiSelect's native paste handling and prevented the
autocomplete lookup from running.

**How it is being fixed:** The custom `onPaste` handler is removed from
the `ClayMultiSelect` component in `ManageCollaborators.js`, allowing the
component's built-in paste handling to trigger `onChange` correctly. A
Playwright test is added to `publicationsUserCollaboration.spec.ts` that
dispatches a `ClipboardEvent` on the input and asserts the pasted email
address appears in the UI.