### PR TITLE
LPD-89466 Fix reviewChanges Playwright race on render panel re-fetch

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -1315,26 +1315,34 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.selectRenderView('Unified View');
 
+	const diffHtmlAdded = page.locator('.diff-html-added');
+
+	await diffHtmlAdded.first().waitFor();
+
 	await expect(
-		page.locator('.diff-html-added').filter({hasText: 'Edited'})
+		diffHtmlAdded.filter({hasText: 'Edited'})
 	).toBeVisible();
 
 	await expect(
-		page.locator('.diff-html-added').filter({hasText: 'Attachments'})
+		diffHtmlAdded.filter({hasText: 'Attachments'})
 	).toBeVisible();
 
 	await changeTrackingPage.selectRenderView('Split View');
 
+	const renderViewContent = page.locator(
+		'td.publications-render-view-content'
+	);
+
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+		renderViewContent.filter({has: page.getByText(wikiPageContent, {exact: true})})
 	).toBeVisible();
 
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+		renderViewContent.filter({
+			has: page.getByText(wikiPageContentEdited, {exact: true}),
+		})
 	).toBeVisible();
 
 	await expect(
@@ -1343,20 +1351,22 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.selectRenderView('Version: 1.0 (Production)');
 
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContent, {exact: true})})
+		renderViewContent.filter({has: page.getByText(wikiPageContent, {exact: true})})
 	).toBeVisible();
 
 	await changeTrackingPage.selectRenderView(
 		`Version: 1.1 (${ctCollection.body.name})`
 	);
 
+	await renderViewContent.first().waitFor();
+
 	await expect(
-		page
-			.locator('td.publications-render-view-content')
-			.filter({has: page.getByText(wikiPageContentEdited, {exact: true})})
+		renderViewContent.filter({
+			has: page.getByText(wikiPageContentEdited, {exact: true}),
+		})
 	).toBeVisible();
 
 	await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89466

## What Changed

`reviewChanges.spec.ts` (`LPS-179026 Can preview changes for WikiPages`) was timing out in `ci:test:publications` because assertions on `.diff-html-added` and `td.publications-render-view-content` ran before the async render panel populated.

## Root Cause

`selectRenderView()` triggers an async render panel re-fetch; the test asserted on the new panel contents immediately, before the fetch returned.

## Fix

- After Unified View: `diffHtmlAdded.first().waitFor()` before asserting.
- After each subsequent `selectRenderView()` call: `renderViewContent.first().waitFor()` before asserting body text.

## Test plan

- [ ] `liferay playwright --tests reviewChanges` passes locally