### PR TITLE
LPD-89451 LPD-89452 Fix Poshi locator drift for SideNavigation and CKEditor 5

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>EDITOR</td>
-	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')]</td>
+	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'ck-editor__editable') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>TOGGLE</td>
-	<td>//*[@data-qa-id='productMenu']</td>
+	<td>//*[@data-qa-id='productMenu'] | //*[@data-qa-id='sideNavigationToggler']</td>
 	<td></td>
 </tr>
 <tr>
@@ -42,12 +42,12 @@
 </tr>
 <tr>
 	<td>PRODUCT_MENU_OPENED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'open') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'closed'))]</td>
+	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'open') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'closed'))] | //*[@data-qa-id='sideNavigation' and contains(@class,'c-slideout-show')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PRODUCT_MENU_CLOSED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'closed') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'open'))]</td>
+	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'closed') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'open'))] | //*[@data-qa-id='sideNavigation' and not(contains(@class,'c-slideout-show'))]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89451
https://liferay.atlassian.net/browse/LPD-89452

## What Changed

Two Poshi path locators drifted from the portal's new SideNavigation and CKEditor 5 implementations.

## Root Cause

**LPD-89451 — ProductMenu locators**

Commit `b8e24c12c5c0d` (LPD-86832) partially updated `ProductMenu.path` to add the `sideNavigation` fallback to `PRODUCT_MENU_BODY`, but left `TOGGLE`, `PRODUCT_MENU_OPENED`, and `PRODUCT_MENU_CLOSED` pointing at the old `sidenavSliderId`-based elements that no longer exist in the new Clay SidePanel implementation.

The new SideNavigation uses:
- Toggle: `data-qa-id="sideNavigationToggler"`
- Open state: `data-qa-id="sideNavigation"` element with `c-slideout-show` class
- Closed state: `data-qa-id="sideNavigation"` element without `c-slideout-show` class

**LPD-89452 — AlloyEditor EDITOR locator**

Commit `245b2b606eccd` (LPD-81886) inverted the `TextProcessor.ts` feature flag so CKEditor 5 (`getCKEditorProcessor`) is now the default. CKEditor 5 uses `ck-editor__editable` as its editable class instead of the CKEditor 4 `cke_editable_inline` class that the `EDITOR` locator was matching.

## Fix

Both fixes add the new selector as an XPath `|` alternative alongside the old selector, preserving backward compatibility for any environments still running the old implementation.