### PR TITLE
LPD-89462 Fix changeTrackingTimeline Playwright race after Save and Continue

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
@@ -568,11 +568,12 @@ test('LPD-39412 Assert publication timeline history is enabled for templates', a
 		.getByPlaceholder('Untitled Template')
 		.pressSequentially(title2, {delay: 50});
 
-	await page
-		.getByRole('button', {exact: true, name: 'Save and Continue'})
-		.click();
-
-	await page.waitForTimeout(500);
+	await Promise.all([
+		page.waitForLoadState('load'),
+		page
+			.getByRole('button', {exact: true, name: 'Save and Continue'})
+			.click(),
+	]);
 
 	const timelineButton = page.getByLabel('timeline-button');
 	await timelineButton.waitFor();
@@ -584,8 +585,6 @@ test('LPD-39412 Assert publication timeline history is enabled for templates', a
 	await expect(timelineActionsButton).toBeVisible();
 
 	await journalEditTemplatePage.goto(site.friendlyUrlPath);
-
-	await page.waitForTimeout(500);
 
 	await timelineButton.waitFor();
 	await timelineButton.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89462

## What Changed

`changeTrackingTimeline.spec.ts` (`LPD-39412 Assert publication timeline history is enabled for templates`) was timing out in `ci:test:publications` because the assertion on `timeline-button` ran while the "Save and Continue" navigation was still in flight.

## Root Cause

`waitForTimeout(500)` after "Save and Continue" is insufficient under CI load; the test then searched for `timeline-button` before the navigation finished.

## Fix

- `Promise.all([page.waitForLoadState('load'), saveAndContinue.click()])` around "Save and Continue" so the navigation completes before the timeline button is sought.
- Removed the now-redundant `waitForTimeout(500)` calls.

## Test plan

- [ ] `liferay playwright --tests changeTrackingTimeline` passes locally