### PR TITLE
LPD-93567 Only run the initializer when the group is newly created

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
@@ -48,23 +48,25 @@ public class SEOStudioFeatureFlagListener implements FeatureFlagListener {
 			Group group = _groupLocalService.fetchGroup(
 				companyId, GroupConstants.SEO_STUDIO);
 
-			if (group == null) {
-				String externalReferenceCode = TextFormatter.format(
-					GroupConstants.SEO_STUDIO, TextFormatter.A);
-
-				group = _groupLocalService.addGroup(
-					"L_" + externalReferenceCode,
-					_userLocalService.getGuestUserId(companyId),
-					GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
-					GroupConstants.DEFAULT_LIVE_GROUP_ID,
-					HashMapBuilder.put(
-						LocaleUtil.getDefault(), GroupConstants.SEO_STUDIO
-					).build(),
-					null, GroupConstants.TYPE_SITE_RESTRICTED, null, true,
-					GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
-					GroupConstants.SEO_STUDIO_FRIENDLY_URL, false, false, true,
-					null);
+			if (group != null) {
+				return;
 			}
+
+			String externalReferenceCode = TextFormatter.format(
+				GroupConstants.SEO_STUDIO, TextFormatter.A);
+
+			group = _groupLocalService.addGroup(
+				"L_" + externalReferenceCode,
+				_userLocalService.getGuestUserId(companyId),
+				GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
+				GroupConstants.DEFAULT_LIVE_GROUP_ID,
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), GroupConstants.SEO_STUDIO
+				).build(),
+				null, GroupConstants.TYPE_SITE_RESTRICTED, null, true,
+				GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
+				GroupConstants.SEO_STUDIO_FRIENDLY_URL, false, false, true,
+				null);
 
 			SiteInitializerUtil.initialize(companyId, group, _siteInitializer);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93567

## What Is Being Fixed

The SEO Studio FeatureFlagListener re-ran the full site initializer on every invocation, including when the LPD-44511 flag value is replayed to the listener each time the seo-studio-web bundle re-activates. Because initialization re-imports the entire site, an existing SEO Studio site was rebuilt on every redeploy — wasteful, and disruptive now that the React UI and its FragmentRenderer live in seo-studio-web: the re-import rebuilt the settings layout while the renderer's bundle was restarting, leaving the page's fragment unrendered until a full delete-site / re-enable-flag cycle.

## How It Is Being Fixed

The listener now returns early when the SEO Studio group already exists, so initialization runs only when the group is first created. Existing sites are left untouched on subsequent flag replays and bundle restarts. This matches the deployment model — a single hosted SEO Studio site whose initializer changes are applied deliberately rather than re-imported on every restart — and restores cycle-free redeploys of seo-studio-web.