### PR TITLE
LPD-89461 LPD-71159 Add USER_AVATAR_BUTTON locator for modern Clay PersonalMenu

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
@@ -8,6 +8,9 @@ definition {
 		else if (IsElementPresent(locator1 = "UserBar#USER_AVATAR_TOGGLE")) {
 			Click.waitForMenuToggleJSClick(locator1 = "UserBar#USER_AVATAR_TOGGLE");
 		}
+		else if (IsElementPresent(locator1 = "UserBar#USER_AVATAR_BUTTON")) {
+			Click.waitForPersonalMenuJSClick(locator1 = "UserBar#USER_AVATAR_BUTTON");
+		}
 		else {
 			Click.waitForPersonalMenuJSClick(locator1 = "UserBar#USER_AVATAR_ICON");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
@@ -42,7 +42,7 @@
 </tr>
 <tr>
 	<td>USER_AVATAR_BUTTON</td>
-	<td>//button[@aria-label='Personal Menu']</td>
+	<td>//button[@data-qa-id='userPersonalMenu']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89461

## What Changed

`UserBar.gotoDropdown()` uses a three-branch conditional to click the personal menu button. The branches check for a portrait image, a `data-toggle="dropdown"` button, and finally a fallback SVG icon. The current `ClayDropDownWithItems`-based `PersonalMenu` renders a button with `data-qa-id="userPersonalMenu"` and no portrait or `data-toggle` attribute, so all three branches fail and the `AssertVisible` on the open dropdown times out.

Also fixes `USER_AVATAR_BUTTON` in `UserBar.path` which had an incorrect `aria-label='Personal Menu'` locator — the actual aria-label is `"{userName} User Profile"`. The correct stable attribute is `data-qa-id="userPersonalMenu"`.

## Root Cause

The `PersonalMenu.js` component uses `ClayDropDownWithItems` with a `ClayButton` trigger that does not carry `data-toggle="dropdown"`. The existing path file's `USER_AVATAR_BUTTON` locator used `@aria-label='Personal Menu'` but the actual rendered aria-label is the user's name suffixed with "User Profile". The locator never matched.

## Fix

1. Update `USER_AVATAR_BUTTON` path from `//button[@aria-label='Personal Menu']` to `//button[@data-qa-id='userPersonalMenu']` (stable attribute on `PersonalMenu`'s `ClayButton` trigger).
2. Add a third `else if` branch in `gotoDropdown()` to check `USER_AVATAR_BUTTON` before falling back to the icon locator.

This covers both LPD-89461 (`CannotPublishPublicationWithPendingAssetEntries`) and LPD-71159 (`CanConfigureUnapprovedChangesToBePublishable`), which both fail at `UserBar.gotoDropdownItem(dropdownItem = "Notifications")`.