### PR TITLE
LPD-89451 Update ProductMenu locators for new SideNavigation

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>TOGGLE</td>
-	<td>//*[@data-qa-id='productMenu']</td>
+	<td>//*[@data-qa-id='productMenu'] | //*[@data-qa-id='sideNavigationToggler']</td>
 	<td></td>
 </tr>
 <tr>
@@ -42,12 +42,12 @@
 </tr>
 <tr>
 	<td>PRODUCT_MENU_OPENED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'open') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'closed'))]</td>
+	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'open') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'closed'))] | //*[@data-qa-id='sideNavigation' and contains(@class,'c-slideout-show')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PRODUCT_MENU_CLOSED</td>
-	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'closed') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'open'))]</td>
+	<td>//*[contains(@id,'sidenavSliderId') and contains(@class,'closed') and not(contains(@class,'sidenav-transition')) and not(contains(@class,'open'))] | //*[@data-qa-id='sideNavigation' and not(contains(@class,'c-slideout-show'))]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89451

## What Changed

Updates `ProductMenu.path` `TOGGLE`, `PRODUCT_MENU_OPENED`, and `PRODUCT_MENU_CLOSED` locators so they match the new Clay SidePanel-based SideNavigation in addition to the legacy `sidenavSliderId` element.

## Root Cause

Commit `b8e24c12c5c0d` (LPD-86832) partially updated `ProductMenu.path` to add the `sideNavigation` fallback to `PRODUCT_MENU_BODY`, but left `TOGGLE`, `PRODUCT_MENU_OPENED`, and `PRODUCT_MENU_CLOSED` pointing at the old `sidenavSliderId`-based elements that no longer exist in the new implementation.

The new SideNavigation uses:
- Toggle: `data-qa-id="sideNavigationToggler"`
- Open state: `data-qa-id="sideNavigation"` element with `c-slideout-show` class
- Closed state: `data-qa-id="sideNavigation"` element without `c-slideout-show` class

## Fix

Adds the new selector as an XPath `|` alternative alongside the old selector, preserving backward compatibility.

## Related

Split out of #3260 (originally bundled with LPD-89452 — see follow-up PR for that).