### PR TITLE
LPD-91205 Fix breadcrumb href to point at the level URL, not the menu name

### DIFF
--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SelectSiteNavigationMenuDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SelectSiteNavigationMenuDisplayContext.java
@@ -539,7 +539,7 @@ public class SelectSiteNavigationMenuDisplayContext {
 					selectSiteNavigationMenuLevelURL != null);
 
 				breadcrumbEntry.setTitle(siteNavigationMenu.getName());
-				breadcrumbEntry.setURL(siteNavigationMenu.getName());
+				breadcrumbEntry.setURL(selectSiteNavigationMenuLevelURL);
 			}
 		).addAll(
 			() -> getParentSiteNavigationMenuItemId() != 0,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91205

## What is being fixed

In the navigation-menu item-selector, the breadcrumb at the menu-level screen rendered the menu's name in the anchor's `href` attribute instead of the URL that drills back into the menu. The breadcrumb link did not navigate anywhere useful and placed user-supplied free text in a position where structured HTML is expected.

## How it is being fixed

The `_getSiteNavigationMenuBreadcrumbEntries` call assigned `siteNavigationMenu.getName()` to both `setTitle` and `setURL`. The intended URL — `selectSiteNavigationMenuLevelURL` — was already computed for the `setBrowsable` call on the line immediately above. The fix passes that local to `setURL`. The regression dates to the LPS-200720 refactor that hoisted the URL into a local; every other refactored call site in that commit used the local correctly, this one slipped.

## Why are there no tests?

The fix is a one-line correction of a copy-paste typo introduced during a refactor. A test would require standing up `SelectSiteNavigationMenuDisplayContext` with a fake `HttpServletRequest` and `ItemSelectorCriterion` — heavyweight setup whose intended behavior is already documented by the four sibling call sites that pass `selectSiteNavigationMenuLevelURL` correctly.