### PR TITLE
LPD-90275 Use the default-language Virtual Host instead of the alphabetically-first hostname

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -509,23 +509,23 @@ public class LayoutReferencesExportImportContentProcessor
 					company.getVirtualHostname(), serverPort, false);
 			}
 
-			NavigableMap<String, String> privateVirtualHostnames =
-				privateLayoutSet.getVirtualHostnames();
+			String privateDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, privateLayoutSet);
 
-			if (!privateVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(privateDefaultVirtualHostname)) {
 				privateLayoutSetPortalURL = _portal.getPortalURL(
-					privateVirtualHostnames.firstKey(), serverPort, false);
+					privateDefaultVirtualHostname, serverPort, false);
 			}
 			else {
 				privateLayoutSetPortalURL = companyPortalURL;
 			}
 
-			NavigableMap<String, String> publicVirtualHostnames =
-				publicLayoutSet.getVirtualHostnames();
+			String publicDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, publicLayoutSet);
 
-			if (!publicVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(publicDefaultVirtualHostname)) {
 				publicLayoutSetPortalURL = _portal.getPortalURL(
-					publicVirtualHostnames.firstKey(), serverPort, false);
+					publicDefaultVirtualHostname, serverPort, false);
 			}
 			else {
 				publicLayoutSetPortalURL = companyPortalURL;
@@ -552,20 +552,20 @@ public class LayoutReferencesExportImportContentProcessor
 					company.getVirtualHostname(), secureSecurePort, true);
 			}
 
-			NavigableMap<String, String> privateVirtualHostnames =
-				privateLayoutSet.getVirtualHostnames();
+			String privateDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, privateLayoutSet);
 
-			if (!privateVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(privateDefaultVirtualHostname)) {
 				privateLayoutSetSecurePortalURL = _portal.getPortalURL(
-					privateVirtualHostnames.firstKey(), secureSecurePort, true);
+					privateDefaultVirtualHostname, secureSecurePort, true);
 			}
 
-			NavigableMap<String, String> publicVirtualHostnames =
-				publicLayoutSet.getVirtualHostnames();
+			String publicDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, publicLayoutSet);
 
-			if (!publicVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(publicDefaultVirtualHostname)) {
 				publicLayoutSetSecurePortalURL = _portal.getPortalURL(
-					publicVirtualHostnames.firstKey(), secureSecurePort, true);
+					publicDefaultVirtualHostname, secureSecurePort, true);
 			}
 
 			if (_isDefaultGroup(group)) {
@@ -794,16 +794,15 @@ public class LayoutReferencesExportImportContentProcessor
 			return url;
 		}
 
-		LayoutSet publicLayoutSet = group.getPublicLayoutSet();
-
-		NavigableMap<String, String> publicLayoutSetVirtualHostnames =
-			publicLayoutSet.getVirtualHostnames();
+		String publicLayoutSetDefaultVirtualHostname =
+			_portal.getDefaultVirtualHostname(
+				false, group.getPublicLayoutSet());
 
 		String portalURL = StringPool.BLANK;
 
-		if (!publicLayoutSetVirtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(publicLayoutSetDefaultVirtualHostname)) {
 			portalURL = _portal.getPortalURL(
-				publicLayoutSetVirtualHostnames.firstKey(), serverPort, secure);
+				publicLayoutSetDefaultVirtualHostname, serverPort, secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {
@@ -817,15 +816,13 @@ public class LayoutReferencesExportImportContentProcessor
 			}
 		}
 
-		LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
+		String privateLayoutSetDefaultVirtualHostname =
+			_portal.getDefaultVirtualHostname(
+				false, group.getPrivateLayoutSet());
 
-		NavigableMap<String, String> privateLayoutSetVirtualHostnames =
-			privateLayoutSet.getVirtualHostnames();
-
-		if (!privateLayoutSetVirtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(privateLayoutSetDefaultVirtualHostname)) {
 			portalURL = _portal.getPortalURL(
-				privateLayoutSetVirtualHostnames.firstKey(), serverPort,
-				secure);
+				privateLayoutSetDefaultVirtualHostname, serverPort, secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -60,7 +60,6 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.NavigableMap;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -1044,12 +1043,9 @@ public class LayoutReferencesExportImportContentProcessorTest {
 			layoutSet = group.getPublicLayoutSet();
 		}
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
 		return _portal.getPortalURL(
-			virtualHostnames.firstKey(), _portal.getPortalServerPort(false),
-			false);
+			_portal.getDefaultVirtualHostname(false, layoutSet),
+			_portal.getPortalServerPort(false), false);
 	}
 
 	private static final String _CONTENT_POSTFIX = "\">link</a>";

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/util/ExportImportContentProcessorTestUtil.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/util/ExportImportContentProcessorTestUtil.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -145,14 +144,7 @@ public class ExportImportContentProcessorTestUtil {
 		}
 
 		LayoutSet sourcePrivateLayoutSet = sourceGroup.getPrivateLayoutSet();
-
-		NavigableMap<String, String> sourcePrivateVirtualHostnames =
-			sourcePrivateLayoutSet.getVirtualHostnames();
-
 		LayoutSet sourcePublicLayoutSet = sourceGroup.getPublicLayoutSet();
-
-		NavigableMap<String, String> sourcePublicVirtualHostnames =
-			sourcePublicLayoutSet.getVirtualHostnames();
 
 		String targetPublicLayoutFriendlyURL = "";
 		String targetPublicLayoutLocaleFriendlyURL = "";
@@ -214,8 +206,10 @@ public class ExportImportContentProcessorTestUtil {
 				String.valueOf(fileEntry.getGroupId()),
 				StringUtil.removeFirst(
 					sourceGroup.getFriendlyURL(), StringPool.SLASH),
-				sourcePrivateVirtualHostnames.firstKey(),
-				sourcePublicVirtualHostnames.firstKey(),
+				PortalUtil.getDefaultVirtualHostname(
+					false, sourcePrivateLayoutSet),
+				PortalUtil.getDefaultVirtualHostname(
+					false, sourcePublicLayoutSet),
 				String.valueOf(fileEntry.getFileEntryId()),
 				targetGroup.getFriendlyURL(),
 				String.valueOf(targetGroup.getGroupId()),

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1680,14 +1680,8 @@ public class LayoutsAdminDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		String virtualHostname = null;
-
-		NavigableMap<String, String> virtualHostnames =
-			PortalUtil.getVirtualHostnames(layoutSet);
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = PortalUtil.getDefaultVirtualHostname(
+			true, layoutSet);
 
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
@@ -1700,14 +1694,8 @@ public class LayoutsAdminDisplayContext {
 				liveGroupLayoutSet = liveGroup.getPrivateLayoutSet();
 			}
 
-			virtualHostname = null;
-
-			virtualHostnames = PortalUtil.getVirtualHostnames(
-				liveGroupLayoutSet);
-
-			if (!virtualHostnames.isEmpty()) {
-				virtualHostname = virtualHostnames.firstKey();
-			}
+			virtualHostname = PortalUtil.getDefaultVirtualHostname(
+				true, liveGroupLayoutSet);
 		}
 
 		return virtualHostname;

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/util/AlternateURLMapperProvider.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/util/AlternateURLMapperProvider.java
@@ -25,7 +25,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
 
 /**
@@ -159,14 +158,8 @@ public class AlternateURLMapperProvider {
 		}
 
 		private String _getPortalURL(ThemeDisplay themeDisplay) {
-			NavigableMap<String, String> virtualHostnames =
-				_portal.getVirtualHostnames(themeDisplay.getLayoutSet());
-
-			String virtualHostname = null;
-
-			if (!virtualHostnames.isEmpty()) {
-				virtualHostname = virtualHostnames.firstKey();
-			}
+			String virtualHostname = _portal.getDefaultVirtualHostname(
+				true, themeDisplay.getLayoutSet());
 
 			if (Validator.isNull(virtualHostname)) {
 				virtualHostname = "localhost";

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -65,7 +65,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -511,17 +510,17 @@ public class PortalImplAlternateURLTest {
 
 		LayoutSet layoutSet = group.getPublicLayoutSet();
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
+		String defaultVirtualHostname = _portal.getDefaultVirtualHostname(
+			false, layoutSet);
 
-		if (virtualHostnames.isEmpty()) {
+		if (Validator.isNull(defaultVirtualHostname)) {
 			return _generateLayoutURL(
 				defaultLocale, friendlyURL, _group.getFriendlyURL(), locale,
 				portalURL, portletPreferences);
 		}
 
 		return StringBundler.concat(
-			"http://", virtualHostnames.firstKey(), ":8080",
+			"http://", defaultVirtualHostname, ":8080",
 			_getI18nPath(defaultLocale, locale, portletPreferences),
 			friendlyURL);
 	}

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetDefaultVirtualHostnameTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetDefaultVirtualHostnameTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class PortalImplGetDefaultVirtualHostnameTest
+	extends BasePortalImplURLTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-90275")
+	public void testGetDefaultVirtualHostname() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"VIRTUAL_HOSTS_DEFAULT_SITE_NAME", group.getName())) {
+
+			_testGetDefaultVirtualHostname(false, StringPool.BLANK);
+
+			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+				group.getGroupId(), false);
+
+			String companyFallbackVirtualHostname =
+				layoutSet.getCompanyFallbackVirtualHostname();
+
+			Assert.assertNotNull(companyFallbackVirtualHostname);
+
+			_testGetDefaultVirtualHostname(
+				true, companyFallbackVirtualHostname);
+		}
+	}
+
+	private void _testGetDefaultVirtualHostname(
+			boolean companyFallback, String expectedDefaultVirtualHostname)
+		throws Exception {
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			group.getGroupId(), false);
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			new TreeMap<>());
+
+		Assert.assertEquals(
+			expectedDefaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				companyFallback,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+
+		String defaultVirtualHostname = "z-" + RandomTestUtil.randomString();
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				"a-" + RandomTestUtil.randomString(),
+				LocaleUtil.toLanguageId(LocaleUtil.US)
+			).put(
+				defaultVirtualHostname, StringPool.BLANK
+			).build());
+
+		Assert.assertEquals(
+			defaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				false,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				RandomTestUtil.randomString(),
+				LocaleUtil.toLanguageId(LocaleUtil.US)
+			).build());
+
+		Assert.assertEquals(
+			expectedDefaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				companyFallback,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+	}
+
+	@Inject
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Inject
+	private VirtualHostLocalService _virtualHostLocalService;
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -39,7 +38,6 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.NavigableMap;
 
 /**
  * @author Sarai Díaz
@@ -195,17 +193,10 @@ public class ExperimentUtil {
 			}
 		}
 
-		String virtualHostname = null;
+		String virtualHostname = portal.getDefaultVirtualHostname(
+			false, layout.getLayoutSet());
 
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
-		else {
+		if (Validator.isNull(virtualHostname)) {
 			Company company = companyLocalService.getCompany(
 				layout.getCompanyId());
 

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.CompanyInfo;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.model.cache.CacheField;
@@ -34,7 +33,6 @@ import com.liferay.portal.kernel.util.Validator;
 import java.security.Key;
 
 import java.util.Locale;
-import java.util.NavigableMap;
 import java.util.TimeZone;
 
 /**
@@ -190,27 +188,25 @@ public class CompanyImpl extends CompanyBaseImpl {
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 		if (group.hasPublicLayouts()) {
-			LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-				groupId, false);
+			String defaultVirtualHostname =
+				PortalUtil.getDefaultVirtualHostname(
+					false,
+					LayoutSetLocalServiceUtil.getLayoutSet(groupId, false));
 
-			NavigableMap<String, String> virtualHostnames =
-				layoutSet.getVirtualHostnames();
-
-			if (!virtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(defaultVirtualHostname)) {
 				portalURL = PortalUtil.getPortalURL(
-					virtualHostnames.firstKey(), portalServerPort, false);
+					defaultVirtualHostname, portalServerPort, false);
 			}
 		}
 		else if (group.hasPrivateLayouts()) {
-			LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-				groupId, true);
+			String defaultVirtualHostname =
+				PortalUtil.getDefaultVirtualHostname(
+					false,
+					LayoutSetLocalServiceUtil.getLayoutSet(groupId, true));
 
-			NavigableMap<String, String> virtualHostnames =
-				layoutSet.getVirtualHostnames();
-
-			if (!virtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(defaultVirtualHostname)) {
 				portalURL = PortalUtil.getPortalURL(
-					virtualHostnames.firstKey(), portalServerPort, false);
+					defaultVirtualHostname, portalServerPort, false);
 			}
 		}
 
@@ -230,15 +226,13 @@ public class CompanyImpl extends CompanyBaseImpl {
 			return portalURL;
 		}
 
-		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-			groupId, privateLayout);
+		String defaultVirtualHostname = PortalUtil.getDefaultVirtualHostname(
+			false,
+			LayoutSetLocalServiceUtil.getLayoutSet(groupId, privateLayout));
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(defaultVirtualHostname)) {
 			portalURL = PortalUtil.getPortalURL(
-				virtualHostnames.firstKey(), portalServerPort, false);
+				defaultVirtualHostname, portalServerPort, false);
 		}
 
 		return portalURL;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2920,8 +2920,8 @@ public class PortalImpl implements Portal {
 			String portalDomain = portalURL.substring(index + 3);
 
 			String virtualHostname = getCanonicalDomain(
-				virtualHostnames, portalDomain, defaultVirtualHostname,
-				layoutSet);
+				defaultVirtualHostname, layoutSet, portalDomain,
+				virtualHostnames);
 
 			virtualHostname = getPortalURL(
 				virtualHostname, portalPort, secureConnection);
@@ -6804,8 +6804,8 @@ public class PortalImpl implements Portal {
 	}
 
 	protected String getCanonicalDomain(
-		NavigableMap<String, String> virtualHostnames, String portalDomain,
-		String defaultVirtualHostname, LayoutSet layoutSet) {
+		String defaultVirtualHostname, LayoutSet layoutSet, String portalDomain,
+		NavigableMap<String, String> virtualHostnames) {
 
 		if (Validator.isBlank(portalDomain) ||
 			StringUtil.equalsIgnoreCase(portalDomain, defaultVirtualHostname) ||
@@ -7672,8 +7672,8 @@ public class PortalImpl implements Portal {
 						!virtualHostnames.containsKey(defaultVirtualHostname)) {
 
 						String virtualHostname = getCanonicalDomain(
-							virtualHostnames, portalDomain,
-							defaultVirtualHostname, layoutSet);
+							defaultVirtualHostname, layoutSet, portalDomain,
+							virtualHostnames);
 
 						portalURL = getPortalURL(
 							virtualHostname, themeDisplay.getServerPort(),

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1222,8 +1222,7 @@ public class PortalImpl implements Portal {
 		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
 			themeDisplay.getLayoutSet());
 
-		String virtualHostname = _getVirtualHostname(
-			virtualHostnames, themeDisplay);
+		String virtualHostname = _getVirtualHostname(themeDisplay);
 
 		if ((!Validator.isBlank(portalDomain) &&
 			 !StringUtil.equalsIgnoreCase(
@@ -2832,17 +2831,10 @@ public class PortalImpl implements Portal {
 			}
 		}
 
-		String virtualHostname = null;
+		String virtualHostname = getDefaultVirtualHostname(
+			false, layout.getLayoutSet());
 
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
-		else {
+		if (Validator.isNull(virtualHostname)) {
 			Company company = CompanyLocalServiceUtil.getCompany(
 				layout.getCompanyId());
 
@@ -2928,7 +2920,8 @@ public class PortalImpl implements Portal {
 			String portalDomain = portalURL.substring(index + 3);
 
 			String virtualHostname = getCanonicalDomain(
-				virtualHostnames, portalDomain, defaultVirtualHostname);
+				virtualHostnames, portalDomain, defaultVirtualHostname,
+				layoutSet);
 
 			virtualHostname = getPortalURL(
 				virtualHostname, portalPort, secureConnection);
@@ -2972,14 +2965,7 @@ public class PortalImpl implements Portal {
 		String defaultVirtualHostname = _getDefaultVirtualHostname(
 			themeDisplay.getCompany());
 
-		String virtualHostname = null;
-
-		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
-			layoutSet);
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = getDefaultVirtualHostname(true, layoutSet);
 
 		if (Validator.isNotNull(virtualHostname) &&
 			!StringUtil.equalsIgnoreCase(
@@ -6819,13 +6805,20 @@ public class PortalImpl implements Portal {
 
 	protected String getCanonicalDomain(
 		NavigableMap<String, String> virtualHostnames, String portalDomain,
-		String defaultVirtualHostname) {
+		String defaultVirtualHostname, LayoutSet layoutSet) {
 
 		if (Validator.isBlank(portalDomain) ||
 			StringUtil.equalsIgnoreCase(portalDomain, defaultVirtualHostname) ||
 			!virtualHostnames.containsKey(defaultVirtualHostname)) {
 
-			return virtualHostnames.firstKey();
+			String virtualHostname = getDefaultVirtualHostname(
+				false, layoutSet);
+
+			if (Validator.isNotNull(virtualHostname)) {
+				return virtualHostname;
+			}
+
+			return defaultVirtualHostname;
 		}
 
 		int pos = portalDomain.indexOf(CharPool.COLON);
@@ -7615,7 +7608,7 @@ public class PortalImpl implements Portal {
 								virtualHostnames, portalDomain)) {
 
 							portalURL = getPortalURL(
-								virtualHostnames.firstKey(),
+								getDefaultVirtualHostname(true, layoutSet),
 								themeDisplay.getServerPort(),
 								themeDisplay.isSecure());
 						}
@@ -7680,7 +7673,7 @@ public class PortalImpl implements Portal {
 
 						String virtualHostname = getCanonicalDomain(
 							virtualHostnames, portalDomain,
-							defaultVirtualHostname);
+							defaultVirtualHostname, layoutSet);
 
 						portalURL = getPortalURL(
 							virtualHostname, themeDisplay.getServerPort(),
@@ -8072,17 +8065,17 @@ public class PortalImpl implements Portal {
 		).build();
 	}
 
-	private String _getVirtualHostname(
-		NavigableMap<String, String> virtualHostnames,
-		ThemeDisplay themeDisplay) {
+	private String _getVirtualHostname(ThemeDisplay themeDisplay) {
+		String virtualHostname = getDefaultVirtualHostname(
+			true, themeDisplay.getLayoutSet());
 
-		if (virtualHostnames.isEmpty()) {
-			Company company = themeDisplay.getCompany();
-
-			return company.getVirtualHostname();
+		if (Validator.isNotNull(virtualHostname)) {
+			return virtualHostname;
 		}
 
-		return virtualHostnames.firstKey();
+		Company company = themeDisplay.getCompany();
+
+		return company.getVirtualHostname();
 	}
 
 	private boolean _isSignedIn(HttpServletRequest httpServletRequest) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2271,6 +2271,26 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
+	public String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet) {
+
+		NavigableMap<String, String> virtualHostnames =
+			layoutSet.getVirtualHostnames();
+
+		for (Map.Entry<String, String> entry : virtualHostnames.entrySet()) {
+			if (Validator.isNull(entry.getValue())) {
+				return entry.getKey();
+			}
+		}
+
+		if (companyFallback) {
+			return layoutSet.getCompanyFallbackVirtualHostname();
+		}
+
+		return StringPool.BLANK;
+	}
+
+	@Override
 	public String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue) {

--- a/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.util;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,8 +16,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
-
-import java.util.NavigableMap;
 
 /**
  * @author David Truong
@@ -45,14 +42,8 @@ public class RobotsUtil {
 
 		int portalServerPort = PortalUtil.getPortalServerPort(secure);
 
-		NavigableMap<String, String> virtualHostnames =
-			PortalUtil.getVirtualHostnames(layoutSet);
-
-		String virtualHostname = StringPool.BLANK;
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = GetterUtil.getString(
+			PortalUtil.getDefaultVirtualHostname(true, layoutSet));
 
 		String robotsTxt = null;
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 78.0.0
+version 79.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -571,6 +571,9 @@ public interface Portal {
 
 	public long getDefaultCompanyId();
 
+	public String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet);
+
 	public String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -773,6 +773,12 @@ public class PortalUtil {
 		return _portal.getDefaultCompanyId();
 	}
 
+	public static String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet) {
+
+		return _portal.getDefaultVirtualHostname(companyFallback, layoutSet);
+	}
+
 	public static String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue) {


### PR DESCRIPTION
## What

[LPD-90275](https://liferay.atlassian.net/browse/LPD-90275) — *Alternate URLs for languages without a Localized Virtual Host use the current page's Virtual Host instead of the Default Virtual Host*.

The reported alternate-URL symptom is one instance of a broader pattern across the portal. Many callers use `virtualHostnames.firstKey()` as a shortcut for "the default-language hostname". Because `LayoutSet#getVirtualHostnames()` returns a `NavigableMap` keyed by hostname (sorted alphabetically), `firstKey()` returns the alphabetically-first hostname rather than the entry whose value (language id) is the empty string.

For a site configured with `mysite.com -> ""`, `en.mysite.com -> en_US`, `es.mysite.com -> es_ES`, `firstKey()` returns `en.mysite.com` instead of `mysite.com`.

## Approach

Add `Portal#getDefaultVirtualHostname(boolean companyFallback, LayoutSet)` as the single lookup, and migrate every caller that picked the default this way. The boolean controls whether to fall back to the layout set's company fallback hostname when no default-language entry exists:

| Original code | Boolean |
| --- | --- |
| `layoutSet.getVirtualHostnames().firstKey()` (raw model map, no fallback) | `false` |
| `PortalUtil.getVirtualHostnames(layoutSet).firstKey()` (synthesizes `{companyFallback -> ""}` when the model map is empty) | `true` |

## Commits

1. **Add `Portal#getDefaultVirtualHostname`** — new API on `Portal`/`PortalUtil`/`PortalImpl`.
2. **Use `Portal#getDefaultVirtualHostname` instead of `NavigableMap#firstKey`** — migrates 14 production callsites across `CompanyImpl`, `RobotsUtil`, `PortalImpl` (×5), `LayoutReferencesExportImportContentProcessor` (×6), `LayoutsAdminDisplayContext` (×2), `AlternateURLMapperProvider`, and `ExperimentUtil` (DXP). The commit body details the boolean selection rule.
3. **Sort `getCanonicalDomain` parameters alphabetically** — parameter-order cleanup on the protected method.
4. **Use `Portal#getDefaultVirtualHostname` from tests** — migrates `LayoutReferencesExportImportContentProcessorTest`, `PortalImplAlternateURLTest`, and the `ExportImportContentProcessorTestUtil` helper.
5. **Add `PortalImplGetDefaultVirtualHostnameTest`** — covers the alphabetic-collision regression (default-language entry sorts last) plus the empty / language-specific-only / company-fallback matrix, parametrized over both boolean values.
6. **Baseline** — bumps `portal-impl/src/com/liferay/portal/util/packageinfo` from `78.0.0` to `79.0.0`. The commit body carries the `# breaking` section documenting the `getCanonicalDomain` signature change.

## Breaking change

The protected `PortalImpl#getCanonicalDomain` signature changed from

```
(NavigableMap<String, String> virtualHostnames, String portalDomain,
 String defaultVirtualHostname)
```

to

```
(String defaultVirtualHostname, LayoutSet layoutSet, String portalDomain,
 NavigableMap<String, String> virtualHostnames)
```

Subclasses overriding `getCanonicalDomain` must update their signature. The new `LayoutSet` parameter is what threads the default-language lookup through; the existing `virtualHostnames` parameter is retained because the original callers pass enriched maps (with the synthetic company-fallback entry) that `LayoutSet#getVirtualHostnames()` alone would not reproduce.

## Test plan

- [ ] `PortalImplGetDefaultVirtualHostnameTest` — regression case (default-language entry sorts after lang-specific ones) + behavior matrix.
- [ ] `PortalImplAlternateURLTest` — existing alternate-URL coverage routed through the new helper.
- [ ] `PortalImplCanonicalURLTest` — full canonical URL coverage.
- [ ] `LayoutReferencesExportImportContentProcessorTest` — export-import URL replacement routed through the new helper.
- [ ] `LayoutSEOLinkManagerCanonicalLayoutSEOLinkTest`, `LayoutSEOCanonicalURLProviderTest`, `EditSEOMVCActionCommandTest`, `OpenGraphTopHeadDynamicIncludeTest` — SEO canonical and alternate URL coverage.
- [ ] `LayoutSitemapURLProviderTest`, `SitemapManagerTest`, `BlogsEntryStatusTransitionTest` — sitemap and downstream URL generation.
- [ ] `LayoutsAdminDisplayContextTest`, `ExperimentUtilTest`, `PortalImplUnitTest`, `PortalImplGroupFriendlyURLTest`, `PortalImplEscapeRedirectTest` — unit coverage of the migrated callers.
- [ ] Manual: page with `mysite.com -> ""`, `en.mysite.com -> en_US`; navigate from `mysite.com`, verify the `<link rel="alternate" hreflang="en">` points to `en.mysite.com` (was returning the current host).
