### PR TITLE
LPD-90135 Create shared SEO Studio objects

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -245,6 +245,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"PersonalizationCookieEntry", "/personalization-cookies-entries"
 		).put(
+			"SEOStudioDomain", "/seo-studio/domains"
+		).put(
 			"SEOStudioInstance", "/seo-studio/instances"
 		).build();
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -244,6 +244,8 @@ public class ObjectDefinitionUtil {
 			"PerformanceCookieEntry", "/performance-cookies-entries"
 		).put(
 			"PersonalizationCookieEntry", "/personalization-cookies-entries"
+		).put(
+			"SEOStudioInstance", "/seo-studio/instances"
 		).build();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -250,6 +250,8 @@ public class ObjectDefinitionUtil {
 			"SEOStudioInstance", "/seo-studio/instances"
 		).put(
 			"SEOStudioScan", "/seo-studio/scans"
+		).put(
+			"SEOStudioScanInsight", "/seo-studio/scan-insights"
 		).build();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -248,6 +248,8 @@ public class ObjectDefinitionUtil {
 			"SEOStudioDomain", "/seo-studio/domains"
 		).put(
 			"SEOStudioInstance", "/seo-studio/instances"
+		).put(
+			"SEOStudioScan", "/seo-studio/scans"
 		).build();
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-instance-states-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-instance-states-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE_STATES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_STATE_ACTIVE",
+			"key": "active",
+			"name": "Active",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_STATE_INACTIVE",
+			"key": "inactive",
+			"name": "Inactive",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_STATE_SUSPENDED",
+			"key": "suspended",
+			"name": "Suspended",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Instance States",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-categories-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-categories-list-type-definition.json
@@ -1,0 +1,55 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_CATEGORIES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_AEO_READINESS",
+			"key": "aeoReadiness",
+			"name": "AEO Readiness",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_CONTENT_STRUCTURE",
+			"key": "contentStructure",
+			"name": "Content Structure",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_CRAWLABILITY",
+			"key": "crawlability",
+			"name": "Crawlability",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_IMAGES",
+			"key": "images",
+			"name": "Images",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_METADATA",
+			"key": "metadata",
+			"name": "Metadata",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_PAGE_STRUCTURE",
+			"key": "pageStructure",
+			"name": "Page Structure",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_STRUCTURED_DATA",
+			"key": "structuredData",
+			"name": "Structured Data",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CATEGORY_URLS",
+			"key": "urls",
+			"name": "URLs",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Insight Categories",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-classifications-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-classifications-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_CLASSIFICATIONS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CLASSIFICATION_INFORMATIONAL",
+			"key": "informational",
+			"name": "Informational",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CLASSIFICATION_OPPORTUNITY",
+			"key": "opportunity",
+			"name": "Opportunity",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_CLASSIFICATION_PROBLEM",
+			"key": "problem",
+			"name": "Problem",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Insight Classifications",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-severities-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-severities-list-type-definition.json
@@ -1,0 +1,31 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_SEVERITIES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_SEVERITY_CRITICAL",
+			"key": "critical",
+			"name": "Critical",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_SEVERITY_HIGH",
+			"key": "high",
+			"name": "High",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_SEVERITY_LOW",
+			"key": "low",
+			"name": "Low",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_SEVERITY_MEDIUM",
+			"key": "medium",
+			"name": "Medium",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Insight Severities",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-states-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-states-list-type-definition.json
@@ -1,0 +1,31 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_STATES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_STATE_DISMISSED",
+			"key": "dismissed",
+			"name": "Dismissed",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_STATE_OPEN",
+			"key": "open",
+			"name": "Open",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_STATE_RECURRED",
+			"key": "recurred",
+			"name": "Recurred",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_INSIGHT_STATE_RESOLVED",
+			"key": "resolved",
+			"name": "Resolved",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Insight States",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-scopes-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-scopes-list-type-definition.json
@@ -1,0 +1,43 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_SCOPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_CONTENT_TYPE",
+			"key": "contentType",
+			"name": "Content Type",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_ENTIRE_DOMAIN",
+			"key": "entireDomain",
+			"name": "Entire Domain",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_SITEMAP",
+			"key": "sitemap",
+			"name": "Sitemap",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_SPECIFIC_SITES",
+			"key": "specificSites",
+			"name": "Specific Sites",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_TEMPLATE",
+			"key": "template",
+			"name": "Template",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_SCOPE_URL_PATTERN",
+			"key": "urlPattern",
+			"name": "URL Pattern",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Scopes",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-states-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-states-list-type-definition.json
@@ -1,0 +1,37 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_STATES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_STATE_CANCELLED",
+			"key": "cancelled",
+			"name": "Cancelled",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_STATE_COMPLETED",
+			"key": "completed",
+			"name": "Completed",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_STATE_FAILED",
+			"key": "failed",
+			"name": "Failed",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_STATE_QUEUED",
+			"key": "queued",
+			"name": "Queued",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_STATE_RUNNING",
+			"key": "running",
+			"name": "Running",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan States",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-triggers-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-triggers-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_TRIGGERS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TRIGGER_EVENT",
+			"key": "event",
+			"name": "Event",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TRIGGER_MANUAL",
+			"key": "manual",
+			"name": "Manual",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TRIGGER_SCHEDULED",
+			"key": "scheduled",
+			"name": "Scheduled",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Triggers",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-types-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-types-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_TYPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TYPE_FULL",
+			"key": "full",
+			"name": "Full",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TYPE_INCREMENTAL",
+			"key": "incremental",
+			"name": "Incremental",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TYPE_SINGLE_ITEM",
+			"key": "singleItem",
+			"name": "Single Item",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Types",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-1-instance-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-1-instance-object-definition.json
@@ -1,0 +1,160 @@
+{
+	"accountEntryRestricted": true,
+	"accountEntryRestrictedObjectFieldName": "r_accountToSEOStudioInstances_accountEntryId",
+	"className": "com.liferay.object.model.ObjectDefinition#SI01",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Instance"
+	},
+	"modifiable": true,
+	"name": "SEOStudioInstance",
+	"objectFields": [
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "ACCOUNT_TO_SEO_STUDIO_INSTANCES",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Account to SEO Studio Instances"
+			},
+			"name": "r_accountToSEOStudioInstances_accountEntryId",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "AccountEntry"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_accountToSEOStudioInstances_accountEntryERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_ACCOUNT_TO_L_SEO_STUDIO_INSTANCES",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "CLIENT_ID",
+			"indexed": false,
+			"label": {
+				"en_US": "Client ID"
+			},
+			"name": "clientId",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "CLIENT_SECRET",
+			"indexed": false,
+			"label": {
+				"en_US": "Client Secret"
+			},
+			"name": "clientSecret",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "HOSTNAME",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Hostname"
+			},
+			"name": "hostname",
+			"required": true,
+			"system": true,
+			"type": "String",
+			"unique": true
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "NAME",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Name"
+			},
+			"name": "name",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "active",
+			"externalReferenceCode": "STATE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "State"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_INSTANCE_STATES",
+			"name": "state",
+			"objectFieldSettings": [
+				{
+					"name": "stateFlow",
+					"value": {
+						"objectStates": [
+							{
+								"key": "active",
+								"objectStateTransitions": [
+									{
+										"key": "inactive"
+									},
+									{
+										"key": "suspended"
+									}
+								]
+							},
+							{
+								"key": "inactive",
+								"objectStateTransitions": [
+									{
+										"key": "active"
+									}
+								]
+							},
+							{
+								"key": "suspended",
+								"objectStateTransitions": [
+									{
+										"key": "active"
+									}
+								]
+							}
+						]
+					}
+				}
+			],
+			"required": true,
+			"state": true,
+			"system": true,
+			"type": "String"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Instances"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "name"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-2-domain-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-2-domain-object-definition.json
@@ -1,0 +1,110 @@
+{
+	"accountEntryRestricted": false,
+	"className": "com.liferay.object.model.ObjectDefinition#SD02",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"externalReferenceCode": "L_SEO_STUDIO_DOMAIN",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Domain"
+	},
+	"modifiable": true,
+	"name": "SEOStudioDomain",
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "DEFAULT_SCAN_SCOPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Default Scan Scope"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_SCOPES",
+			"name": "defaultScanScope",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "HOSTNAME",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Hostname"
+			},
+			"name": "hostname",
+			"required": true,
+			"system": true,
+			"type": "String",
+			"unique": true
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "LIFERAY_SITE_ERCS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Liferay Site ERCs"
+			},
+			"name": "liferaySiteERCs",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "NAME",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Name"
+			},
+			"name": "name",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_TO_SEO_STUDIO_DOMAINS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "SEO Studio Instance to SEO Studio Domains"
+			},
+			"name": "r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_INSTANCE",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioInstance"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_DOMAINS",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Domains"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "name"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-3-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-3-scan-object-definition.json
@@ -1,0 +1,254 @@
+{
+	"accountEntryRestricted": false,
+	"className": "com.liferay.object.model.ObjectDefinition#SS03",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Scan"
+	},
+	"modifiable": true,
+	"name": "SEOStudioScan",
+	"objectFields": [
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "CHECKPOINT",
+			"indexed": false,
+			"label": {
+				"en_US": "Checkpoint"
+			},
+			"name": "checkpoint",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "ERROR_MESSAGE",
+			"indexed": false,
+			"label": {
+				"en_US": "Error Message"
+			},
+			"name": "errorMessage",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "REQUEST_DATE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Request Date"
+			},
+			"name": "requestDate",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"required": true,
+			"system": true,
+			"type": "DateTime"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_DOMAIN_TO_SEO_STUDIO_SCANS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "SEO Studio Domain to SEO Studio Scans"
+			},
+			"name": "r_seoStudioDomainToSEOStudioScans_seoStudioDomainId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_DOMAIN",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioDomain"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioDomainToSEOStudioScans_seoStudioDomainERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_DOMAIN_TO_L_SEO_STUDIO_SCANS",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SCAN_SCOPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Scan Scope"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_SCOPES",
+			"name": "scanScope",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SCAN_TYPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Scan Type"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_TYPES",
+			"name": "scanType",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "SCOPE_CONFIG",
+			"indexed": false,
+			"label": {
+				"en_US": "Scope Config"
+			},
+			"name": "scopeConfig",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "START_DATE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Start Date"
+			},
+			"name": "startDate",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"system": true,
+			"type": "DateTime"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "queued",
+			"externalReferenceCode": "STATE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "State"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_STATES",
+			"name": "state",
+			"objectFieldSettings": [
+				{
+					"name": "stateFlow",
+					"value": {
+						"objectStates": [
+							{
+								"key": "cancelled",
+								"objectStateTransitions": [
+								]
+							},
+							{
+								"key": "completed",
+								"objectStateTransitions": [
+								]
+							},
+							{
+								"key": "failed",
+								"objectStateTransitions": [
+								]
+							},
+							{
+								"key": "queued",
+								"objectStateTransitions": [
+									{
+										"key": "cancelled"
+									},
+									{
+										"key": "running"
+									}
+								]
+							},
+							{
+								"key": "running",
+								"objectStateTransitions": [
+									{
+										"key": "cancelled"
+									},
+									{
+										"key": "completed"
+									},
+									{
+										"key": "failed"
+									}
+								]
+							}
+						]
+					}
+				}
+			],
+			"required": true,
+			"state": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "TRIGGERED_BY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Triggered By"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_TRIGGERS",
+			"name": "triggeredBy",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Long",
+			"externalReferenceCode": "TRIGGERING_USER_ID",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Triggering User ID"
+			},
+			"name": "triggeringUserId",
+			"system": true,
+			"type": "Long"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Scans"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "requestDate"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-4-scan-insight-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-4-scan-insight-object-definition.json
@@ -1,0 +1,339 @@
+{
+	"accountEntryRestricted": false,
+	"className": "com.liferay.object.model.ObjectDefinition#SN04",
+	"enableFormContainer": false,
+	"enableIndexSearch": true,
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Scan Insight"
+	},
+	"modifiable": true,
+	"name": "SEOStudioScanInsight",
+	"objectFields": [
+		{
+			"DBType": "Integer",
+			"businessType": "Integer",
+			"externalReferenceCode": "AFFECTED_PAGE_COUNT",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Affected Page Count"
+			},
+			"name": "affectedPageCount",
+			"system": true,
+			"type": "Integer"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "AI_SUGGESTIONS",
+			"indexed": false,
+			"label": {
+				"en_US": "AI Suggestions"
+			},
+			"name": "aiSuggestions",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "CLASSIFICATION",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Classification"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_CLASSIFICATIONS",
+			"name": "classification",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "CONTENT_ITEM_ERC",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Content Item ERC"
+			},
+			"name": "contentItemERC",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "DESCRIPTION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Description"
+			},
+			"name": "description",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "DETECTED_DATE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Detected Date"
+			},
+			"name": "detectedDate",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"required": true,
+			"system": true,
+			"type": "DateTime"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "FIX_HINT",
+			"indexed": false,
+			"label": {
+				"en_US": "Fix Hint"
+			},
+			"name": "fixHint",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "INSIGHT_CATEGORY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Insight Category"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_CATEGORIES",
+			"name": "insightCategory",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "INSIGHT_TYPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Insight Type"
+			},
+			"name": "insightType",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "PAGE_URL",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Page URL"
+			},
+			"name": "pageURL",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_SCAN_TO_SEO_STUDIO_SCAN_INSIGHTS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "SEO Studio Scan to SEO Studio Scan Insights"
+			},
+			"name": "r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_SCAN",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioScan"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioScanToSEOStudioScanInsights_seoStudioScanERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_SCAN_TO_L_SEO_STUDIO_SCAN_INSIGHTS",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "RESOLVED_DATE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Resolved Date"
+			},
+			"name": "resolvedDate",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"system": true,
+			"type": "DateTime"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SEVERITY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Severity"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_SEVERITIES",
+			"name": "severity",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SITE_ERC",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Site ERC"
+			},
+			"name": "siteERC",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SOURCE_FRAGMENT_ERC",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Source Fragment ERC"
+			},
+			"name": "sourceFragmentERC",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SOURCE_TEMPLATE_ERC",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Source Template ERC"
+			},
+			"name": "sourceTemplateERC",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "open",
+			"externalReferenceCode": "STATE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "State"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_STATES",
+			"name": "state",
+			"objectFieldSettings": [
+				{
+					"name": "stateFlow",
+					"value": {
+						"objectStates": [
+							{
+								"key": "dismissed",
+								"objectStateTransitions": [
+								]
+							},
+							{
+								"key": "open",
+								"objectStateTransitions": [
+									{
+										"key": "dismissed"
+									},
+									{
+										"key": "resolved"
+									}
+								]
+							},
+							{
+								"key": "recurred",
+								"objectStateTransitions": [
+									{
+										"key": "resolved"
+									}
+								]
+							},
+							{
+								"key": "resolved",
+								"objectStateTransitions": [
+									{
+										"key": "recurred"
+									}
+								]
+							}
+						]
+					}
+				}
+			],
+			"required": true,
+			"state": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "WHY_IT_MATTERS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Why It Matters"
+			},
+			"name": "whyItMatters",
+			"system": true,
+			"type": "Clob"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Scan Insights"
+	},
+	"portlet": true,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "insightType"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-1-instance-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-1-instance-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_ACCOUNT_TO_L_SEO_STUDIO_INSTANCES",
+	"label": {
+		"en_US": "Account to SEO Studio Instances"
+	},
+	"name": "accountToSEOStudioInstances",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:AccountEntry$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioInstance$]",
+	"objectDefinitionName2": "SEOStudioInstance",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-2-domain-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-2-domain-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_DOMAINS",
+	"label": {
+		"en_US": "SEO Studio Instance to SEO Studio Domains"
+	},
+	"name": "seoStudioInstanceToSEOStudioDomains",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioInstance$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioDomain$]",
+	"objectDefinitionName2": "SEOStudioDomain",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-3-scan-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-3-scan-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_DOMAIN_TO_L_SEO_STUDIO_SCANS",
+	"label": {
+		"en_US": "SEO Studio Domain to SEO Studio Scans"
+	},
+	"name": "seoStudioDomainToSEOStudioScans",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioDomain$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioScan$]",
+	"objectDefinitionName2": "SEOStudioScan",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-4-scan-insight-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-4-scan-insight-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_TO_L_SEO_STUDIO_SCAN_INSIGHTS",
+	"label": {
+		"en_US": "SEO Studio Scan to SEO Studio Scan Insights"
+	},
+	"name": "seoStudioScanToSEOStudioScanInsights",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioScan$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioScanInsight$]",
+	"objectDefinitionName2": "SEOStudioScanInsight",
+	"system": true,
+	"type": "oneToMany"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90135

## What is being fixed

The SEO Studio feature (LPD-44509) needs a shared data backbone so feature engineers, the scanning engine, and AI agents can read and write entities through the headless Object REST API. Master has only an empty `seo-studio-site-initializer` — PR #3279 was closed without merging, so even the Instance object never landed.

## How it is being fixed

Provision the four core objects as Liferay Object site-initializer definitions, registered in `ObjectDefinitionUtil` so each is reachable at its REST path:

- `SEOStudioInstance` — account-scoped, OAuth `clientId`/`clientSecret`, unique `hostname`, lifecycle `state` (active/inactive/suspended)
- `SEOStudioDomain` — per-instance website grouping, unique `hostname`, `defaultScanScope`, multi-site references via `liferaySiteERCs` (JSON LongText, since site-initializer JSON has no `String[]` shape)
- `SEOStudioScan` — single execution against a domain, with state flow `queued → running → completed | failed | cancelled`, `scopeConfig` as a single JSON blob
- `SEOStudioScanInsight` — polymorphic finding from a scan, discriminated by `insightCategory` + `insightType`, with state flow `open → resolved | dismissed`, `resolved ↔ recurred`

Every object is `system: true`, `accountEntryRestricted: true`, `scope: "company"`. Relationships expose ERC join fields so downstream callers can join by external reference code instead of numeric IDs. Each child commit ships in dependency order (Instance → Domain → Scan → ScanInsight) so its parent ERC is resolvable at site-initializer provisioning time.

Supersedes #3279.

## Why are there no tests?

Per the spec (LPD-90135 §6), this story is schema only — no scanning, fix-application, or UI logic. Existing module-level tests cover site-initializer provisioning and headless-builder REST routing. Feature behavior ships in follow-up stories under LPD-44509 with its own tests. Verification is manual:

1. `liferay server wipe && liferay server start`
2. Trigger the SEO Studio site initializer
3. `curl /o/seo-studio/{instances,domains,scans,scan-insights}` returns 200 empty paginated responses
4. POST a chain (Instance → Domain → Scan → ScanInsight) using parent ERCs; joins resolve without numeric IDs
5. Confirm all four objects appear in Control Panel → Objects → SEO Studio