### PR TITLE
LPD-89463 Fix ctContextChange Playwright race on notifications Save

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
@@ -174,9 +174,14 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 
 	await page.getByLabel('Hide warning when changing').uncheck();
 
-	await page.getByRole('button', {name: 'Save'}).click();
-
-	await page.reload();
+	await Promise.all([
+		page.waitForResponse(
+			(response) =>
+				response.url().includes('save_display_preference') &&
+				response.ok()
+		),
+		page.getByRole('button', {name: 'Save'}).click(),
+	]);
 
 	await journalPage.goto(site1.friendlyUrlPath);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89463

## What Changed

`ctContextChange.spec.ts` (`LPD-29693, LPD-29294 Assert silence context change popover behavior`) was timing out in `ci:test:publications`: the popover assertion ran before the notifications "Save" fetch had settled.

## Root Cause

The Save button in the Notifications modal issues a `fetch()` to `/change_tracking/save_display_preference` — not a page navigation. `waitForLoadState('load')` resolved immediately and left the race open.

## Fix

- Wrap the click in `Promise.all([waitForResponse(save_display_preference), saveButton.click()])` so subsequent steps run only after the fetch response arrives.
- Remove the redundant `page.reload()` — the JS handler calls `window.location.reload()` after the fetch succeeds, and `journalPage.goto()` navigates away regardless.

## Test plan

- [ ] `liferay playwright --tests ctContextChange` passes locally