### PR TITLE
LPD-92699 Preserve navigation menu item settings on export/import

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuItemDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/NavigationMenuItemDTOConverter.java
@@ -72,8 +72,9 @@ public class NavigationMenuItemDTOConverter
 		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
 			unicodeProperties.getProperty("externalReferenceCode"),
 			siteNavigationMenuItem.getGroupId());
-		Object navigationMenuItemSettings = _getNavigationMenuItemSettings(
-			siteNavigationMenuItem.getType(), unicodeProperties);
+		Object navigationMenuItemSettingsObject =
+			_getNavigationMenuItemSettings(
+				siteNavigationMenuItem.getType(), unicodeProperties);
 
 		String navigationMenuItemType = _toType(
 			siteNavigationMenuItem.getType());
@@ -188,7 +189,8 @@ public class NavigationMenuItemDTOConverter
 							},
 							NavigationMenuItem.class);
 					});
-				setNavigationMenuItemSettings(() -> navigationMenuItemSettings);
+				setNavigationMenuItemSettings(
+					() -> navigationMenuItemSettingsObject);
 				setType(siteNavigationMenuItem::getType);
 				setUseCustomName(
 					() -> Boolean.valueOf(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92699

## What is being fixed

Exporting and re-importing a site navigation menu through the batch engine dropped a Display Page type menu item's type-specific settings. After import the item lost its `className` and `externalReferenceCode`, so its display page reference was gone, and the integration test `DisplayPageTypeSiteNavigationMenuItemTypeTest.testGetDisplayPageTypeSiteNavigationMenuItemFromExportImport` failed.

## How it is being fixed

In `NavigationMenuItemDTOConverter.toDTO` the local variable holding the computed settings shared its name with the inherited `NavigationMenuItem` field. Inside the anonymous `NavigationMenuItem`, the `setNavigationMenuItemSettings(() -> navigationMenuItemSettings)` supplier therefore resolved to the null field instead of the computed local, so the settings were never written to the exported JSON. Renaming the local to `navigationMenuItemSettingsObject` lets the supplier capture the computed value and restores the export/import round-trip.
