### PR TITLE
LPD-91115 Prevent Navigation Menus preview from blanking

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/components/PreviewModal.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/components/PreviewModal.js
@@ -22,8 +22,22 @@ export function PreviewModal({observer}) {
 
 	const displayTemplateSelectId = `${portletNamespace}-displayTemplateSelect`;
 
+	const effectiveDisplayTemplateOptions =
+		!!displayTemplateOptions.length &&
+		!displayTemplateOptions.some((option) => option.selected)
+			? [
+					{
+						label: Liferay.Language.get('default'),
+						selected: true,
+						value: '',
+					},
+					...displayTemplateOptions,
+				]
+			: displayTemplateOptions;
+
 	const [displayTemplateId, setDisplayTemplateId] = useState(
-		displayTemplateOptions.find((option) => option.selected).value
+		effectiveDisplayTemplateOptions.find((option) => option.selected)
+			?.value ?? ''
 	);
 
 	const [loading, setLoading] = useState(true);
@@ -47,19 +61,23 @@ export function PreviewModal({observer}) {
 
 			<ClayModal.Body className="site-navigation__preview-modal">
 				<ClayForm.Group className="h-100">
-					<label htmlFor={displayTemplateSelectId}>
-						{Liferay.Language.get('display-template')}
-					</label>
+					{!!effectiveDisplayTemplateOptions.length && (
+						<>
+							<label htmlFor={displayTemplateSelectId}>
+								{Liferay.Language.get('display-template')}
+							</label>
 
-					<ClaySelectWithOption
-						id={displayTemplateSelectId}
-						onChange={(event) => {
-							setDisplayTemplateId(event.target.value);
-							setLoading(true);
-						}}
-						options={displayTemplateOptions}
-						value={displayTemplateId}
-					/>
+							<ClaySelectWithOption
+								id={displayTemplateSelectId}
+								onChange={(event) => {
+									setDisplayTemplateId(event.target.value);
+									setLoading(true);
+								}}
+								options={effectiveDisplayTemplateOptions}
+								value={displayTemplateId}
+							/>
+						</>
+					)}
 
 					{loading && (
 						<div className="pt-4">

--- a/modules/apps/site-navigation/site-navigation-admin-web/test/site_navigation_menu_editor/components/PreviewModal.test.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/test/site_navigation_menu_editor/components/PreviewModal.test.js
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {PreviewModal} from '../../../src/main/resources/META-INF/resources/js/site_navigation_menu_editor/components/PreviewModal';
+import {ConstantsProvider} from '../../../src/main/resources/META-INF/resources/js/site_navigation_menu_editor/contexts/ConstantsContext';
+
+jest.mock('@clayui/modal', () => {
+	const ModalShell = ({children}) => (
+		<div data-testid="preview-modal">{children}</div>
+	);
+
+	ModalShell.Header = ({children}) => <div>{children}</div>;
+	ModalShell.Body = ({children}) => <div>{children}</div>;
+
+	return {
+		__esModule: true,
+		default: ModalShell,
+	};
+});
+
+jest.mock('frontend-js-web', () => ({
+	addParams: (params, url) =>
+		`${url}?${new URLSearchParams(params).toString()}`,
+}));
+
+function renderComponent({displayTemplateOptions = []} = {}) {
+	return render(
+		<ConstantsProvider
+			constants={{
+				displayTemplateOptions,
+				portletNamespace: '_test_',
+				previewSiteNavigationMenuURL: 'http://localhost/preview',
+			}}
+		>
+			<PreviewModal observer={{}} />
+		</ConstantsProvider>
+	);
+}
+
+describe('PreviewModal', () => {
+	beforeEach(() => {
+		global.Liferay = {
+			Language: {
+				get: jest.fn((key) => key),
+			},
+		};
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	// LPD-91115
+
+	it('renders the display-template select when options are provided', () => {
+		renderComponent({
+			displayTemplateOptions: [
+				{
+					label: 'List Menu',
+					selected: false,
+					value: 'list-menu-ftl',
+				},
+				{
+					label: 'Bar Minimally Styled',
+					selected: true,
+					value: 'navbar-blank-ftl',
+				},
+			],
+		});
+
+		expect(screen.getByLabelText('display-template')).toHaveValue(
+			'navbar-blank-ftl'
+		);
+	});
+
+	it('does not render the display-template select when options are empty', () => {
+		renderComponent({displayTemplateOptions: []});
+
+		expect(
+			screen.queryByLabelText('display-template')
+		).not.toBeInTheDocument();
+	});
+
+	it('prepends a blank option that renders the default template when no option is marked as selected', () => {
+		renderComponent({
+			displayTemplateOptions: [
+				{
+					label: 'Nav Pills',
+					selected: false,
+					value: 'nav-pills-ftl',
+				},
+			],
+		});
+
+		const select = screen.getByLabelText('display-template');
+
+		expect(select).toHaveValue('');
+
+		const options = Array.from(select.querySelectorAll('option'));
+
+		expect(options).toHaveLength(2);
+		expect(options[0]).toHaveValue('');
+		expect(options[0]).toHaveTextContent('default');
+		expect(options[1]).toHaveValue('nav-pills-ftl');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91115

## What is being fixed

When a user has no view permission on any Widget Template registered for the Navigation Menu, the preview modal crashed during mount with `TypeError: displayTemplateOptions.find(...) is undefined`, leaving the editor's preview region blank. The OOTB Navigation Menu Widget Templates live in the Global scope and are Owner-only by default, so any non-administrator role with Navigation Menu permissions hit this immediately.

## How it is being fixed

The `useState` initializer in `PreviewModal.js` now guards the `.find(...).value` chain with optional chaining, and the display-template dropdown is hidden when the server-filtered option list is empty. When the server returns options that include some viewable templates but none that match the configured default, a localized "Default" placeholder is prepended so the user can preview the default template (the server already falls back to it when `ddmTemplateKey` is blank) without exposing the actual default template's name. The Jest test in `PreviewModal.test.js` covers the three regression scenarios: populated options with a selected entry, the empty list, and the synthesized-default case.