### PR TITLE
LPD-79516 User can access Remote Servers across virtual instances

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTRemoteResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTRemoteResourceImpl.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -163,6 +164,10 @@ public class CTRemoteResourceImpl extends BaseCTRemoteResourceImpl {
 	private CTRemote _toCTRemote(Long ctRemoteId) throws Exception {
 		com.liferay.change.tracking.model.CTRemote ctRemote =
 			_ctRemoteLocalService.getCTRemote(ctRemoteId);
+
+		_ctRemoteModelResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(), ctRemote,
+			ActionKeys.VIEW);
 
 		return _ctRemoteDTOConverter.toDTO(
 			_getDTOConverterContext(ctRemote), ctRemote);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/security/permission/resource/CTRemoteModelResourcePermission.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/security/permission/resource/CTRemoteModelResourcePermission.java
@@ -61,6 +61,10 @@ public class CTRemoteModelResourcePermission
 		PermissionChecker permissionChecker, CTRemote ctRemote,
 		String actionId) {
 
+		if (ctRemote.getCompanyId() != permissionChecker.getCompanyId()) {
+			return false;
+		}
+
 		if (permissionChecker.hasOwnerPermission(
 				ctRemote.getCompanyId(), CTRemote.class.getName(),
 				ctRemote.getCtRemoteId(), ctRemote.getUserId(), actionId)) {

--- a/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/security/permission/resource/CTRemoteModelResourcePermissionTest.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/test/java/com/liferay/change/tracking/internal/security/permission/resource/CTRemoteModelResourcePermissionTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.security.permission.resource;
+
+import com.liferay.change.tracking.model.CTRemote;
+import com.liferay.change.tracking.model.impl.CTRemoteImpl;
+import com.liferay.change.tracking.service.CTRemoteLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author David Truong
+ */
+public class CTRemoteModelResourcePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_ctRemoteModelResourcePermission =
+			new CTRemoteModelResourcePermission();
+
+		CTRemoteLocalService ctRemoteLocalService = Mockito.mock(
+			CTRemoteLocalService.class);
+
+		Mockito.when(
+			ctRemoteLocalService.getCTRemote(_OTHER_COMPANY_CTREMOTE_ID)
+		).thenReturn(
+			_createCTRemote(_OTHER_COMPANY_ID, _OTHER_COMPANY_CTREMOTE_ID)
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_ctRemoteModelResourcePermission, "_ctRemoteLocalService",
+			ctRemoteLocalService);
+	}
+
+	@Test
+	public void testContainsAllowsCTRemoteFromSameCompany() throws Exception {
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getCompanyId()
+		).thenReturn(
+			_CURRENT_COMPANY_ID
+		);
+
+		Mockito.when(
+			permissionChecker.hasOwnerPermission(
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		CTRemote ctRemote = _createCTRemote(_CURRENT_COMPANY_ID, 200L);
+
+		Assert.assertTrue(
+			"contains() must return true for a CTRemote owned by the same " +
+				"company when the user has owner permission",
+			_ctRemoteModelResourcePermission.contains(
+				permissionChecker, ctRemote, ActionKeys.VIEW));
+	}
+
+	@Test
+	public void testContainsRejectsCTRemoteFromOtherCompany() throws Exception {
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getCompanyId()
+		).thenReturn(
+			_CURRENT_COMPANY_ID
+		);
+
+		Mockito.when(
+			permissionChecker.hasOwnerPermission(
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			permissionChecker.hasPermission(
+				Mockito.nullable(Group.class), Mockito.anyString(),
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		CTRemote ctRemote = _createCTRemote(
+			_OTHER_COMPANY_ID, _OTHER_COMPANY_CTREMOTE_ID);
+
+		Assert.assertFalse(
+			"contains() must return false for a CTRemote owned by a " +
+				"different company",
+			_ctRemoteModelResourcePermission.contains(
+				permissionChecker, ctRemote, ActionKeys.VIEW));
+
+		Assert.assertFalse(
+			"contains(long) must return false for a CTRemote owned by a " +
+				"different company",
+			_ctRemoteModelResourcePermission.contains(
+				permissionChecker, _OTHER_COMPANY_CTREMOTE_ID,
+				ActionKeys.VIEW));
+	}
+
+	private CTRemote _createCTRemote(long companyId, long ctRemoteId) {
+		CTRemote ctRemote = new CTRemoteImpl();
+
+		ctRemote.setCtRemoteId(ctRemoteId);
+		ctRemote.setCompanyId(companyId);
+
+		return ctRemote;
+	}
+
+	private static final long _CURRENT_COMPANY_ID = 1;
+
+	private static final long _OTHER_COMPANY_CTREMOTE_ID = 100;
+
+	private static final long _OTHER_COMPANY_ID = 2;
+
+	private CTRemoteModelResourcePermission _ctRemoteModelResourcePermission;
+
+}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/EditCTCollectionMVCRenderCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/EditCTCollectionMVCRenderCommand.java
@@ -9,6 +9,7 @@ import com.liferay.change.tracking.configuration.helper.CTSettingsConfigurationH
 import com.liferay.change.tracking.constants.CTPortletKeys;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.model.CTCollectionTemplate;
+import com.liferay.change.tracking.model.CTRemote;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTCollectionTemplateLocalService;
 import com.liferay.change.tracking.service.CTRemoteLocalService;
@@ -78,9 +79,24 @@ public class EditCTCollectionMVCRenderCommand implements MVCRenderCommand {
 		long ctRemoteId = ParamUtil.getLong(renderRequest, "ctRemoteId");
 
 		if (ctRemoteId != 0) {
-			renderRequest.setAttribute(
-				CTWebKeys.CT_REMOTE,
-				_ctRemoteLocalService.fetchCTRemote(ctRemoteId));
+			CTRemote ctRemote = _ctRemoteLocalService.fetchCTRemote(ctRemoteId);
+
+			try {
+				if ((ctRemote != null) &&
+					!_ctRemoteModelResourcePermission.contains(
+						themeDisplay.getPermissionChecker(), ctRemote,
+						ActionKeys.VIEW)) {
+
+					ctRemote = null;
+				}
+			}
+			catch (Exception exception) {
+				SessionErrors.add(renderRequest, exception.getClass());
+
+				return "/publications/error.jsp";
+			}
+
+			renderRequest.setAttribute(CTWebKeys.CT_REMOTE, ctRemote);
 		}
 
 		JSONSerializer jsonSerializer = _jsonFactory.createJSONSerializer();
@@ -139,6 +155,11 @@ public class EditCTCollectionMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private CTRemoteLocalService _ctRemoteLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.change.tracking.model.CTRemote)"
+	)
+	private ModelResourcePermission<CTRemote> _ctRemoteModelResourcePermission;
 
 	@Reference
 	private CTSettingsConfigurationHelper _ctSettingsConfigurationHelper;

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/EditCTRemoteMVCRenderCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/EditCTRemoteMVCRenderCommand.java
@@ -6,10 +6,16 @@
 package com.liferay.change.tracking.web.internal.portlet.action;
 
 import com.liferay.change.tracking.constants.CTPortletKeys;
+import com.liferay.change.tracking.model.CTRemote;
 import com.liferay.change.tracking.service.CTRemoteLocalService;
 import com.liferay.change.tracking.web.internal.constants.CTWebKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
@@ -33,16 +39,39 @@ public class EditCTRemoteMVCRenderCommand implements MVCRenderCommand {
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		long ctRemoteId = ParamUtil.getLong(renderRequest, "ctRemoteId");
 
-		renderRequest.setAttribute(
-			CTWebKeys.CT_REMOTE,
-			_ctRemoteLocalService.fetchCTRemote(ctRemoteId));
+		CTRemote ctRemote = _ctRemoteLocalService.fetchCTRemote(ctRemoteId);
+
+		try {
+			if ((ctRemote != null) &&
+				!_ctRemoteModelResourcePermission.contains(
+					themeDisplay.getPermissionChecker(), ctRemote,
+					ActionKeys.VIEW)) {
+
+				ctRemote = null;
+			}
+		}
+		catch (Exception exception) {
+			SessionErrors.add(renderRequest, exception.getClass());
+
+			return "/publications/error.jsp";
+		}
+
+		renderRequest.setAttribute(CTWebKeys.CT_REMOTE, ctRemote);
 
 		return "/publications/edit_ct_remote.jsp";
 	}
 
 	@Reference
 	private CTRemoteLocalService _ctRemoteLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.change.tracking.model.CTRemote)"
+	)
+	private ModelResourcePermission<CTRemote> _ctRemoteModelResourcePermission;
 
 }


### PR DESCRIPTION
## Summary

- An admin in virtual instance A could view/edit/delete a Publications "Remote Server" (CTRemote) belonging to virtual instance B by tampering with the `ctRemoteId` URL parameter on the edit screen, leaking the remote host, client ID, and client secret.
- Root cause: `CTRemoteModelResourcePermission.contains(...)` did not assert `ctRemote.getCompanyId() == permissionChecker.getCompanyId()`. The owner-permission branch and the `hasPermission(group, ...)` fallback both allowed an OmniAdmin (or any role with global VIEW on `CTRemote.class`) to satisfy the check against a foreign-company resource. Most `ModelResourcePermission`s are generated via `ModelResourcePermissionFactory.create(...)` and lean on `ResourcePermissionLocalService.hasResourcePermission(companyId=checker.companyId, ...)` which scopes by company implicitly; `CTRemoteModelResourcePermission` is a hand-rolled exception.
- Adds a `companyId` equality guard in `CTRemoteModelResourcePermission.contains(...)`, which transitively closes the `update`/`delete` paths in `CTRemoteServiceImpl`. Adds explicit `ModelResourcePermission` checks at three call sites that previously bypassed the resolver: `EditCTRemoteMVCRenderCommand`, `EditCTCollectionMVCRenderCommand` (URL-param `ctRemoteId`), and `CTRemoteResourceImpl._toCTRemote` (REST GET / GraphQL `ctRemote` / `getCTRemotesPage` items).

## Test plan

- [x] Unit test `CTRemoteModelResourcePermissionTest` (positive + negative): with `hasOwnerPermission` and `hasPermission(Group, ...)` stubbed `true` to simulate a privileged caller, `contains(checker_companyA, ctRemote_companyB, VIEW)` returns `false`; same-company access still returns `true`. Failed before fix, passes after.
- [x] `change-tracking-web` and `change-tracking-rest-impl` compile clean.
- [x] `liferay sf` clean for all three modified modules.
- [ ] Manual repro per ticket STR (two virtual instances): the "Edit Remote Server" page now renders an empty/error response instead of disclosing the foreign instance's record.

## Files changed

- `change-tracking-service/.../CTRemoteModelResourcePermission.java` — companyId guard
- `change-tracking-service/src/test/.../CTRemoteModelResourcePermissionTest.java` — new unit test
- `change-tracking-web/.../EditCTRemoteMVCRenderCommand.java` — gate render path
- `change-tracking-web/.../EditCTCollectionMVCRenderCommand.java` — gate render path
- `change-tracking-rest-impl/.../CTRemoteResourceImpl.java` — gate REST GET path