### PR TITLE
LPD-89465 Fix publicationsPage Delete Entries dialog locator

### DIFF
--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -83,10 +83,13 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await this.page
-			.getByLabel('Delete Entries- Loading')
-			.getByRole('button', {name: 'Delete'})
-			.click();
+		const deleteEntriesModal = this.page.getByRole('dialog', {
+			name: 'Delete Entries',
+		});
+
+		await deleteEntriesModal.waitFor();
+
+		await deleteEntriesModal.getByRole('button', {name: 'Delete'}).click();
 	}
 
 	async editTemplate(name: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89465

## What Changed

`publicationsPage.spec.ts` was timing out in `ci:test:publications` when clicking the confirmation Delete button in the Delete Entries dialog.

## Root Cause

`getByLabel('Delete Entries- Loading')` is a dynamically generated aria-live label that only exists during the loading state, making it unreliable as a locator for the confirmation dialog.

## Fix

Updated `DisplayPageTemplatesPage.deleteEntries` to use `getByRole('dialog', {name: 'Delete Entries'}).waitFor()` — the stable dialog role — before clicking the confirmation Delete button.

## Test plan

- [ ] `liferay playwright --tests publicationsPage` passes locally