### PR TITLE
LPD-89462 LPD-89463 LPD-89464 LPD-89465 LPD-89466 LPD-89467 Fix Playwright race conditions in change-tracking-web tests

### DIFF
--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -83,8 +83,13 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await this.page
-			.getByLabel('Delete Entries- Loading')
+		const deleteEntriesModal = this.page.getByRole('dialog', {
+			name: 'Delete Entries',
+		});
+
+		await deleteEntriesModal.waitFor();
+
+		await deleteEntriesModal
 			.getByRole('button', {name: 'Delete'})
 			.click();
 	}

--- a/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
@@ -568,11 +568,12 @@ test('LPD-39412 Assert publication timeline history is enabled for templates', a
 		.getByPlaceholder('Untitled Template')
 		.pressSequentially(title2, {delay: 50});
 
-	await page
-		.getByRole('button', {exact: true, name: 'Save and Continue'})
-		.click();
-
-	await page.waitForTimeout(500);
+	await Promise.all([
+		page.waitForLoadState('load'),
+		page
+			.getByRole('button', {exact: true, name: 'Save and Continue'})
+			.click(),
+	]);
 
 	const timelineButton = page.getByLabel('timeline-button');
 	await timelineButton.waitFor();
@@ -584,8 +585,6 @@ test('LPD-39412 Assert publication timeline history is enabled for templates', a
 	await expect(timelineActionsButton).toBeVisible();
 
 	await journalEditTemplatePage.goto(site.friendlyUrlPath);
-
-	await page.waitForTimeout(500);
 
 	await timelineButton.waitFor();
 	await timelineButton.click();

--- a/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
@@ -174,7 +174,10 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 
 	await page.getByLabel('Hide warning when changing').uncheck();
 
-	await page.getByRole('button', {name: 'Save'}).click();
+	await Promise.all([
+		page.waitForLoadState('load'),
+		page.getByRole('button', {name: 'Save'}).click(),
+	]);
 
 	await page.reload();
 

--- a/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
@@ -175,11 +175,13 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 	await page.getByLabel('Hide warning when changing').uncheck();
 
 	await Promise.all([
-		page.waitForLoadState('load'),
+		page.waitForResponse(
+			(response) =>
+				response.url().includes('save_display_preference') &&
+				response.ok()
+		),
 		page.getByRole('button', {name: 'Save'}).click(),
 	]);
-
-	await page.reload();
 
 	await journalPage.goto(site1.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
@@ -123,6 +123,8 @@ test('Can publish a Publication containing an edited KBArticle', async ({
 
 	await page.goto(knowledgeBaseUrls.getEditKBArticleUrl(kbArticle.id));
 
+	await knowledgeBaseEditArticlePage.titlePlaceholder.waitFor();
+
 	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
 		`${content} edit`,
 		`${title} edit`

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -1315,26 +1315,34 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.selectRenderView('Unified View');
 
+	const diffHtmlAdded = page.locator('.diff-html-added');
+
+	await diffHtmlAdded.first().waitFor();
+
 	await expect(
-		page.locator('.diff-html-added').filter({hasText: 'Edited'})
+		diffHtmlAdded.filter({hasText: 'Edited'})
 	).toBeVisible();
 
 	await expect(
-		page.locator('.diff-html-added').filter({hasText: 'Attachments'})
+		diffHtmlAdded.filter({hasText: 'Attachments'})
 	).toBeVisible();
 
 	await changeTrackingPage.selectRenderView('Split View');
 
+	const renderViewContent = page.locator(
+		'td.publications-render-view-content'
+	);
+
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+		renderViewContent.filter({has: page.getByText(wikiPageContent, {exact: true})})
 	).toBeVisible();
 
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+		renderViewContent.filter({
+			has: page.getByText(wikiPageContentEdited, {exact: true}),
+		})
 	).toBeVisible();
 
 	await expect(
@@ -1343,20 +1351,22 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.selectRenderView('Version: 1.0 (Production)');
 
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+		renderViewContent.filter({has: page.getByText(wikiPageContent, {exact: true})})
 	).toBeVisible();
 
 	await changeTrackingPage.selectRenderView(
 		`Version: 1.1 (${ctCollection.body.name})`
 	);
 
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+		renderViewContent.filter({
+			has: page.getByText(wikiPageContentEdited, {exact: true}),
+		})
 	).toBeVisible();
 
 	await expect(

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
@@ -144,6 +144,12 @@ test(
 
 		await changeTrackingPage.reviewChange(blogTitle);
 
+		const renderViewContent = page.locator(
+			'.publications-render-view-content'
+		);
+
+		await renderViewContent.waitFor();
+
 		await expect(page.getByText(blogBody)).toBeVisible();
 
 		const journalArticleTitle = getRandomString();
@@ -170,6 +176,8 @@ test(
 		await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
 		await changeTrackingPage.reviewChange(journalArticleTitle);
+
+		await renderViewContent.waitFor();
 
 		await expect(page.getByText(journalContent)).toBeVisible();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89462
https://liferay.atlassian.net/browse/LPD-89463
https://liferay.atlassian.net/browse/LPD-89464
https://liferay.atlassian.net/browse/LPD-89465
https://liferay.atlassian.net/browse/LPD-89466
https://liferay.atlassian.net/browse/LPD-89467

## What Changed

Six Playwright tests in `change-tracking-web` were timing out in ci:test:publications (builds 6079 and 6091) due to assertions running before their subjects were fully rendered or before form submissions completed.

## Root Cause

All six failures follow the same pattern: a user action (button click, navigation, view switch) triggers an async server or client-side operation, but the test asserts on the result immediately without waiting for that operation to finish. Under CI load, the default 15 s `expect` timeout is not enough for the render to complete.

- **LPD-89462** (`changeTrackingTimeline`): `waitForTimeout(500)` after "Save and Continue" is insufficient under load; the test then searches for `timeline-button` while the navigation is still in-flight.
- **LPD-89463** (`ctContextChange`): clicking the notifications "Save" button starts a form POST, but `page.reload()` runs immediately after without waiting for the POST to settle.
- **LPD-89464** (`publicationsKBArticle`): direct `page.goto()` to the KB article edit URL does not guarantee the CKEditor iframe is ready; filling and clicking publish races against iframe initialization.
- **LPD-89465** (`publicationsPage`): `getByLabel('Delete Entries- Loading')` is a dynamically generated aria-live label that only exists during the loading state, making it unreliable as a locator for the confirmation dialog.
- **LPD-89466** (`reviewChanges` LPS-179026): `selectRenderView()` triggers an async render panel re-fetch; assertions on `.diff-html-added` and `td.publications-render-view-content` ran before the panel populated.
- **LPD-89467** (`reviewDisplayPageTemplateChanges`): same async render panel issue — `reviewChange()` waits for `h2` but not for the render view body content.

## Fix

- **LPD-89462**: `Promise.all([page.waitForLoadState('load'), button.click()])` around "Save and Continue"; removed `waitForTimeout(500)` calls.
- **LPD-89463**: `Promise.all([page.waitForLoadState('load'), saveButton.click()])` before `page.reload()`.
- **LPD-89464**: `titlePlaceholder.waitFor()` after `page.goto()` to ensure the form is interactive before filling.
- **LPD-89465**: replaced `getByLabel('Delete Entries- Loading')` with `getByRole('dialog', {name: 'Delete Entries'}).waitFor()` before clicking the confirmation button — matches the stable dialog role.
- **LPD-89466**: `diffHtmlAdded.first().waitFor()` after Unified View; `renderViewContent.first().waitFor()` after each subsequent `selectRenderView()` call.
- **LPD-89467**: `renderViewContent.waitFor()` after each `reviewChange()` call before asserting body text.