### PR TITLE
LPD-89478 Simplify GetEntryRenderDataMVCResourceCommand

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -156,6 +156,32 @@ public class GetEntryRenderDataMVCResourceCommand
 		}
 	}
 
+	private <T extends BaseModel<T>> JSONObject
+		_buildEditInProductionJSONObject(
+			long ctCollectionId, CTSQLModeThreadLocal.CTSQLMode ctSQLMode,
+			CTEntry ctEntry, CTCollection ctCollection, T model,
+			HttpServletRequest httpServletRequest,
+			ResourceRequest resourceRequest,
+			ResourceResponse resourceResponse) {
+
+		String editURL = _ctDisplayRendererRegistry.getEditURL(
+			ctCollectionId, ctSQLMode, httpServletRequest, model,
+			ctEntry.getModelClassNameId());
+
+		if (Validator.isNull(editURL)) {
+			return null;
+		}
+
+		return _getEditJSONObject(
+			_language.format(
+				httpServletRequest,
+				"you-are-currently-working-on-x.-work-on-production",
+				new Object[] {ctCollection.getName()}, false),
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, editURL,
+			_language.get(httpServletRequest, "edit-in-production"),
+			resourceRequest, resourceResponse);
+	}
+
 	private Function<String, ServiceContext> _createServiceContextFunction() {
 		return className -> {
 			ServiceContext serviceContext = new ServiceContext();
@@ -180,16 +206,8 @@ public class GetEntryRenderDataMVCResourceCommand
 			_ctDisplayRendererRegistry.getCTDisplayRenderer(
 				ctEntry.getModelClassNameId());
 
-		String changeType = "modified";
-
-		if (ctEntry.getChangeType() == CTConstants.CT_CHANGE_TYPE_ADDITION) {
-			changeType = "added";
-		}
-		else if (ctEntry.getChangeType() ==
-					CTConstants.CT_CHANGE_TYPE_DELETION) {
-
-			changeType = "deleted";
-		}
+		String changeType = CTConstants.getCTChangeTypeLabel(
+			ctEntry.getChangeType());
 
 		boolean localize = ParamUtil.getBoolean(resourceRequest, "localize");
 
@@ -265,14 +283,9 @@ public class GetEntryRenderDataMVCResourceCommand
 				}
 
 				if (ArrayUtil.isNotEmpty(availableLanguageIds)) {
-					for (String languageId : availableLanguageIds) {
-						localizedTitlesJSONObject.put(
-							languageId,
-							_ctDisplayRendererRegistry.getTitle(
-								ctCollectionId, ctSQLMode,
-								LocaleUtil.fromLanguageId(languageId),
-								rightModel, ctEntry.getModelClassNameId()));
-					}
+					_putLocalizedTitles(
+						availableLanguageIds, ctCollectionId, ctSQLMode,
+						ctEntry, localizedTitlesJSONObject, rightModel);
 
 					rightLocalizedPreviewJSONObject =
 						_getLocalizedPreviewJSONObject(
@@ -345,22 +358,11 @@ public class GetEntryRenderDataMVCResourceCommand
 				}
 
 				if (leftModel != null) {
-					String editURL = _ctDisplayRendererRegistry.getEditURL(
-						leftCtCollectionId, leftCTSQLMode, httpServletRequest,
-						leftModel, ctEntry.getModelClassNameId());
-
-					if (Validator.isNotNull(editURL)) {
-						editInProductionJSONObject = _getEditJSONObject(
-							_language.format(
-								httpServletRequest,
-								"you-are-currently-working-on-x.-work-on-" +
-									"production",
-								new Object[] {ctCollection.getName()}, false),
-							CTConstants.CT_COLLECTION_ID_PRODUCTION, editURL,
-							_language.get(
-								httpServletRequest, "edit-in-production"),
+					editInProductionJSONObject =
+						_buildEditInProductionJSONObject(
+							leftCtCollectionId, leftCTSQLMode, ctEntry,
+							ctCollection, leftModel, httpServletRequest,
 							resourceRequest, resourceResponse);
-					}
 
 					String leftVersionName = ctDisplayRenderer.getVersionName(
 						leftModel);
@@ -370,16 +372,14 @@ public class GetEntryRenderDataMVCResourceCommand
 							httpServletRequest, "production");
 					}
 					else {
-						leftTitle = StringBundler.concat(
-							_language.get(httpServletRequest, "version"), ": ",
-							leftVersionName, " (",
-							_language.get(httpServletRequest, "production"),
-							")");
+						leftTitle = _getVersionTitle(
+							httpServletRequest, leftVersionName,
+							_language.get(httpServletRequest, "production"));
 					}
 
-					rightTitle = StringBundler.concat(
-						_language.get(httpServletRequest, "version"), ": ",
-						rightVersionName, " (", ctCollection.getName(), ")");
+					rightTitle = _getVersionTitle(
+						httpServletRequest, rightVersionName,
+						ctCollection.getName());
 
 					if (ArrayUtil.isNotEmpty(availableLanguageIds)) {
 						leftLocalizedPreviewJSONObject =
@@ -428,22 +428,11 @@ public class GetEntryRenderDataMVCResourceCommand
 				if (ctEntry.getChangeType() ==
 						CTConstants.CT_CHANGE_TYPE_MODIFICATION) {
 
-					String editURL = _ctDisplayRendererRegistry.getEditURL(
-						leftCtCollectionId, leftCTSQLMode, httpServletRequest,
-						leftModel, ctEntry.getModelClassNameId());
-
-					if (Validator.isNotNull(editURL)) {
-						editInProductionJSONObject = _getEditJSONObject(
-							_language.format(
-								httpServletRequest,
-								"you-are-currently-working-on-x.-work-on-" +
-									"production",
-								new Object[] {ctCollection.getName()}, false),
-							CTConstants.CT_COLLECTION_ID_PRODUCTION, editURL,
-							_language.get(
-								httpServletRequest, "edit-in-production"),
+					editInProductionJSONObject =
+						_buildEditInProductionJSONObject(
+							leftCtCollectionId, leftCTSQLMode, ctEntry,
+							ctCollection, leftModel, httpServletRequest,
 							resourceRequest, resourceResponse);
-					}
 				}
 
 				if (localize &&
@@ -460,14 +449,9 @@ public class GetEntryRenderDataMVCResourceCommand
 				}
 
 				if (ArrayUtil.isNotEmpty(availableLanguageIds)) {
-					for (String languageId : availableLanguageIds) {
-						localizedTitlesJSONObject.put(
-							languageId,
-							_ctDisplayRendererRegistry.getTitle(
-								leftCtCollectionId, leftCTSQLMode,
-								LocaleUtil.fromLanguageId(languageId),
-								leftModel, ctEntry.getModelClassNameId()));
-					}
+					_putLocalizedTitles(
+						availableLanguageIds, leftCtCollectionId, leftCTSQLMode,
+						ctEntry, localizedTitlesJSONObject, leftModel);
 
 					leftLocalizedPreviewJSONObject =
 						_getLocalizedPreviewJSONObject(
@@ -540,16 +524,14 @@ public class GetEntryRenderDataMVCResourceCommand
 						rightTitle = ctCollection.getName();
 					}
 					else {
-						rightTitle = StringBundler.concat(
-							_language.get(httpServletRequest, "version"), ": ",
-							rightVersionName, " (", ctCollection.getName(),
-							")");
+						rightTitle = _getVersionTitle(
+							httpServletRequest, rightVersionName,
+							ctCollection.getName());
 					}
 
-					leftTitle = StringBundler.concat(
-						_language.get(httpServletRequest, "version"), ": ",
-						leftVersionName, " (",
-						_language.get(httpServletRequest, "deleted"), ")");
+					leftTitle = _getVersionTitle(
+						httpServletRequest, leftVersionName,
+						_language.get(httpServletRequest, "deleted"));
 
 					if (ArrayUtil.isNotEmpty(availableLanguageIds)) {
 						rightLocalizedPreviewJSONObject =
@@ -1114,6 +1096,15 @@ public class GetEntryRenderDataMVCResourceCommand
 		jsonObject.put("segmentsExperiences", jsonArray);
 	}
 
+	private String _getVersionTitle(
+		HttpServletRequest httpServletRequest, String versionName,
+		String context) {
+
+		return StringBundler.concat(
+			_language.get(httpServletRequest, "version"), ": ", versionName,
+			" (", context, ")");
+	}
+
 	private <T extends BaseModel<T>> JSONArray _getWorkflowActionsJSONArray(
 			CTEntry ctEntry, T model, ThemeDisplay themeDisplay,
 			ResourceResponse resourceResponse)
@@ -1630,6 +1621,21 @@ public class GetEntryRenderDataMVCResourceCommand
 		}
 
 		return workflowTasks.get(0);
+	}
+
+	private <T extends BaseModel<T>> void _putLocalizedTitles(
+		String[] availableLanguageIds, long ctCollectionId,
+		CTSQLModeThreadLocal.CTSQLMode ctSQLMode, CTEntry ctEntry,
+		JSONObject localizedTitlesJSONObject, T model) {
+
+		for (String languageId : availableLanguageIds) {
+			localizedTitlesJSONObject.put(
+				languageId,
+				_ctDisplayRendererRegistry.getTitle(
+					ctCollectionId, ctSQLMode,
+					LocaleUtil.fromLanguageId(languageId), model,
+					ctEntry.getModelClassNameId()));
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89478

## What is being fixed

`GetEntryRenderDataMVCResourceCommand` is a 1700-line MVC resource command in `change-tracking-web` that builds the JSON payload for the Publications "view entry" panel. Its main method `_getCTEntryRenderDataJSONObject` had four pieces of duplicated logic across its ADDITION, MODIFICATION, and DELETION branches: a manual mapping from `CTConstants.CT_CHANGE_TYPE_*` to label strings, a `version: <name> (<context>)` `StringBundler.concat` shape, an `editURL` / `Validator.isNotNull` / `_getEditJSONObject` pipeline, and a `for`-loop populating `localizedTitlesJSONObject` from `getTitle`.

## How it is being fixed

Replace the manual change-type if/else with the existing `CTConstants.getCTChangeTypeLabel` helper from `change-tracking-api`. This changes the default for unknown change types from `"modified"` to `StringPool.BLANK`, which is unreachable for valid `CTEntry` data because the column is constrained at insert.

Extract three private helpers in the class to remove the remaining duplication: `_getVersionTitle` collapses four `StringBundler.concat` blocks; `_buildEditInProductionJSONObject` collapses two byte-identical 14-line `getEditURL` pipelines used by the ADDITION-with-baseline and MODIFICATION branches; `_putLocalizedTitles` collapses two identical `for`-loops.

No behavior change at runtime.

## Why are there no tests?

Pure refactor with no behavior change. The Publications view-entry endpoint is covered by existing integration tests, which exercise this command's JSON output for ADDITION, MODIFICATION, and DELETION change types.