### PR TITLE
LPD-91657 Discard Changes in a publication does not delete the associated workflow task

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/reference/DLFileVersionTableReferenceDefinition.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/change/tracking/spi/reference/DLFileVersionTableReferenceDefinition.java
@@ -22,6 +22,7 @@ import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.ClassNameTable;
+import com.liferay.portal.kernel.model.WorkflowInstanceLinkTable;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.trash.model.TrashVersionTable;
@@ -216,6 +217,22 @@ public class DLFileVersionTableReferenceDefinition
 				ClassNameTable.INSTANCE,
 				ClassNameTable.INSTANCE.classNameId.eq(
 					TrashVersionTable.INSTANCE.classNameId
+				).and(
+					ClassNameTable.INSTANCE.value.eq(
+						DLFileEntry.class.getName())
+				)
+			)
+		).referenceInnerJoin(
+			fromStep -> fromStep.from(
+				WorkflowInstanceLinkTable.INSTANCE
+			).innerJoinON(
+				DLFileVersionTable.INSTANCE,
+				DLFileVersionTable.INSTANCE.fileVersionId.eq(
+					WorkflowInstanceLinkTable.INSTANCE.classPK)
+			).innerJoinON(
+				ClassNameTable.INSTANCE,
+				ClassNameTable.INSTANCE.classNameId.eq(
+					WorkflowInstanceLinkTable.INSTANCE.classNameId
 				).and(
 					ClassNameTable.INSTANCE.value.eq(
 						DLFileEntry.class.getName())

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
@@ -9,36 +9,33 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
-import java.util.Collections;
-
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
  * @author Preston Crary
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class DLFileVersionTableReferenceDefinitionTest
 	extends BaseTableReferenceDefinitionTestCase {
@@ -55,42 +52,47 @@ public class DLFileVersionTableReferenceDefinitionTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
-
-		InputStream inputStream = new ByteArrayInputStream(bytes);
-
-		_dlFileEntry = _dlFileEntryLocalService.addFileEntry(
-			null, group.getCreatorUserId(), group.getGroupId(),
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, null,
-			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+			group.getCreatorUserId(), group.getCompanyId(), group.getGroupId(),
+			DLFolder.class.getName(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL, "Single Approver",
+			1);
 	}
 
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
-		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		InputStream inputStream = new ByteArrayInputStream(bytes);
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
 
-		_dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
-			group.getCreatorUserId(), _dlFileEntry.getFileEntryId(),
-			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
-			StringUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null, null,
-			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+		boolean workflowEnabled = WorkflowThreadLocal.isEnabled();
 
-		return _dlFileEntry.getFileVersion();
+		try {
+			WorkflowThreadLocal.setEnabled(true);
+
+			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+				null, group.getCreatorUserId(), group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+				RandomTestUtil.randomString(), StringPool.BLANK,
+				StringPool.BLANK, StringPool.BLANK,
+				TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+				serviceContext);
+
+			return (DLFileEntry)fileEntry.getModel();
+		}
+		finally {
+			WorkflowThreadLocal.setEnabled(workflowEnabled);
+		}
 	}
 
-	private DLFileEntry _dlFileEntry;
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
 
 	@Inject
-	private DLFileEntryLocalService _dlFileEntryLocalService;
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91657

**What is being fixed:** Discarding a Document Library file entry from a publication (change-tracking collection) left its workflow behind. The WorkflowInstanceLink and the downstream Kaleo entries, including the KaleoTaskInstanceToken that backs the visible workflow task, were not removed, leaving an orphaned task pointing at content that no longer existed.

**How it is being fixed:** Document Library stores its WorkflowInstanceLink under the DLFileEntry class name with the file version ID as the class primary key, so the generic workflow handling could not match it from the file's change-tracking closure. This adds a WorkflowInstanceLink reference to DLFileVersionTableReferenceDefinition, joining the file version ID to the link's class primary key and pinning the class name to DLFileEntry via ClassNameTable, mirroring the module's existing TrashVersion reference. With the link in the closure, its KaleoInstance, KaleoInstanceToken, KaleoTaskInstanceToken, KaleoTaskAssignmentInstance, and KaleoLog entries are discarded together with the file. The previously ignored DLFileVersionTableReferenceDefinitionTest is re-enabled and configured with a Single Approver workflow to cover the scenario end to end.