### PR TITLE
LPD-91657 Delete orphaned workflow tasks when discarding a CTEntry

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.WorkflowedModel;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexable;
@@ -84,6 +85,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
@@ -1231,6 +1233,43 @@ public class CTCollectionLocalServiceImpl
 
 		CTService<?> ctService = _ctServiceRegistry.getCTService(classNameId);
 
+		Class<?> modelClass = ctService.getModelClass();
+
+		Map<Long, Long> groupIdByClassPK = Collections.emptyMap();
+
+		if (WorkflowedModel.class.isAssignableFrom(modelClass) &&
+			GroupedModel.class.isAssignableFrom(modelClass)) {
+
+			groupIdByClassPK = new HashMap<>();
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollection.getCtCollectionId())) {
+
+				CTPersistence<?> ctPersistence = ctService.getCTPersistence();
+
+				for (CTEntry ctEntry : ctEntries) {
+					Object model = ctPersistence.fetchByPrimaryKey(
+						ctEntry.getModelClassPK());
+
+					if (!(model instanceof WorkflowedModel)) {
+						continue;
+					}
+
+					WorkflowedModel workflowedModel = (WorkflowedModel)model;
+
+					if (workflowedModel.isDraft()) {
+						continue;
+					}
+
+					GroupedModel groupedModel = (GroupedModel)model;
+
+					groupIdByClassPK.put(
+						ctEntry.getModelClassPK(), groupedModel.getGroupId());
+				}
+			}
+		}
+
 		ctService.updateWithUnsafeFunction(
 			ctPersistence -> {
 				Set<String> primaryKeyNames = ctPersistence.getCTColumnNames(
@@ -1291,8 +1330,23 @@ public class CTCollectionLocalServiceImpl
 			processedClassPKs += batchSize;
 		}
 
-		Indexer<?> indexer = _indexerRegistry.getIndexer(
-			ctService.getModelClass());
+		if (!groupIdByClassPK.isEmpty()) {
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollection.getCtCollectionId())) {
+
+				for (Map.Entry<Long, Long> entry :
+						groupIdByClassPK.entrySet()) {
+
+					_workflowInstanceLinkLocalService.
+						deleteWorkflowInstanceLink(
+							ctCollection.getCompanyId(), entry.getValue(),
+							modelClass.getName(), entry.getKey());
+				}
+			}
+		}
+
+		Indexer<?> indexer = _indexerRegistry.getIndexer(modelClass);
 
 		if (indexer != null) {
 			TransactionCommitCallbackUtil.registerCallback(
@@ -1736,5 +1790,8 @@ public class CTCollectionLocalServiceImpl
 	@Reference
 	private WorkflowDefinitionLinkLocalService
 		_workflowDefinitionLinkLocalService;
+
+	@Reference
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
 
 }

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionLocalServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionLocalServiceTest.java
@@ -30,9 +30,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -497,6 +500,59 @@ public class CTCollectionLocalServiceTest {
 	}
 
 	@Test
+	public void testDiscardCTEntry() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				_group.getGroupId(), JournalFolder.class.getName(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.DDM_STRUCTURE_ID_ALL, "Single Approver",
+				1);
+
+		try {
+			JournalArticle journalArticle;
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_ctCollection1.getCtCollectionId())) {
+
+				journalArticle = JournalTestUtil.addArticleWithWorkflow(
+					_group.getGroupId(),
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, false);
+
+				Assert.assertEquals(
+					WorkflowConstants.STATUS_PENDING,
+					journalArticle.getStatus());
+
+				Assert.assertNotNull(
+					_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+						TestPropsValues.getCompanyId(), _group.getGroupId(),
+						JournalArticle.class.getName(),
+						journalArticle.getId()));
+			}
+
+			_ctCollectionLocalService.discardCTEntry(
+				_ctCollection1.getCtCollectionId(), _journalArticleClassNameId,
+				journalArticle.getId(), false);
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_ctCollection1.getCtCollectionId())) {
+
+				Assert.assertNull(
+					_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+						TestPropsValues.getCompanyId(), _group.getGroupId(),
+						JournalArticle.class.getName(),
+						journalArticle.getId()));
+			}
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	@Test
 	public void testMoveCTEntryFromExpiredCTCollection() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
@@ -753,5 +809,12 @@ public class CTCollectionLocalServiceTest {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
 
 }


### PR DESCRIPTION
## Summary

- When a CTEntry is discarded, its associated `WorkflowInstanceLink` was not removed, leaving an orphaned task in My Workflow Tasks.
- Root cause: `WorkflowInstanceLink` uses a polymorphic `classNameId/classPK` reference that the CT closure builder cannot traverse — it is never pulled into the discard set.
- Fix: in `CTCollectionLocalServiceImpl._discardCTEntries()`, capture the `groupId` for every non-draft `WorkflowedModel+GroupedModel` CTEntry being discarded, then call `deleteWorkflowInstanceLink` in the CT collection context after the CT rows are removed. Running inside the CT context triggers `CTPersistenceHelperImpl.onBeforeRemove()`'s undo-addition path, which cleans up both the CT row and the `CTEntry`.

## Test plan

- [ ] Deploy `change-tracking-service` and `change-tracking-test`.
- [ ] Run `testDiscardCTEntry` in `CTCollectionLocalServiceTest`.