### PR TITLE
LPD-88837 Add scan name list type, object action, and API key field

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-name-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-name-list-type-definition.json
@@ -1,0 +1,13 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_NAMES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "SEO_STUDIO_SCAN_NAME_PAGE_SPEED",
+			"key": "pageSpeed",
+			"name": "PageSpeed",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Names",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
@@ -1,0 +1,20 @@
+{
+	"object-actions": [
+		{
+			"active": true,
+			"errorMessage": {
+				"en_US": "PageSpeed scan failed. Please try again later or contact support."
+			},
+			"externalReferenceCode": "L_SEO_STUDIO_SCAN_PAGESPEED",
+			"label": {
+				"en_US": "PageSpeed Scan"
+			},
+			"name": "pageSpeedScan",
+			"objectActionExecutorKey": "function#liferay-seostudio-pagespeed-object-action-scan",
+			"objectActionTriggerKey": "onAfterAdd",
+			"parameters": {
+			}
+		}
+	],
+	"objectDefinitionId": "[$OBJECT_DEFINITION_ID:SEOStudioScan$]"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/01-seo-studio-instance-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/01-seo-studio-instance-object-definition.json
@@ -64,6 +64,18 @@
 			"type": "String"
 		},
 		{
+			"DBType": "Clob",
+			"businessType": "Encrypted",
+			"externalReferenceCode": "GOOGLE_PAGESPEED_API_KEY",
+			"indexed": false,
+			"label": {
+				"en_US": "Google PageSpeed API Key"
+			},
+			"name": "googlePageSpeedAPIKey",
+			"system": true,
+			"type": "Clob"
+		},
+		{
 			"DBType": "String",
 			"businessType": "Text",
 			"externalReferenceCode": "HOSTNAME",

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
@@ -36,6 +36,20 @@
 			"type": "Clob"
 		},
 		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "NAME",
+			"indexed": true,
+			"label": {
+				"en_US": "Name"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_NAMES",
+			"name": "name",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
 			"DBType": "DateTime",
 			"businessType": "DateTime",
 			"externalReferenceCode": "REQUEST_DATE",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

SEO Studio needs a PageSpeed scan name in the scan list type definition, an object action to trigger the PageSpeed client extension, and a Google PageSpeed API key field on SEOStudioInstance to store the credentials for the PageSpeed Insights API.

## How It Is Being Fixed

A `pageSpeed` entry is added to the scan name list type definition. An object action is registered on SEOStudioScan to dispatch to the PageSpeed client extension endpoint. The `googlePageSpeedAPIKey` field is added to SEOStudioInstance, and the `name` field is added to SEOStudioScan to identify the scan type.

## Why Are There No Tests?

This PR only adds JSON site-initializer resource files (list type definitions, object actions, object definitions). No runtime code is introduced.