### PR TITLE
LPD-89449 Wait for tag Save navigation before asserting publication overview

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -218,7 +218,11 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 	await page.goto(`/group/guest${PORTLET_URLS.tagsAdmin}`);
 	await page.getByRole('link', {name: 'Add Tag'}).click();
 	await page.getByPlaceholder('Name').fill(getRandomString());
-	await page.getByRole('button', {name: 'Save'}).click();
+
+	await Promise.all([
+		page.waitForLoadState('load'),
+		page.getByRole('button', {name: 'Save'}).click(),
+	]);
 
 	await apiHelpers.headlessDelivery.postMessageBoardThread({
 		articleBody: getRandomString(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89449

## What Changed

The test `LPD-29088 Assert Publication Overview panel is visible` in `reviewChanges.spec.ts` clicked the tag form's Save button without waiting for the resulting page navigation to complete. The server POSTs the form, creates the tag, and redirects back to the tag list — but Playwright's `click()` returns as soon as the click is delivered, before that redirect finishes.

## Root Cause

New failure in ci:test:publications build 6091 (2026-05-08); passing in build 6079 (2026-05-07). No breaking commit was identified in the CT or publications codebase between the two builds. Build 6091 also showed "Top Level Build" and `PortalLogAssertorTest` infrastructure failures, indicating server load issues. Under heavy load the tag form POST can lag behind the subsequent Playwright assertions, causing the overview panel to not yet reflect the tag change.

## Fix

Wraps the Save click in `Promise.all([page.waitForLoadState('load'), click()])`, the standard Playwright pattern for ensuring a form-submit navigation completes before proceeding. This guarantees the tag is committed to the database before the MB thread, document, and blog API calls are made and before `goToReviewChanges` navigates to the assertions.