### PR TITLE
LPD-90505 Connect Sitemap generation to DLStore for XML storage and retrieval

### DIFF
--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.xml.Element;
 
+import java.io.InputStream;
+
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -62,6 +64,11 @@ public interface SitemapManager {
 	public String getSitemap(
 			String assetType, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
 		throws PortalException;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -51,6 +51,12 @@ import com.liferay.site.configuration.manager.SitemapConfigurationManager;
 import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.site.provider.SitemapURLProvider;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
 
 import java.text.DateFormat;
 
@@ -283,6 +289,47 @@ public class SitemapManagerImpl implements SitemapManager {
 		return _getSitemap(layoutUuid, groupId, privateLayout, themeDisplay);
 	}
 
+	@Override
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+		throws PortalException {
+
+		long companyId = themeDisplay.getCompanyId();
+
+		if (_sitemapConfigurationManager.xmlSitemapIndexCompanyEnabled(
+				companyId) &&
+			StringUtil.equals(
+				_sitemapConfigurationManager.xmlSitemapIndexMode(companyId),
+				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				if (assetTypeKey == null) {
+					return _sitemapStorageHelper.getSitemapInputStream(
+						companyId, groupId);
+				}
+
+				return _sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+			}
+		}
+
+		String xml = getSitemap(
+			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			privateLayout, themeDisplay);
+
+		if (xml == null) {
+			return null;
+		}
+
+		return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
@@ -359,7 +406,20 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				themeDisplay.getCompanyId(), groupId,
+				_assetTypeKeys.get(assetType), 1, xml);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return xml;
 	}
 
 	private String _getFriendlyURL(String path, long groupId) {
@@ -429,10 +489,12 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		String xmlSitemapIndexMode =
+			_sitemapConfigurationManager.xmlSitemapIndexMode(
+				themeDisplay.getCompanyId());
+
 		if (StringUtil.equals(
-				_sitemapConfigurationManager.xmlSitemapIndexMode(
-					themeDisplay.getCompanyId()),
-				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			String portalURL = themeDisplay.getPortalURL();
 
@@ -484,7 +546,23 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		if (StringUtil.equals(
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				_sitemapStorageHelper.storeSitemapFile(
+					themeDisplay.getCompanyId(), groupId, xml);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(exception);
+				}
+			}
+		}
+
+		return xml;
 	}
 
 	private List<LayoutSet> _getLayoutSets(
@@ -828,5 +906,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private SitemapConfigurationManager _sitemapConfigurationManager;
+
+	@Reference
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.internal.struts;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutSetException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -32,6 +31,8 @@ import com.liferay.site.manager.SitemapManager;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -112,35 +113,26 @@ public class SitemapStrutsAction implements StrutsAction {
 			Group currentGroup = _groupLocalService.getGroup(
 				layoutSet.getGroupId());
 
-			if (currentGroup.isActive()) {
-				String assetTypeKey = ParamUtil.getString(
-					httpServletRequest, "assetTypeKey");
-
-				String assetTypeClassName =
-					_sitemapManager.getAssetTypeClassName(assetTypeKey);
-
-				String layoutUuid = ParamUtil.getString(
-					httpServletRequest, "layoutUuid");
-
-				String sitemap = _sitemapManager.getSitemap(
-					assetTypeClassName, layoutUuid, layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout(), themeDisplay);
-
-				if (sitemap == null) {
-					httpServletResponse.sendError(
-						HttpServletResponse.SC_NOT_FOUND);
-
-					return null;
-				}
-
-				ServletResponseUtil.sendFile(
-					httpServletRequest, httpServletResponse, null,
-					sitemap.getBytes(StringPool.UTF8),
-					ContentTypes.TEXT_XML_UTF8);
-			}
-			else {
+			if (!currentGroup.isActive()) {
 				throw new NoSuchLayoutSetException();
 			}
+
+			InputStream inputStream = _sitemapManager.getSitemapInputStream(
+				ParamUtil.getString(httpServletRequest, "assetTypeKey"),
+				ParamUtil.getString(httpServletRequest, "layoutUuid"),
+				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
+				themeDisplay,
+				ParamUtil.getInteger(httpServletRequest, "page", 1));
+
+			if (inputStream == null) {
+				httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+				return null;
+			}
+
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, null, inputStream,
+				ContentTypes.TEXT_XML_UTF8);
 		}
 		catch (NoSuchLayoutSetException noSuchLayoutSetException) {
 			_portal.sendError(

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
@@ -6,25 +6,60 @@
 package com.liferay.site.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.constants.SitemapConstants;
+import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +77,48 @@ public class SitemapStrutsActionTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_companyConfigurationTemporarySwapper =
+			new CompanyConfigurationTemporarySwapper(
+				TestPropsValues.getCompanyId(),
+				_PID_SITEMAP_COMPANY_CONFIGURATION,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"xmlSitemapIndexEnabled", true
+				).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_companyConfigurationTemporarySwapper.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
+	}
 
 	@Test
 	public void testExecute() throws Exception {
@@ -69,12 +145,9 @@ public class SitemapStrutsActionTest {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		Company company = _companyLocalService.getCompany(
-			TestPropsValues.getCompanyId());
-
-		themeDisplay.setCompany(company);
+		themeDisplay.setCompany(_company);
 		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(company.getGuestUser()));
+			PermissionCheckerFactoryUtil.create(_company.getGuestUser()));
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -101,13 +174,249 @@ public class SitemapStrutsActionTest {
 		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
 	}
 
+	@Test
+	public void testExecuteReturnsSitemapIndexXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("sitemapindex", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteReturnsWebContentSitemapXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Map<String, String> assetTypeKeys =
+				_sitemapManager.getAssetTypeKeys();
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				assetTypeKeys.get(JournalArticle.class.getName()), null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("urlset", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					"web-content", 1));
+		}
+	}
+
+	@Test
+	public void testExecuteWithIndexDisabledDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", false
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteWithPageLayoutModeDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_PAGE_LAYOUT
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, _layout.getUuid());
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	private JournalArticle _addJournalArticle() throws Exception {
+		Locale locale = LocaleUtil.getSiteDefault();
+
+		return JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true, RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, false, _serviceContext);
+	}
+
+	private void _addJournalArticleAssetDisplayPageEntry(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				journalArticle.getDDMStructureKey(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			journalArticle.getResourcePrimKey(),
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+			AssetDisplayPageConstants.TYPE_SPECIFIC, _serviceContext);
+	}
+
+	private MockHttpServletResponse _executeRequest(
+			String assetTypeKey, String layoutUuid)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+
+		_themeDisplay.setRequest(mockHttpServletRequest);
+
+		if (assetTypeKey != null) {
+			mockHttpServletRequest.setParameter("assetTypeKey", assetTypeKey);
+		}
+
+		if (layoutUuid != null) {
+			mockHttpServletRequest.setParameter("layoutUuid", layoutUuid);
+		}
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_sitemapStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		return mockHttpServletResponse;
+	}
+
+	private void _setUpThemeDisplay() throws Exception {
+		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group, _layout);
+
+		_themeDisplay.setPortalDomain(_company.getVirtualHostname());
+		_themeDisplay.setPortalURL(_company.getPortalURL(_group.getGroupId()));
+		_themeDisplay.setServerName(_company.getVirtualHostname());
+		_themeDisplay.setServerPort(8080);
+	}
+
+	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
+		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
+
+	private static CompanyConfigurationTemporarySwapper
+		_companyConfigurationTemporarySwapper;
+
+	@Inject
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
+
+	private Company _company;
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private SAXReader _saxReader;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	@Inject(
 		filter = "component.name=com.liferay.site.internal.struts.SitemapStrutsAction"
 	)
 	private StrutsAction _sitemapStrutsAction;
+
+	private ThemeDisplay _themeDisplay;
 
 	@Inject
 	private VirtualHostLocalService _virtualHostLocalService;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -88,7 +88,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.redirect.model.RedirectEntry;
 import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
 import java.io.Serializable;
@@ -106,6 +108,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,6 +162,14 @@ public class SitemapManagerTest {
 			_group.getGroupId());
 
 		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
 	}
 
 	@Test
@@ -336,7 +347,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			ObjectEntry includedObjectEntry = _addObjectEntry(
@@ -387,7 +399,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -412,7 +425,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1164,7 +1178,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			List<String> urls = new ArrayList<>();
@@ -1202,7 +1217,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1251,7 +1267,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1272,7 +1289,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1290,7 +1308,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1312,7 +1331,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(false, _group.getGroupId(), StringPool.BLANK);
@@ -1849,8 +1869,6 @@ public class SitemapManagerTest {
 	private static final String _CLASS_NAME_OBJECT_ENTRY =
 		ObjectEntry.class.getName();
 
-	private static final String _INDEX_MODE_ASSET_TYPE = "asset-type";
-
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
@@ -1926,6 +1944,9 @@ public class SitemapManagerTest {
 
 	@Inject
 	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	private ThemeDisplay _themeDisplay;
 


### PR DESCRIPTION
**FYI: this depends on https://liferay.atlassian.net/browse/LPD-88225 which hasn't been merged yet.**

### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90505

### How am I fixing it?

This connects the existing sitemap generation logic to `SitemapStorageHelper` so that generated XML is persisted via DLStore and served from storage when available, eliminating repeated dynamic generation for large sites. Key changes include:

- `SitemapManagerImpl` now persists generated XML through `SitemapStorageHelper` after building both the sitemap index and per-asset-type sitemaps. Storage only happens when the sitemap index is enabled and the mode is "Asset Type" — page-layout mode and index-disabled mode remain dynamic-only with no DLStore interaction.
- `SitemapStrutsAction` attempts to stream stored sitemaps directly from DLStore before falling back to dynamic generation. The InputStream is streamed directly to the servlet response, avoiding loading the full XML into a String.
- On cold start (no stored file), `getSitemapInputStream` throws a `PortalException` which is caught at debug level, and the request falls through to dynamic generation. Since `SitemapManagerImpl` stores on generation, subsequent requests are served from DLStore.
- Storage failures in `SitemapManagerImpl` are caught and logged at warn level so they never block sitemap serving — DLStore acts as a best-effort cache.
- FYI: Sitemap regeneration and scheduling for cluster safety will be implemented in the subsequent sibling subtask: https://liferay.atlassian.net/browse/LPD-90950

### How can you verify that it works?

Sitemap storage tests can be run in the `site-test` module with `gradlew testIntegration --tests SitemapManagerTest`

This PR adds 4 new test cases.

The following test cases were added:

1. `testSitemapAssetTypeStoresInDLStore` - Enables index + asset-type mode, generates a web-content sitemap, and verifies the XML file exists at `sitemaps/{groupId}/web-content/1.xml` in DLStore
2. `testSitemapDoesNotStoreWhenIndexDisabled` - Generates a sitemap with index disabled (default config) and verifies no sitemap-index.xml is written to DLStore
3. `testSitemapDoesNotStoreWhenPageLayoutMode` - Enables index with page-layout mode and verifies no sitemap-index.xml is written to DLStore
4. `testSitemapIndexStoresInDLStore` - Enables index + asset-type mode, generates the sitemap index, and verifies the XML file exists at `sitemaps/{groupId}/sitemap-index.xml` in DLStore
