### PR TITLE
LPD-86444 Remove apiHelpers.headlessSite calls for Commerce

### DIFF
--- a/modules/test/playwright/tests/account-admin-web/main/accountEntriesManagementPortlet.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/main/accountEntriesManagementPortlet.spec.ts
@@ -258,11 +258,9 @@ test(
 
 		const layout1 = await createWidgetPage(apiHelpers, site.id);
 
-		const site2 = await apiHelpers.headlessSite.createSite({
+		const site2 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 		const layout2 = await createWidgetPage(apiHelpers, site2.id);
 

--- a/modules/test/playwright/tests/commerce/commerce-cart-content-web/main/commerceCart.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-cart-content-web/main/commerceCart.spec.ts
@@ -108,11 +108,9 @@ test('LPD-27036 Cart shows decimal quantities', async ({
 });
 
 test('LPD-29864 Cart updates when order is open', async ({apiHelpers}) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'Cart Site',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-cart-content-web/main/commerceMiniCart.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-cart-content-web/main/commerceMiniCart.spec.ts
@@ -35,11 +35,9 @@ test('COMMERCE-12316 Mini cart bundle with UOM', async ({
 	globalMenuPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
 		pageDefinition: getPageDefinition([
@@ -318,11 +316,9 @@ test('LPD-3496 Mini cart bundle without enough quantity', async ({
 	globalMenuPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
 		pageDefinition: getPageDefinition([
@@ -497,11 +493,9 @@ test('LPD-26906 Mini cart bundle quantity edit', async ({
 		user.id
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
 		pageDefinition: getPageDefinition([

--- a/modules/test/playwright/tests/commerce/commerce-channel-web/main/commerceAdminChannelDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-channel-web/main/commerceAdminChannelDetails.spec.ts
@@ -113,11 +113,9 @@ test('LPD-30466 Verify users without edit permission cannot click on channel nam
 	commerceAdminChannelDetailsPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-checkout-web/main/checkout.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-checkout-web/main/checkout.spec.ts
@@ -401,11 +401,9 @@ test(
 	}) => {
 		test.setTimeout(180000);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const channel =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({

--- a/modules/test/playwright/tests/commerce/commerce-initializer-util/main/commerceOrderGenerator.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-initializer-util/main/commerceOrderGenerator.spec.ts
@@ -32,11 +32,9 @@ test(
 		gogoShellPage,
 		page,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const channel =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/main/commerceAdminOrderDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/main/commerceAdminOrderDetails.spec.ts
@@ -38,11 +38,9 @@ test(
 		commerceAdminOrdersPage,
 		page,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const channel =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({
@@ -193,11 +191,9 @@ test('LPD-26244 Split order items are shown on admin order details page when sho
 	commerceAdminOrderDetailsPage,
 	commerceAdminOrdersPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,
@@ -328,11 +324,9 @@ test(
 		commerceAdminShipmentsPage,
 		page,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const channel =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({
@@ -960,11 +954,9 @@ test('LPD-30856 Can update order status by deleting unshipped items', async ({
 	commerceAdminShipmentsPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,
@@ -1153,11 +1145,9 @@ test('COMMERCE-7982 Can Edit Order Measurement Unit', async ({
 	commerceAdminOrdersPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/main/commerceAdminOrders.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/main/commerceAdminOrders.spec.ts
@@ -25,11 +25,9 @@ test(
 	'Orders can be bulk deleted on admin orders page',
 	{tag: '@LPD-55981'},
 	async ({apiHelpers, commerceAdminOrdersPage, page}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const channel =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({

--- a/modules/test/playwright/tests/commerce/commerce-order-management/main/discounts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-management/main/discounts.spec.ts
@@ -1409,13 +1409,8 @@ test(
 				],
 			});
 
-		const otherSite = await apiHelpers.headlessSite.createSite({
+		const otherSite = await apiHelpers.headlessAdminSite.postSite({
 			name: 'OtherSite-' + getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: otherSite.externalReferenceCode,
-			type: 'site',
 		});
 
 		const otherChannel =

--- a/modules/test/playwright/tests/commerce/commerce-order-management/main/orders.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-management/main/orders.spec.ts
@@ -834,13 +834,8 @@ test(
 			type: 'business',
 		});
 
-		const otherSite = await apiHelpers.headlessSite.createSite({
+		const otherSite = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Other ' + getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: otherSite.externalReferenceCode,
-			type: 'site',
 		});
 
 		const otherChannel =

--- a/modules/test/playwright/tests/commerce/commerce-order-web/main/commerceAdminOrder.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-web/main/commerceAdminOrder.spec.ts
@@ -32,11 +32,9 @@ test('LPD-44010 Check no delete dropdown in order admin page without delete perm
 	commerceAdminOrdersPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,
@@ -206,7 +204,7 @@ test('LPD-45268 Notes tab should not be visible if user does not have required p
 	commerceAdminOrdersPage,
 	page,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
 

--- a/modules/test/playwright/tests/commerce/commerce-payment-web/main/commercePayments.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-payment-web/main/commercePayments.spec.ts
@@ -35,11 +35,9 @@ test('LPD-5742 Can view payments list admin page', async ({
 		['test@liferay.com']
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'Payment Site',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-product-asset-categories-web/main/commerceAssetCategories.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-asset-categories-web/main/commerceAssetCategories.spec.ts
@@ -23,13 +23,11 @@ test('LPD-3381 Error message is shown when saving an existing override category 
 	commerceAdminChannelDetailsPage,
 	commerceAdminChannelsPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	await apiHelpers.headlessAdminSite.postSite({
 		name: 'Minium',
 		templateKey: 'minium-initializer',
 		templateType: 'site-initializer',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const pageName = 'Placed Orders';
 

--- a/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/sort.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/sort.spec.ts
@@ -69,23 +69,19 @@ test('LPD-18714 Setting default sort for commerce products', async ({
 
 	const siteName1 = 'Minium' + getRandomInt();
 
-	const site1 = await apiHelpers.headlessSite.createSite({
+	await apiHelpers.headlessAdminSite.postSite({
 		name: siteName1,
 		templateKey: 'minium-initializer',
 		templateType: 'site-initializer',
 	});
 
-	apiHelpers.data.push({id: site1.externalReferenceCode, type: 'site'});
-
 	const siteName2 = 'Minium' + getRandomInt();
 
-	const site2 = await apiHelpers.headlessSite.createSite({
+	await apiHelpers.headlessAdminSite.postSite({
 		name: siteName2,
 		templateKey: 'minium-initializer',
 		templateType: 'site-initializer',
 	});
-
-	apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 	const sortingOption1 = 'Name Ascending';
 	const sortingOption2 = 'Name Descending';

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/main/commerceProducts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/main/commerceProducts.spec.ts
@@ -341,11 +341,9 @@ test('COMMERCE-8153 Verify the visibility rules', async ({
 		accountGroup.externalReferenceCode
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'ProductDetailsSite',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,
@@ -496,11 +494,9 @@ test('LPD-33807 Mapped product add to cart', async ({
 		['test@liferay.com']
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await apiHelpers.headlessDelivery.createSitePage({
 		pageDefinition: getPageDefinition([
@@ -994,11 +990,9 @@ test('LPD-39067 Can product media and relation show correct date format', async 
 	commerceAdminProductDetailsProductRelationsPage,
 	commerceAdminProductPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const document1 = await apiHelpers.headlessDelivery.postDocument(
 		site.id,

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productComparison.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/main/productComparison.spec.ts
@@ -125,11 +125,9 @@ test(
 	'Product Compare is removed upon logout and login',
 	{tag: ['@LPD-37427', '@LPD-60912']},
 	async ({apiHelpers, globalMenuPage, page, productComparisonPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.headlessCommerceAdminChannel.postChannel({
 			siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-product-definitions-web/main/commerceAdminProductConfigurations.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-definitions-web/main/commerceAdminProductConfigurations.spec.ts
@@ -51,11 +51,9 @@ test('LPD-41420 Verify configuration list eligibility management is available', 
 		productConfigurationList.id
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,
@@ -154,11 +152,9 @@ test('LPD-41420 Verify configuration list eligibility management save button cle
 		productConfigurationList.id
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/commerce/commerce-wish-list-web/main/commerceWishLists.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-wish-list-web/main/commerceWishLists.spec.ts
@@ -61,11 +61,9 @@ test('LPD-34906 Verify wishlist visibility rules', async ({
 		accountGroup.externalReferenceCode
 	);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'WishListsSite',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
 		pageDefinition: getPageDefinition([

--- a/modules/test/playwright/tests/commerce/utils/commerce.ts
+++ b/modules/test/playwright/tests/commerce/utils/commerce.ts
@@ -389,11 +389,9 @@ export async function completedVirtualOrderItemSetUp(
 	apiHelpers: DataApiHelpers,
 	orderItemQuantity: number
 ) {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		name: getRandomString(),
@@ -492,13 +490,11 @@ export async function initializerSetUp(
 	catalogName = catalogName || siteName;
 	channelName = channelName || siteName;
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 		templateKey,
 		templateType: 'site-initializer',
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const channels =
 		await apiHelpers.headlessCommerceAdminChannel.getChannelsPage(

--- a/modules/test/playwright/tests/portal-default-permissions-web/main/defaultPermissionsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/main/defaultPermissionsConfiguration.spec.ts
@@ -138,11 +138,9 @@ test('LPD-22038 Set up the default site permissions for pages', async ({
 		page,
 	});
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await setupSiteDefaultPermissions({
 		defaultPermissionsSiteConfigurationPage,
@@ -211,11 +209,9 @@ test('LPD-22040 Check default permissions for pages', async ({
 		page,
 	});
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	let layout = await apiHelpers.headlessDelivery.createSitePage({
 		siteId: site.id,
@@ -324,11 +320,9 @@ test('LPD-35542 Default Permissions changes Unlock the values checked', async ({
 
 	await waitForAlert(page);
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
 		siteId: site.id,

--- a/modules/test/playwright/tests/portal-user-locale-options-web/main/userLocaleOptions.spec.ts
+++ b/modules/test/playwright/tests/portal-user-locale-options-web/main/userLocaleOptions.spec.ts
@@ -24,11 +24,9 @@ test('LPD-46913 Language should change properly for admins even if the site does
 	siteSettingsLocalizationPage,
 	userLocaleOptionsPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await siteSettingsLocalizationPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
@@ -1672,11 +1672,9 @@ test(
 			site1
 		);
 
-		const site2 = await apiHelpers.headlessSite.createSite({
+		const site2 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 		const bookmarkName2 = getRandomString();
 

--- a/modules/test/playwright/tests/roles-admin-web/main/siteRoles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/main/siteRoles.spec.ts
@@ -24,11 +24,9 @@ test('LPD-35066 Site role search should not persist after selecting an option', 
 	page,
 	usersAndOrganizationsPage,
 }) => {
-	const site1 = await apiHelpers.headlessSite.createSite({
+	const site1 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site1.externalReferenceCode, type: 'site'});
 
 	const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
@@ -41,11 +39,9 @@ test('LPD-35066 Site role search should not persist after selecting an option', 
 		user.id
 	);
 
-	const site2 = await apiHelpers.headlessSite.createSite({
+	const site2 = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 	await apiHelpers.headlessAdminUser.assignUserToSite(
 		role.id,

--- a/modules/test/playwright/tests/users-admin-web/main/anonymize.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/anonymize.spec.ts
@@ -113,11 +113,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.headlessDelivery.postBlog(site.id);
 
@@ -424,11 +422,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -571,7 +567,7 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
 
@@ -579,8 +575,6 @@ test(
 			siteId: site.id,
 			title: 'Page' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -758,11 +752,9 @@ test(
 			surname: userAccount.familyName,
 		};
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.headlessDelivery.createSitePage({
 			siteId: site.id,
@@ -877,11 +869,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -1013,11 +1003,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const attachment1 = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -1155,11 +1143,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const attachment = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -1258,11 +1244,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const blog = await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: 'Blog' + getRandomInt(),
@@ -1444,11 +1428,9 @@ test(
 			userAccount.id
 		);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await performUserSwitch(page, userAccount.alternateName);
 
@@ -1565,11 +1547,9 @@ test(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.headlessDelivery.postDocument(
 			site.id,

--- a/modules/test/playwright/tests/users-admin-web/main/gdpr.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/gdpr.spec.ts
@@ -89,11 +89,9 @@ testAdmin(
 
 		await performUserSwitch(page, contentUser.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await contactsCenterPage.createPage(apiHelpers, site.id, {
 			title: 'contact',
@@ -228,11 +226,9 @@ testAdmin(
 			surname: userAccount.familyName,
 		};
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.headlessDelivery.createSitePage({
 			siteId: site.id,
@@ -353,11 +349,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -459,11 +453,9 @@ testAdmin(
 			surname: userAccount.familyName,
 		};
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const role =
 			await apiHelpers.headlessAdminUser.getRoleByName('Administrator');
@@ -576,11 +568,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -691,7 +681,7 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
 
@@ -699,8 +689,6 @@ testAdmin(
 			siteId: site.id,
 			title: 'Page' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const attachment1 = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -870,11 +858,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const blog = await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: 'Blog' + getRandomInt(),
@@ -1018,11 +1004,9 @@ testAdmin(
 			userAccount.id
 		);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.headlessDelivery.createSitePage({
 			siteId: site.id,
@@ -1126,11 +1110,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const formTitle = 'Form' + getRandomInt();
 		const textFieldLabel = 'Text Field';
@@ -1261,11 +1243,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const folder = await apiHelpers.headlessDelivery.postDocumentFolder(
 			site.id
@@ -1407,11 +1387,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site' + getRandomInt(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: getRandomString(),
@@ -1535,11 +1513,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const documentA = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -1707,11 +1683,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const announcementsPage =
 			await userAssociatedDataAnnouncementPage.createAnnouncementPage(
@@ -1807,11 +1781,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const document = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -2030,11 +2002,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: 'Blog' + getRandomInt(),
@@ -2162,11 +2132,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const blog1 = await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: 'Blog' + getRandomInt(),
@@ -2242,11 +2210,9 @@ testAdmin(
 
 		await performUserSwitch(page, userAccount.alternateName);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const blog = await apiHelpers.headlessDelivery.postBlog(site.id, {
 			headline: 'Blog' + getRandomInt(),

--- a/modules/test/playwright/tests/users-admin-web/main/termsOfUse.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/termsOfUse.spec.ts
@@ -136,65 +136,57 @@ test(
 		termsOfUseInstanceSettingsPage,
 		userLoginPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: `Site${getRandomString()}`,
 		});
 
-		try {
-			const temsContent = 'This is a custom terms of use content.';
+		const temsContent = 'This is a custom terms of use content.';
 
-			const ddmStructureId =
-				await getBasicWebContentStructureId(apiHelpers);
+		const ddmStructureId = await getBasicWebContentStructureId(apiHelpers);
 
-			const webContent =
-				await apiHelpers.jsonWebServicesJournal.addWebContent({
-					content: temsContent,
-					ddmStructureId,
-					groupId: Number(site.id),
-					serviceContext: {
-						addGroupPermissions: true,
-						addGuestPermissions: true,
-						workflowAction: 1,
-					},
-					titleMap: {en_US: `ToU WC ${getRandomString()}`},
-				});
-
-			const user = await apiHelpers.headlessAdminUser.postUserAccount();
-
-			await termsOfUseInstanceSettingsPage.goto();
-
-			await termsOfUseInstanceSettingsPage.termsOfUseRequiredCheckbox.check();
-
-			await termsOfUseInstanceSettingsPage.groupIdInput.fill(
-				String(site.id)
-			);
-			await termsOfUseInstanceSettingsPage.articleIdInput.fill(
-				String(webContent.articleId)
-			);
-			await termsOfUseInstanceSettingsPage.saveButton.click();
-
-			await waitForAlert(page);
-
-			await performLogout(page);
-
-			await userLoginPage.goto();
-			await userLoginPage.emailAddressInput.fill(user.emailAddress);
-			await userLoginPage.passwordInput.fill(userData['test'].password);
-			await userLoginPage.signInButton.click();
-
-			await expect(page.getByText(temsContent)).toBeVisible({
-				timeout: 10000,
+		const webContent =
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				content: temsContent,
+				ddmStructureId,
+				groupId: Number(site.id),
+				serviceContext: {
+					addGroupPermissions: true,
+					addGuestPermissions: true,
+					workflowAction: 1,
+				},
+				titleMap: {en_US: `ToU WC ${getRandomString()}`},
 			});
 
-			await userLoginPage.iAgreeButton.click();
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
-			await expect(userLoginPage.userProfileMenuButton).toBeVisible({
-				timeout: 20000,
-			});
-		}
-		finally {
-			await apiHelpers.headlessSite.deleteSite(site.id);
-		}
+		await termsOfUseInstanceSettingsPage.goto();
+
+		await termsOfUseInstanceSettingsPage.termsOfUseRequiredCheckbox.check();
+
+		await termsOfUseInstanceSettingsPage.groupIdInput.fill(String(site.id));
+		await termsOfUseInstanceSettingsPage.articleIdInput.fill(
+			String(webContent.articleId)
+		);
+		await termsOfUseInstanceSettingsPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await performLogout(page);
+
+		await userLoginPage.goto();
+		await userLoginPage.emailAddressInput.fill(user.emailAddress);
+		await userLoginPage.passwordInput.fill(userData['test'].password);
+		await userLoginPage.signInButton.click();
+
+		await expect(page.getByText(temsContent)).toBeVisible({
+			timeout: 10000,
+		});
+
+		await userLoginPage.iAgreeButton.click();
+
+		await expect(userLoginPage.userProfileMenuButton).toBeVisible({
+			timeout: 20000,
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/users-admin-web/main/users.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/users.spec.ts
@@ -899,11 +899,9 @@ test(
 	{tag: '@LPD-62301'},
 	async ({apiHelpers, editUserPage, page, usersAndOrganizationsPage}) => {
 		const name = '<img src=x onerror=alert(origin)>';
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name,
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 

--- a/modules/test/playwright/tests/users-admin-web/main/usersAndOrganizations.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/usersAndOrganizations.spec.ts
@@ -1033,11 +1033,9 @@ test(
 			[userAccount1.id, userAccount2.id]
 		);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const role =
 			await apiHelpers.headlessAdminUser.getRoleByName(

--- a/modules/test/playwright/tests/users-admin-web/properties/userNotifications.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/properties/userNotifications.spec.ts
@@ -190,7 +190,7 @@ test(
 			).toBeVisible();
 		}
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: `Site${getRandomString()}`,
 		});
 
@@ -270,8 +270,6 @@ test(
 		}
 		finally {
 			await mockMockPage.close();
-
-			await apiHelpers.headlessSite.deleteSite(site.id);
 
 			await emailInstanceSettingsPage.goToEmailSender();
 

--- a/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/main/fixtures/marketplaceSite.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/main/fixtures/marketplaceSite.ts
@@ -20,7 +20,7 @@ const SITE_NAME = 'Marketplace';
 export const marketplaceSiteFixture = test.extend<Marketplace>({
 	marketplace: [
 		async ({apiHelpers, page}, use) => {
-			const site = await apiHelpers.headlessSite.getSiteByERC(
+			const site = await apiHelpers.headlessAdminSite.getSite(
 				SITE_EXTERNAL_REFERENCE_CODE
 			);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86444

## What is being fixed

The Playwright Commerce tests create sites with `apiHelpers.headlessSite.createSite`, which returns a site whose `externalReferenceCode` then has to be tracked manually via `apiHelpers.data.push(...)` for teardown. This duplicates state and bloats the tests.

## How it is being fixed

Each `apiHelpers.headlessSite.createSite(...)` call is replaced with `apiHelpers.headlessAdminSite.postSite(...)`, and the matching `apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'})` lines are removed because the new helper handles cleanup automatically.