### PR TITLE
LPD-91192 Skip orphan rows during site navigation menu item upgrade

### DIFF
--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
 
@@ -99,14 +100,15 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 								"groupId")));
 		}
 		else if (Objects.equals(type, JournalArticle.class.getName())) {
-			persistedModel = _journalArticleLocalService.getLatestArticle(
+			persistedModel = _journalArticleLocalService.fetchLatestArticle(
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 		}
 		else if (Objects.equals(type, KBArticle.class.getName())) {
-			persistedModel = _kbArticleLocalService.getLatestKBArticle(
+			persistedModel = _kbArticleLocalService.fetchLatestKBArticle(
 				GetterUtil.getLong(
-					typeSettingsUnicodeProperties.getProperty("classPK")));
+					typeSettingsUnicodeProperties.getProperty("classPK")),
+				WorkflowConstants.STATUS_ANY);
 		}
 		else if (Objects.equals(
 					type, SiteNavigationMenuItemTypeConstants.LAYOUT)) {
@@ -135,7 +137,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 				PersistedModelLocalServiceRegistryUtil.
 					getPersistedModelLocalService(className);
 
-			persistedModel = persistedModelLocalService.getPersistedModel(
+			persistedModel = persistedModelLocalService.fetchPersistedModel(
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 		}

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -74,7 +74,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 				getPersistedModelLocalService(className);
 
 		PersistedModel persistedModel =
-			persistedModelLocalService.getPersistedModel(
+			persistedModelLocalService.fetchPersistedModel(
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
 
@@ -77,14 +78,15 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 		PersistedModel persistedModel = null;
 
 		if (Objects.equals(type, JournalArticle.class.getName())) {
-			persistedModel = _journalArticleLocalService.getLatestArticle(
+			persistedModel = _journalArticleLocalService.fetchLatestArticle(
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 		}
 		else if (Objects.equals(type, KBArticle.class.getName())) {
-			persistedModel = _kbArticleLocalService.getLatestKBArticle(
+			persistedModel = _kbArticleLocalService.fetchLatestKBArticle(
 				GetterUtil.getLong(
-					typeSettingsUnicodeProperties.getProperty("classPK")));
+					typeSettingsUnicodeProperties.getProperty("classPK")),
+				WorkflowConstants.STATUS_ANY);
 		}
 		else {
 			if (className.equals(FileEntry.class.getName())) {
@@ -98,7 +100,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 				PersistedModelLocalServiceRegistryUtil.
 					getPersistedModelLocalService(className);
 
-			persistedModel = persistedModelLocalService.getPersistedModel(
+			persistedModel = persistedModelLocalService.fetchPersistedModel(
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 		}

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
@@ -261,6 +261,36 @@ public class SiteNavigationMenuItemUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeWithNonexistentJournalArticle() throws Exception {
+		SiteNavigationMenuItem siteNavigationMenuItem =
+			_addSiteNavigationMenuItem(
+				JournalArticle.class.getName(),
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"className", JournalArticle.class.getName()
+				).put(
+					"classPK", RandomTestUtil.randomLong()
+				).put(
+					"type", JournalArticle.class.getName()
+				).buildString());
+
+		_runUpgrade();
+
+		siteNavigationMenuItem =
+			_siteNavigationMenuItemLocalService.getSiteNavigationMenuItem(
+				siteNavigationMenuItem.getSiteNavigationMenuItemId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		Assert.assertNull(
+			typeSettingsUnicodeProperties.get("externalReferenceCode"));
+	}
+
+	@Test
 	public void testUpgradeWithObjectEntry() throws Exception {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.addCustomObjectDefinition(

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
@@ -271,6 +271,42 @@ public class SiteNavigationMenuItemUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeWithNonexistentJournalArticle() throws Exception {
+		SiteNavigationMenuItem siteNavigationMenuItem =
+			_addSiteNavigationMenuItem(
+				JournalArticle.class.getName(),
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"classNameId",
+					_classNameLocalService.getClassNameId(JournalArticle.class)
+				).put(
+					"classPK", RandomTestUtil.randomLong()
+				).put(
+					"classTypeId", RandomTestUtil.randomLong()
+				).put(
+					"type", JournalArticle.class.getName()
+				).buildString());
+
+		_runUpgrade();
+
+		siteNavigationMenuItem =
+			_siteNavigationMenuItemLocalService.getSiteNavigationMenuItem(
+				siteNavigationMenuItem.getSiteNavigationMenuItemId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		Assert.assertEquals(
+			JournalArticle.class.getName(),
+			typeSettingsUnicodeProperties.get("className"));
+		Assert.assertNull(
+			typeSettingsUnicodeProperties.get("externalReferenceCode"));
+	}
+
+	@Test
 	public void testUpgradeWithObjectEntry() throws Exception {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.addCustomObjectDefinition(

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/test/SiteNavigationMenuItemUpgradeProcessTest.java
@@ -554,6 +554,29 @@ public class SiteNavigationMenuItemUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeWithNonexistentJournalArticle() throws Exception {
+		SiteNavigationMenuItem siteNavigationMenuItem =
+			_addSiteNavigationMenuItem(
+				JournalArticle.class.getName(),
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"className", JournalArticle.class.getName()
+				).put(
+					"classPK", RandomTestUtil.randomLong()
+				).put(
+					"externalReferenceCode", RandomTestUtil.randomString()
+				).put(
+					"type", JournalArticle.class.getName()
+				).buildString());
+
+		_runUpgrade();
+
+		_assertNavigationMenuItemFromSameGroup(
+			siteNavigationMenuItem.getSiteNavigationMenuItemId());
+	}
+
+	@Test
 	public void testUpgradeWithSiteScopedObjectEntry() throws Exception {
 		ObjectDefinition siteScopedObjectDefinition =
 			_objectDefinitionLocalService.addCustomObjectDefinition(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91192

## What is being fixed

When a `SiteNavigationMenuItem` references a `JournalArticle`, `KBArticle`, or any other persisted model whose row has been deleted, the upgrade from `site-navigation-service` 2.5.0 to 5.0.0 aborts mid-batch with `NoSuchModelException`. The instance fails to start and subsequent restarts re-fail at the same row until the bad data is patched by hand — LPP-63412 needed exactly this manual cleanup.

## How it is being fixed

The `JournalArticle`, `KBArticle`, and generic `PersistedModel` branches in `v3_0_0`, `v4_0_0`, and `v5_0_0` of `SiteNavigationMenuItemUpgradeProcess` were calling `get*` lookups that throw on miss. The surrounding `if (persistedModel == null) return;` check showed the loop was meant to tolerate orphans — but only the sibling `AssetVocabulary` and `Layout` branches (using `fetch*`) could reach it. Switching the throwing lookups to their `fetch*` counterparts makes that null check load-bearing for every branch and matches the runtime UI, which already renders orphan menu items with a "this item references a page that is missing or not yet available" tooltip rather than treating them as a data-integrity emergency.

Tests in `site-navigation-test` pin the orphan-row scenario for the `JournalArticle` path on each upgrade version so the regression cannot recur.