### PR TITLE
LPD-91396 Handle missing scope group in Asset Vocabulary menu item

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -42,6 +43,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -77,6 +79,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Lourdes Fernández Besada
@@ -865,6 +868,65 @@ public class AssetVocabularySiteNavigationMenuItemTypeTest {
 
 		Assert.assertFalse(
 			siteNavigationMenuItemType.isBrowsable(siteNavigationMenuItem));
+	}
+
+	@Test
+	public void testRenderEditPageWithDeletedScopeGroup() throws Exception {
+		Group scopeGroup = GroupTestUtil.addGroup();
+
+		ServiceContext scopeServiceContext =
+			ServiceContextTestUtil.getServiceContext(
+				scopeGroup.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary scopeAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), scopeGroup.getGroupId(),
+				RandomTestUtil.randomString(), scopeServiceContext);
+
+		SiteNavigationMenu siteNavigationMenu =
+			_siteNavigationMenuLocalService.addSiteNavigationMenu(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				SiteNavigationConstants.TYPE_DEFAULT, true, _serviceContext);
+
+		SiteNavigationMenuItem siteNavigationMenuItem =
+			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				siteNavigationMenu.getSiteNavigationMenuId(), 0,
+				SiteNavigationMenuItemTypeConstants.ASSET_VOCABULARY,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"externalReferenceCode",
+					scopeAssetVocabulary.getExternalReferenceCode()
+				).put(
+					"scopeExternalReferenceCode",
+					scopeGroup.getExternalReferenceCode()
+				).put(
+					"title", scopeAssetVocabulary.getTitle()
+				).put(
+					"type", "asset-vocabulary"
+				).buildString(),
+				_serviceContext);
+
+		_groupLocalService.deleteGroup(scopeGroup);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		SiteNavigationMenuItemType siteNavigationMenuItemType =
+			_siteNavigationMenuItemTypeRegistry.getSiteNavigationMenuItemType(
+				SiteNavigationMenuItemTypeConstants.ASSET_VOCABULARY);
+
+		siteNavigationMenuItemType.renderEditPage(
+			mockHttpServletRequest, new MockHttpServletResponse(),
+			siteNavigationMenuItem);
 	}
 
 	private AssetCategory _addAssetCategory(long parentAssetCategoryId)

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/display/context/AssetVocabularySiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/display/context/AssetVocabularySiteNavigationMenuTypeDisplayContext.java
@@ -77,11 +77,17 @@ public class AssetVocabularySiteNavigationMenuTypeDisplayContext {
 				scopeExternalReferenceCode, _themeDisplay.getCompanyId());
 		}
 
-		_assetVocabulary =
-			AssetVocabularyLocalServiceUtil.
-				fetchAssetVocabularyByExternalReferenceCode(
-					_typeSettingsUnicodeProperties.get("externalReferenceCode"),
-					group.getGroupId());
+		if (group == null) {
+			_assetVocabulary = null;
+		}
+		else {
+			_assetVocabulary =
+				AssetVocabularyLocalServiceUtil.
+					fetchAssetVocabularyByExternalReferenceCode(
+						_typeSettingsUnicodeProperties.get(
+							"externalReferenceCode"),
+						group.getGroupId());
+		}
 	}
 
 	public Map<String, Object> getAssetVocabularyContextualSidebarContext()
@@ -179,7 +185,7 @@ public class AssetVocabularySiteNavigationMenuTypeDisplayContext {
 
 				if (scopeExternalReferenceCode != null) {
 					group =
-						GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+						GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
 							scopeExternalReferenceCode,
 							_themeDisplay.getCompanyId());
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91396

## What is being fixed

Opening an Asset Vocabulary navigation menu item whose referenced scope group has been deleted throws a `NullPointerException` and the edit page fails to render.

## How it is being fixed

The display context constructor at `AssetVocabularySiteNavigationMenuTypeDisplayContext.java:84` dereferenced the result of `fetchGroupByExternalReferenceCode` without a null check; it now leaves `_assetVocabulary` null when the group cannot be resolved, and the existing null handling in the sidebar lambdas (`title`, `numberOfCategories`) renders the saved type-settings fallback. The `siteName` lambda further down was calling the throwing `getGroupByExternalReferenceCode`, which made the immediately following `if (group == null)` branch dead code; switching it to `fetchGroupByExternalReferenceCode` makes the existing `unable-to-find-x` placeholder reachable. Both fixes mirror the patterns already in use in the analogous `DisplayPageTypeSiteNavigationMenu*` code.