### PR TITLE
LPD-90135 Create an SEOStudioInstance object scoped by account

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -244,6 +244,8 @@ public class ObjectDefinitionUtil {
 			"PerformanceCookieEntry", "/performance-cookies-entries"
 		).put(
 			"PersonalizationCookieEntry", "/personalization-cookies-entries"
+		).put(
+			"SEOStudioInstance", "/seo-studio/instances"
 		).build();
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-instance-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-instance-object-definition.json
@@ -1,0 +1,66 @@
+{
+	"accountEntryRestricted": true,
+	"accountEntryRestrictedObjectFieldName": "r_accountToSEOStudioInstances_accountEntryId",
+	"className": "com.liferay.object.model.ObjectDefinition#A7IN",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Instance"
+	},
+	"modifiable": true,
+	"name": "SEOStudioInstance",
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "NAME",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Name"
+			},
+			"name": "name",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "ACCOUNT_TO_SEO_STUDIO_INSTANCES",
+			"indexed": true,
+			"label": {
+				"en_US": "Account to SEO Studio Instances"
+			},
+			"name": "r_accountToSEOStudioInstances_accountEntryId",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "AccountEntry"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_accountToSEOStudioInstances_accountEntryERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_ACCOUNT_TO_L_SEO_STUDIO_INSTANCES",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Instances"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "name"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-instance-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-instance-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_ACCOUNT_TO_L_SEO_STUDIO_INSTANCES",
+	"label": {
+		"en_US": "Account to SEO Studio Instances"
+	},
+	"name": "accountToSEOStudioInstances",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AccountEntry$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioInstance$]",
+	"objectDefinitionName2": "SEOStudioInstance",
+	"system": true,
+	"type": "oneToMany"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90135

## What is being fixed

The SEO Studio feature needs an `SEOStudioInstance` system object that is scoped per account, so each account can hold its own SEO Studio configuration independently.

## How it is being fixed

Registers `SEOStudioInstance` as a modifiable system object definition in `ObjectDefinitionUtil` so its REST endpoint is reachable at `/seo-studio/instances`. Adds the site-initializer JSON files that create the `SEOStudioInstance` object definition and its many-to-one relationship to `AccountEntry`, so the object is provisioned when the SEO Studio site initializer runs.

## Why are there no tests?

This change is purely site-initializer configuration plus a one-line registration entry — data, not logic. Provisioning of site-initializer-defined objects and REST routing of registered system objects are already covered by existing site-initializer and headless-builder tests. Feature-level tests will be added in follow-up commits that introduce functionality on top of the object.