### PR TITLE
LPD-92453 Escape the redirect parameter passed to <clay:link>

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/configuration/screen/entry.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/configuration/screen/entry.jsp
@@ -10,7 +10,7 @@
 <%
 SiteSettingsConfigurationScreenContributor siteSettingsConfigurationScreenContributor = (SiteSettingsConfigurationScreenContributor)request.getAttribute(SiteAdminWebKeys.SITE_SETTINGS_CONFIGURATION_SCREEN_CONTRIBUTOR);
 
-String redirect = ParamUtil.getString(request, "redirect");
+String redirect = PortalUtil.escapeRedirect(ParamUtil.getString(request, "redirect"));
 
 PortletURL portletURL = renderResponse.createRenderURL();
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
+String redirect = PortalUtil.escapeRedirect(ParamUtil.getString(request, "redirect"));
 
 if (Validator.isNull(redirect)) {
 	redirect = PortletURLBuilder.createRenderURL(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92453

## What is being fixed

The "redirect" request parameter in Site Management was read straight from the request and rendered into the href of a <clay:link> cancel button without sanitization, in both the site settings configuration screen (entry.jsp) and the membership request reply page (reply_membership_request.jsp). An attacker could craft a URL with a malicious redirect value, producing an open redirect when the user clicked cancel.

## How it is being fixed

Both JSPs now pass the parameter through PortalUtil.escapeRedirect(...) before use. escapeRedirect rejects protocol-relative URLs, disallowed schemes, and off-list domains, returning null for anything unsafe, which falls through the existing Validator.isNull(redirect) guard to a safe default URL. It also neutralizes attribute-breakout XSS, since such payloads fail URI parsing.