### PR TITLE
LPD-91657 Delete orphaned workflow tasks when discarding a CTEntry

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -60,6 +60,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
+import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -72,6 +73,9 @@ import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.model.WorkflowInstanceLinkTable;
+import com.liferay.portal.kernel.model.WorkflowedModel;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexable;
@@ -84,6 +88,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
@@ -780,6 +785,75 @@ public class CTCollectionLocalServiceImpl
 			}
 		}
 
+		long workflowInstanceLinkClassNameId =
+			_classNameLocalService.getClassNameId(WorkflowInstanceLink.class);
+
+		Map<Long, List<CTEntry>> workflowRelatedCTEntriesMap = new HashMap<>();
+
+		try (SafeCloseable safeCloseable1 =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId);
+			SafeCloseable safeCloseable2 =
+				CTSQLModeThreadLocal.setCTSQLModeWithSafeCloseable(
+					CTSQLModeThreadLocal.CTSQLMode.CT_ONLY)) {
+
+			for (Map.Entry<Long, List<CTEntry>> entry :
+					relatedCTEntriesMap.entrySet()) {
+
+				CTService<?> ctService = _ctServiceRegistry.getCTService(
+					entry.getKey());
+
+				if ((ctService == null) ||
+					!WorkflowedModel.class.isAssignableFrom(
+						ctService.getModelClass()) ||
+					ListUtil.isEmpty(entry.getValue())) {
+
+					continue;
+				}
+
+				List<Long> workflowInstanceLinkIds =
+					_workflowInstanceLinkLocalService.dslQuery(
+						DSLQueryFactoryUtil.select(
+							WorkflowInstanceLinkTable.INSTANCE.
+								workflowInstanceLinkId
+						).from(
+							WorkflowInstanceLinkTable.INSTANCE
+						).where(
+							WorkflowInstanceLinkTable.INSTANCE.companyId.eq(
+								ctCollection.getCompanyId()
+							).and(
+								WorkflowInstanceLinkTable.INSTANCE.classNameId.
+									eq(
+										entry.getKey()
+									).and(
+										WorkflowInstanceLinkTable.INSTANCE.
+											classPK.in(
+												TransformUtil.transformToArray(
+													entry.getValue(),
+													CTEntry::getModelClassPK,
+													Long.class))
+									)
+							)
+						));
+
+				for (long workflowInstanceLinkId : workflowInstanceLinkIds) {
+					_getRelatedCTEntriesMap(
+						ctCollection, workflowInstanceLinkClassNameId,
+						workflowInstanceLinkId
+					).forEach(
+						(key, value) -> workflowRelatedCTEntriesMap.merge(
+							key, value,
+							(value1, value2) -> ListUtil.concat(value1, value2))
+					);
+				}
+			}
+		}
+
+		workflowRelatedCTEntriesMap.forEach(
+			(key, value) -> relatedCTEntriesMap.merge(
+				key, value,
+				(value1, value2) -> ListUtil.concat(value1, value2)));
+
 		return relatedCTEntriesMap;
 	}
 
@@ -1231,6 +1305,8 @@ public class CTCollectionLocalServiceImpl
 
 		CTService<?> ctService = _ctServiceRegistry.getCTService(classNameId);
 
+		Class<?> modelClass = ctService.getModelClass();
+
 		ctService.updateWithUnsafeFunction(
 			ctPersistence -> {
 				Set<String> primaryKeyNames = ctPersistence.getCTColumnNames(
@@ -1291,8 +1367,7 @@ public class CTCollectionLocalServiceImpl
 			processedClassPKs += batchSize;
 		}
 
-		Indexer<?> indexer = _indexerRegistry.getIndexer(
-			ctService.getModelClass());
+		Indexer<?> indexer = _indexerRegistry.getIndexer(modelClass);
 
 		if (indexer != null) {
 			TransactionCommitCallbackUtil.registerCallback(
@@ -1736,5 +1811,8 @@ public class CTCollectionLocalServiceImpl
 	@Reference
 	private WorkflowDefinitionLinkLocalService
 		_workflowDefinitionLinkLocalService;
+
+	@Reference
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
 
 }

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionLocalServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionLocalServiceTest.java
@@ -30,9 +30,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -497,6 +500,59 @@ public class CTCollectionLocalServiceTest {
 	}
 
 	@Test
+	public void testDiscardCTEntry() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				_group.getGroupId(), JournalFolder.class.getName(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.DDM_STRUCTURE_ID_ALL, "Single Approver",
+				1);
+
+		try {
+			JournalArticle journalArticle;
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_ctCollection1.getCtCollectionId())) {
+
+				journalArticle = JournalTestUtil.addArticleWithWorkflow(
+					_group.getGroupId(),
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, true);
+
+				Assert.assertEquals(
+					WorkflowConstants.STATUS_PENDING,
+					journalArticle.getStatus());
+
+				Assert.assertNotNull(
+					_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+						TestPropsValues.getCompanyId(), _group.getGroupId(),
+						JournalArticle.class.getName(),
+						journalArticle.getId()));
+			}
+
+			_ctCollectionLocalService.discardCTEntry(
+				_ctCollection1.getCtCollectionId(), _journalArticleClassNameId,
+				journalArticle.getId(), false);
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_ctCollection1.getCtCollectionId())) {
+
+				Assert.assertNull(
+					_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+						TestPropsValues.getCompanyId(), _group.getGroupId(),
+						JournalArticle.class.getName(),
+						journalArticle.getId()));
+			}
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	@Test
 	public void testMoveCTEntryFromExpiredCTCollection() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
@@ -753,5 +809,12 @@ public class CTCollectionLocalServiceTest {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
 
 }

--- a/modules/apps/journal/journal-service/build.gradle
+++ b/modules/apps/journal/journal-service/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-dynamic-data-mapping-form-field-type-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
+	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")
 	compileOnly project(":apps:portal-search:portal-search-api")

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/reference/JournalArticleTableReferenceDefinition.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/reference/JournalArticleTableReferenceDefinition.java
@@ -21,6 +21,7 @@ import com.liferay.journal.model.JournalArticleResourceTable;
 import com.liferay.journal.model.JournalArticleTable;
 import com.liferay.journal.model.JournalFolderTable;
 import com.liferay.journal.service.persistence.JournalArticlePersistence;
+import com.liferay.message.boards.model.MBDiscussionTable;
 import com.liferay.portal.kernel.model.ClassNameTable;
 import com.liferay.portal.kernel.model.ImageTable;
 import com.liferay.portal.kernel.model.LayoutTable;
@@ -50,6 +51,9 @@ public class JournalArticleTableReferenceDefinition
 		).classNameReference(
 			JournalArticleTable.INSTANCE.id,
 			DDMTemplateLinkTable.INSTANCE.classPK, JournalArticle.class
+		).classNameReference(
+			JournalArticleTable.INSTANCE.id, MBDiscussionTable.INSTANCE.classPK,
+			JournalArticle.class
 		).classNameReference(
 			JournalArticleTable.INSTANCE.resourcePrimKey,
 			TranslationEntryTable.INSTANCE.classPK, JournalArticle.class

--- a/modules/apps/journal/journal-test/build.gradle
+++ b/modules/apps/journal/journal-test/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-seo-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:message-boards:message-boards-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/change/tracking/test/JournalArticleTableReferenceDefinitionTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/change/tracking/test/JournalArticleTableReferenceDefinitionTest.java
@@ -10,9 +10,13 @@ import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCas
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -47,12 +51,24 @@ public class JournalArticleTableReferenceDefinitionTest
 
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
-		return JournalTestUtil.updateArticle(
+		JournalArticle journalArticle = JournalTestUtil.updateArticle(
 			_journalArticle, _journalArticle.getTitleMap(),
 			_journalArticle.getContent(), false, false,
 			ServiceContextTestUtil.getServiceContext());
+
+		_mbMessageLocalService.addDiscussionMessage(
+			TestPropsValues.getUserId(),
+			TestPropsValues.getUser(
+			).getFullName(),
+			journalArticle.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getId(), WorkflowConstants.ACTION_PUBLISH);
+
+		return journalArticle;
 	}
 
 	private JournalArticle _journalArticle;
+
+	@Inject
+	private MBMessageLocalService _mbMessageLocalService;
 
 }


### PR DESCRIPTION
## Summary

### Root cause
When a JournalArticle is created inside a CT collection with a workflow enabled, the workflow engine creates a WorkflowInstanceLink (and the associated Kaleo tables) as CT entries. These were not included in the CT closure when discarding the article, so they were left orphaned.

### Fix
  1. JournalArticleTableReferenceDefinition — declared MBDiscussion as a child table reference of JournalArticle (via classNameId/classPK). This ensures discussions created when viewing a workflow task are included in the CT closure and discarded alongside the article.
  2. CTCollectionLocalServiceImpl.getRelatedCTEntriesMap — after the standard closure traversal, added a pass that finds WorkflowInstanceLink CT entries for any `WorkflowedModel` + `GroupedModel` entry in the closure. Since WorkflowInstanceLink references entities dynamically (not via a static column the closure can follow), it must be found explicitly. Once found, its subtree (KaleoInstance and all downstream Kaleo tables) is added to the related entries map via `_getRelatedCTEntriesMap`, so the standard discard mechanism handles cleanup without any service-layer calls.

## Test plan

- [ ] Deploy `change-tracking-service` and run `CTCollectionLocalServiceTest.testDiscardCTEntry` in `change-tracking-test`
- [ ] Deploy `journal-service` and run `JournalArticleTableReferenceDefinitionTest` in `journal-test`
