### PR TITLE
LPD-89452 Update AlloyEditor EDITOR locator for CKEditor 5

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>EDITOR</td>
-	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')]</td>
+	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'ck-editor__editable') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89452

## What Changed

Updates the `AlloyEditor.path` `EDITOR` locator so it matches CKEditor 5's `ck-editor__editable` class in addition to the legacy CKEditor 4 `cke_editable_inline` class.

## Root Cause

Commit `245b2b606eccd` (LPD-81886) inverted the `TextProcessor.ts` feature flag so CKEditor 5 (`getCKEditorProcessor`) is now the default. CKEditor 5 uses `ck-editor__editable` as its editable class instead of the CKEditor 4 `cke_editable_inline` class.

## Fix

Adds the CK5 class as an XPath `|` alternative so the locator works against both editor implementations.

## Related

Split out of #3260 (originally bundled with LPD-89451 — see companion PR for that).