### PR TITLE
LPD-89448 Wait for both publications to complete before asserting journal content

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/ctCollectionPublish.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctCollectionPublish.spec.ts
@@ -212,13 +212,18 @@ test('Publish Parallel Publications', async ({
 
 	await waitForAlert(page, `Success:${title2} was created successfully.`);
 
-	await apiHelpers.headlessChangeTracking.publishCTCollection(
-		ctCollection.body.id
-	);
+	await Promise.all([
+		apiHelpers.headlessChangeTracking.publishCTCollection(
+			ctCollection.body.id
+		),
+		apiHelpers.headlessChangeTracking.publishCTCollection(
+			ctCollection2.body.id
+		),
+	]);
 
-	await apiHelpers.headlessChangeTracking.publishCTCollection(
-		ctCollection2.body.id
-	);
+	await changeTrackingPage.assertStatus('Published', ctCollection.body.name);
+
+	await changeTrackingPage.assertStatus('Published', ctCollection2.body.name);
 
 	await journalPage.goto(site.friendlyUrlPath);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89448

## What Changed

`ctCollectionPublish.spec.ts#Publish Parallel Publications` timed out at the `expect(link).toBeVisible()` assertions after publishing two CT collections via API.

## Root Cause

`apiHelpers.headlessChangeTracking.publishCTCollection()` enqueues a background task and returns immediately. The test called it for both collections and then navigated straight to the journal page to check for the published content — but the background tasks had not yet completed, so the content was absent. This caused a 15 s Playwright timeout.

New failure in ci:test:publications build 6091 (2026-05-08). No breaking commit to the spec or CT code was found between builds 6079 (passing) and 6091 (failing); the failure is a timing sensitivity exposed under CI load.

## Fix

Add `changeTrackingPage.assertStatus('Published', …)` after each `publishCTCollection` call. `assertStatus` navigates to the publication history page and waits for the row to show the "Published" status, blocking until the background task completes. This matches the established pattern in `publicationsPage.spec.ts` and other callers of `publishCTCollection` in the same suite.