### PR TITLE
LPD-89467 Fix reviewDisplayPageTemplateChanges Playwright race on render panel

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
@@ -144,6 +144,12 @@ test(
 
 		await changeTrackingPage.reviewChange(blogTitle);
 
+		const renderViewContent = page.locator(
+			'.publications-render-view-content'
+		);
+
+		await renderViewContent.waitFor();
+
 		await expect(page.getByText(blogBody)).toBeVisible();
 
 		const journalArticleTitle = getRandomString();
@@ -170,6 +176,8 @@ test(
 		await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
 		await changeTrackingPage.reviewChange(journalArticleTitle);
+
+		await renderViewContent.waitFor();
 
 		await expect(page.getByText(journalContent)).toBeVisible();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89467

## What Changed

`reviewDisplayPageTemplateChanges.spec.ts` was timing out in `ci:test:publications` because assertions on `blogBody` and `journalContent` ran before the async render panel was populated.

## Root Cause

Same async render panel issue as LPD-89466 — `reviewChange()` waits for `h2` but not for the render view body content.

## Fix

Added `.publications-render-view-content` `waitFor()` after each `reviewChange()` call before asserting body text.

## Test plan

- [ ] `liferay playwright --tests reviewDisplayPageTemplateChanges` passes locally