### PR TITLE
LPD-90724 Reject cross-site redirect entry info panel reads

### DIFF
--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/web/internal/portlet/action/test/InfoPanelMVCResourceCommandTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/web/internal/portlet/action/test/InfoPanelMVCResourceCommandTest.java
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.redirect.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.redirect.model.RedirectEntry;
+import com.liferay.redirect.service.RedirectEntryLocalService;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class InfoPanelMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group1 = GroupTestUtil.addGroup();
+		_group2 = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.SITE_ADMINISTRATOR);
+	}
+
+	@Test
+	@TestInfo("LPD-90724")
+	public void testDoServeResourceWithRowIdsFromOtherGroup() throws Exception {
+		RedirectEntry redirectEntry =
+			_redirectEntryLocalService.addRedirectEntry(
+				_group2.getGroupId(), "destinationURL", null, false,
+				"sourceURL",
+				ServiceContextTestUtil.getServiceContext(_group2.getGroupId()));
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			Assert.assertThrows(
+				PrincipalException.class,
+				() -> ReflectionTestUtil.invoke(
+					_mvcResourceCommand, "doServeResource",
+					new Class<?>[] {
+						ResourceRequest.class, ResourceResponse.class
+					},
+					_getMockLiferayResourceRequest(
+						new long[] {redirectEntry.getRedirectEntryId()}),
+					new MockLiferayResourceResponse()));
+		}
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
+		long[] rowIds) {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setParameter(
+			"rowIds", StringUtil.merge(rowIds));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private Group _group1;
+	private Group _group2;
+
+	@Inject(filter = "mvc.command.name=/redirect/info_panel")
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private RedirectEntryLocalService _redirectEntryLocalService;
+
+	private User _user;
+
+}

--- a/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/InfoPanelMVCResourceCommand.java
+++ b/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/InfoPanelMVCResourceCommand.java
@@ -10,7 +10,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.redirect.model.RedirectEntry;
-import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.redirect.service.RedirectEntryService;
 import com.liferay.redirect.web.internal.constants.RedirectPortletKeys;
 import com.liferay.redirect.web.internal.display.context.RedirectEntryInfoPanelDisplayContext;
 
@@ -46,7 +46,7 @@ public class InfoPanelMVCResourceCommand extends BaseMVCResourceCommand {
 				ParamUtil.getLongValues(resourceRequest, "rowIds")) {
 
 			redirectEntries.add(
-				_redirectEntryLocalService.fetchRedirectEntry(redirectEntryId));
+				_redirectEntryService.fetchRedirectEntry(redirectEntryId));
 		}
 
 		resourceRequest.setAttribute(
@@ -62,6 +62,6 @@ public class InfoPanelMVCResourceCommand extends BaseMVCResourceCommand {
 	private Portal _portal;
 
 	@Reference
-	private RedirectEntryLocalService _redirectEntryLocalService;
+	private RedirectEntryService _redirectEntryService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90724

## What is being fixed

A user with Site Administrator access in one site could read another site's redirect entry details through the Redirection info panel. `InfoPanelMVCResourceCommand` resolved each submitted `rowIds` value through `RedirectEntryLocalService.fetchRedirectEntry`, which bypasses permission checks, so replaying the info panel request with another site's `redirectEntryId` rendered that entry's creator, type, create date, latest occurrence, and expiration date.

## How it is being fixed

The fetch now goes through `RedirectEntryService.fetchRedirectEntry`, which checks `VIEW` permission on the resolved entry's `groupId` and throws `PrincipalException.MustHavePermission` for an entry the current user cannot see. An integration test drives `InfoPanelMVCResourceCommand.doServeResource` directly, seeds a redirect entry in a second group, runs as a site administrator scoped to the first group, and asserts the cross-site read is rejected.