### PR TITLE
LPD-89464 Fix publicationsKBArticle Playwright race against CKEditor init

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
@@ -123,6 +123,8 @@ test('Can publish a Publication containing an edited KBArticle', async ({
 
 	await page.goto(knowledgeBaseUrls.getEditKBArticleUrl(kbArticle.id));
 
+	await knowledgeBaseEditArticlePage.titlePlaceholder.waitFor();
+
 	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
 		`${content} edit`,
 		`${title} edit`


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89464

## What Changed

`publicationsKBArticle.spec.ts` (`Can publish a Publication containing an edited KBArticle`) was timing out in `ci:test:publications` because the publish step ran before the CKEditor form was interactive.

## Root Cause

`page.goto()` to the KB article edit URL does not guarantee the CKEditor iframe is ready; filling and clicking publish raced against iframe initialization.

## Fix

Added `titlePlaceholder.waitFor()` after `page.goto()` so the form is interactive before `publishNewKnowledgeBaseArticle` fills and submits.

## Test plan

- [ ] `liferay playwright --tests publicationsKBArticle` passes locally