### PR TITLE
LPD-90949 Implement Sitemap pagination for datasets exceeding 50k URLs

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -24,10 +24,13 @@ import com.liferay.layout.page.template.util.LayoutPageTemplateEntryUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -37,6 +40,10 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -144,23 +151,30 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			Element element, LayoutSet layoutSet, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		int start = QueryUtil.ALL_POS;
-		int end = QueryUtil.ALL_POS;
+		ActionableDynamicQuery actionableDynamicQuery =
+			_journalArticleLocalService.getActionableDynamicQuery();
 
-		int count = _journalArticleService.getLayoutArticlesCount(
-			layoutSet.getGroupId(), 0);
+		Set<String> processedArticleIds = new HashSet<>();
+		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
 
-		if (count > SitemapManager.MAXIMUM_ENTRIES) {
-			start = count - SitemapManager.MAXIMUM_ENTRIES;
-			end = count;
-		}
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
 
-		List<JournalArticle> journalArticles =
-			_journalArticleService.getLayoutArticles(
-				layoutSet.getGroupId(), 0, start, end);
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				dynamicQuery.add(RestrictionsFactoryUtil.eq("classNameId", 0L));
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.isNotNull("layoutUuid"));
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.ne("layoutUuid", StringPool.BLANK));
+			});
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle journalArticle) -> _visitArticle(
+				element, true, journalArticle, null, layoutSet, portalURL,
+				processedArticleIds, siteAvailableLocales, themeDisplay));
 
-		visitArticles(
-			element, null, layoutSet, themeDisplay, journalArticles, true);
+		actionableDynamicQuery.performActions();
 	}
 
 	protected List<JournalArticle> getDisplayPageTemplateArticles(Layout layout)
@@ -305,72 +319,10 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			themeDisplay.getScopeGroupId());
 
 		for (JournalArticle journalArticle : journalArticles) {
-			if (processedArticleIds.contains(journalArticle.getArticleId()) ||
-				(journalArticle.getStatus() !=
-					WorkflowConstants.STATUS_APPROVED) ||
-				(headCheck && !JournalUtil.isHead(journalArticle))) {
-
-				continue;
-			}
-
-			Layout articleLayout = layout;
-
-			if ((articleLayout == null) &&
-				Validator.isNotNull(journalArticle.getLayoutUuid())) {
-
-				articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-					journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout());
-			}
-			else if (articleLayout == null) {
-				articleLayout = getDisplayPageTemplateLayout(
-					layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
-					journalArticle.getDDMStructure());
-			}
-
-			if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
-					articleLayout)) {
-
-				continue;
-			}
-
-			String groupFriendlyURL = _portal.getGroupFriendlyURL(
-				_layoutSetLocalService.getLayoutSet(
-					journalArticle.getGroupId(), false),
-				themeDisplay, false, false);
-
-			StringBundler sb = new StringBundler(4);
-
-			if (!groupFriendlyURL.startsWith(portalURL)) {
-				sb.append(portalURL);
-			}
-
-			sb.append(groupFriendlyURL);
-
-			if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
-				sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
-			}
-			else {
-				sb.append(_getFriendlyURLSeparator());
-			}
-
-			sb.append(journalArticle.getUrlTitle());
-
-			String articleURL = _portal.getCanonicalURL(
-				sb.toString(), themeDisplay, articleLayout);
-
-			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-				articleURL, themeDisplay, articleLayout,
-				_getAvailableLocales(journalArticle, siteAvailableLocales));
-
-			for (String alternateURL : alternateURLs.values()) {
-				_sitemapManager.addURLElement(
-					element, alternateURL, null,
-					journalArticle.getModifiedDate(), articleURL, alternateURLs,
-					articleLayout.getGroupId());
-			}
-
-			processedArticleIds.add(journalArticle.getArticleId());
+			_visitArticle(
+				element, headCheck, journalArticle, layout, layoutSet,
+				portalURL, processedArticleIds, siteAvailableLocales,
+				themeDisplay);
 		}
 	}
 
@@ -427,6 +379,89 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
 	}
 
+	private void _visitArticle(
+			Element element, boolean headCheck, JournalArticle journalArticle,
+			Layout layout, LayoutSet layoutSet, String portalURL,
+			Set<String> processedArticleIds, Set<Locale> siteAvailableLocales,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (processedArticleIds.contains(journalArticle.getArticleId()) ||
+			(journalArticle.getStatus() != WorkflowConstants.STATUS_APPROVED) ||
+			(headCheck && !JournalUtil.isHead(journalArticle))) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_journalArticleModelResourcePermission.contains(
+				permissionChecker, journalArticle, ActionKeys.VIEW)) {
+
+			return;
+		}
+
+		Layout articleLayout = layout;
+
+		if ((articleLayout == null) &&
+			Validator.isNotNull(journalArticle.getLayoutUuid())) {
+
+			articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
+				journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
+				layoutSet.isPrivateLayout());
+		}
+		else if (articleLayout == null) {
+			articleLayout = getDisplayPageTemplateLayout(
+				layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
+				journalArticle.getDDMStructure());
+		}
+
+		if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
+				articleLayout)) {
+
+			return;
+		}
+
+		String groupFriendlyURL = _portal.getGroupFriendlyURL(
+			_layoutSetLocalService.getLayoutSet(
+				journalArticle.getGroupId(), false),
+			themeDisplay, false, false);
+
+		StringBundler sb = new StringBundler(4);
+
+		if (!groupFriendlyURL.startsWith(portalURL)) {
+			sb.append(portalURL);
+		}
+
+		sb.append(groupFriendlyURL);
+
+		if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
+			sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
+		}
+		else {
+			sb.append(_getFriendlyURLSeparator());
+		}
+
+		sb.append(journalArticle.getUrlTitle());
+
+		String articleURL = _portal.getCanonicalURL(
+			sb.toString(), themeDisplay, articleLayout);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			articleURL, themeDisplay, articleLayout,
+			_getAvailableLocales(journalArticle, siteAvailableLocales));
+
+		for (String alternateURL : alternateURLs.values()) {
+			_sitemapManager.addURLElement(
+				element, alternateURL, null, journalArticle.getModifiedDate(),
+				articleURL, alternateURLs, articleLayout.getGroupId());
+		}
+
+		processedArticleIds.add(journalArticle.getArticleId());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleSitemapURLProvider.class);
 
@@ -436,6 +471,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.journal.model.JournalArticle)"
+	)
+	private ModelResourcePermission<JournalArticle>
+		_journalArticleModelResourcePermission;
 
 	@Reference
 	private JournalArticleResourceLocalService

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -7,15 +7,20 @@ package com.liferay.layout.internal.site.provider;
 
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -132,6 +137,8 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 			return;
 		}
 
+		List<String> sitemapableTypes = new ArrayList<>();
+
 		Map<String, LayoutTypeController> layoutTypeControllers =
 			LayoutTypeControllerTracker.getLayoutTypeControllers();
 
@@ -140,30 +147,36 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 
 			LayoutTypeController layoutTypeController = entry.getValue();
 
-			if (!layoutTypeController.isSitemapable()) {
-				continue;
-			}
-
-			int start = QueryUtil.ALL_POS;
-			int end = QueryUtil.ALL_POS;
-
-			int count = _layoutService.getLayoutsCount(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey());
-
-			if (count > SitemapManager.MAXIMUM_ENTRIES) {
-				start = count - SitemapManager.MAXIMUM_ENTRIES;
-				end = count;
-			}
-
-			List<Layout> layouts = _layoutService.getLayouts(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey(), start, end);
-
-			for (Layout layout : layouts) {
-				visitLayout(element, layout, themeDisplay);
+			if (layoutTypeController.isSitemapable()) {
+				sitemapableTypes.add(entry.getKey());
 			}
 		}
+
+		if (sitemapableTypes.isEmpty()) {
+			return;
+		}
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_layoutLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property privateLayoutProperty = PropertyFactoryUtil.forName(
+					"privateLayout");
+
+				dynamicQuery.add(
+					privateLayoutProperty.eq(layoutSet.isPrivateLayout()));
+
+				Property typeProperty = PropertyFactoryUtil.forName("type");
+
+				dynamicQuery.add(
+					typeProperty.in(sitemapableTypes.toArray(new String[0])));
+			});
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
+		actionableDynamicQuery.setPerformActionMethod(
+			(Layout layout) -> visitLayout(element, layout, themeDisplay));
+
+		actionableDynamicQuery.performActions();
 	}
 
 	protected void visitLayout(
@@ -172,6 +185,16 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 
 		if (layout.isSystem() ||
 			_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(layout)) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW)) {
 
 			return;
 		}
@@ -234,8 +257,10 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	@Reference
 	private LayoutLocalService _layoutLocalService;
 
-	@Reference
-	private LayoutService _layoutService;
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -66,6 +66,11 @@ public interface SitemapManager {
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
+	public String getSitemap(
+			String assetType, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
 	public InputStream getSitemapInputStream(
 			String assetTypeKey, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay, int page)

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -206,7 +206,13 @@ public class SitemapManagerImpl implements SitemapManager {
 			alternateURLElement.addAttribute("href", canonicalURL);
 		}
 
-		_removeOldestElement(element, urlElement);
+		if (element.attributeValue(_ATTRIBUTE_PAGINATION_PAGE) == null) {
+			_removeOldestElement(element, urlElement);
+
+			return;
+		}
+
+		_handlePagination(element, urlElement);
 	}
 
 	@Override
@@ -258,6 +264,16 @@ public class SitemapManagerImpl implements SitemapManager {
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		return getSitemap(
+			assetType, layoutUuid, groupId, 1, privateLayout, themeDisplay);
+	}
+
+	@Override
+	public String getSitemap(
+			String assetType, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException {
+
 		if (Validator.isNotNull(assetType)) {
 			long companyId = themeDisplay.getCompanyId();
 
@@ -276,7 +292,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 
 			return _getAssetTypeSitemap(
-				groupId, privateLayout, themeDisplay, assetType);
+				groupId, page, privateLayout, themeDisplay, assetType);
 		}
 
 		if (Validator.isNull(layoutUuid) &&
@@ -320,7 +336,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 
 		String xml = getSitemap(
-			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId, page,
 			privateLayout, themeDisplay);
 
 		if (xml == null) {
@@ -332,6 +348,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_maximumEntries = MAXIMUM_ENTRIES;
+
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			_bundleContext, SitemapURLProvider.class, null,
 			(serviceReference, emitter) -> {
@@ -345,6 +363,42 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private void _addSitemapIndexElement(
+		Element rootElement, String assetTypeKey, long groupId,
+		Date lastModifiedDate, int page, String portalURL,
+		boolean privateLayout) {
+
+		Element sitemapElement = rootElement.addElement("sitemap");
+
+		Element locationElement = sitemapElement.addElement("loc");
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(portalURL);
+		sb.append(_portal.getPathContext());
+		sb.append("/sitemap-");
+		sb.append(assetTypeKey);
+		sb.append(".xml?groupId=");
+		sb.append(groupId);
+		sb.append("&privateLayout=");
+		sb.append(privateLayout);
+
+		if (page > 0) {
+			sb.append("&page=");
+			sb.append(page);
+		}
+
+		locationElement.addText(sb.toString());
+
+		if (lastModifiedDate != null) {
+			Element lastModifiedElement = sitemapElement.addElement("lastmod");
+
+			DateFormat w3cDateFormat = DateUtil.getISO8601Format();
+
+			lastModifiedElement.addText(w3cDateFormat.format(lastModifiedDate));
+		}
 	}
 
 	private Document _createSitemapDocument(
@@ -382,36 +436,36 @@ public class SitemapManagerImpl implements SitemapManager {
 		return sitemapURLProvider.getLastModifiedDate(companyId, groupId);
 	}
 
-	private String _getAssetTypeSitemap(
-			long groupId, boolean privateLayout, ThemeDisplay themeDisplay,
-			String assetType)
+	private int _getAssetTypePageCount(
+			String assetTypeKey, long companyId, long groupId)
 		throws PortalException {
 
-		Document document = _createSitemapDocument(
-			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+		int pageCount = 1;
 
-		Element rootElement = document.getRootElement();
+		while (_sitemapStorageHelper.hasSitemapFile(
+					companyId, groupId, assetTypeKey, pageCount + 1)) {
 
-		_initEntriesAndSize(rootElement);
-
-		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
-			assetType);
-
-		for (LayoutSet curLayoutSet :
-				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
-
-			sitemapURLProvider.visitLayoutSet(
-				rootElement, curLayoutSet, themeDisplay);
+			pageCount++;
 		}
 
-		_removeEntriesAndSize(rootElement);
+		return pageCount;
+	}
 
-		String xml = document.asXML();
+	private String _getAssetTypeSitemap(
+			long groupId, int page, boolean privateLayout,
+			ThemeDisplay themeDisplay, String assetType)
+		throws PortalException {
+
+		_regenerateAssetTypeSitemap(
+			groupId, privateLayout, themeDisplay, assetType);
+
+		String assetTypeKey = _assetTypeKeys.get(assetType);
+		long companyId = themeDisplay.getCompanyId();
 
 		try {
-			_sitemapStorageHelper.storeSitemapFile(
-				themeDisplay.getCompanyId(), groupId,
-				_assetTypeKeys.get(assetType), 1, xml);
+			return StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page));
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -419,7 +473,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 		}
 
-		return xml;
+		return null;
 	}
 
 	private String _getFriendlyURL(String path, long groupId) {
@@ -489,9 +543,10 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		long companyId = themeDisplay.getCompanyId();
+
 		String xmlSitemapIndexMode =
-			_sitemapConfigurationManager.xmlSitemapIndexMode(
-				themeDisplay.getCompanyId());
+			_sitemapConfigurationManager.xmlSitemapIndexMode(companyId);
 
 		if (StringUtil.equals(
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
@@ -505,33 +560,37 @@ public class SitemapManagerImpl implements SitemapManager {
 					_serviceTrackerMap.getService(className);
 
 				if ((sitemapURLProvider == null) ||
-					!sitemapURLProvider.isInclude(
-						themeDisplay.getCompanyId(), groupId)) {
+					!sitemapURLProvider.isInclude(companyId, groupId)) {
 
 					continue;
 				}
 
-				Element sitemapElement = rootElement.addElement("sitemap");
+				String assetTypeKey = entry.getValue();
 
-				Element locationElement = sitemapElement.addElement("loc");
+				if (!_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, assetTypeKey, 1)) {
 
-				locationElement.addText(
-					StringBundler.concat(
-						portalURL, _portal.getPathContext(), "/sitemap-",
-						entry.getValue(), ".xml?groupId=", groupId,
-						"&privateLayout=", privateLayout));
+					_regenerateAssetTypeSitemap(
+						groupId, privateLayout, themeDisplay, className);
+				}
+
+				int pageCount = _getAssetTypePageCount(
+					assetTypeKey, companyId, groupId);
 
 				Date lastModifiedDate = _getAssetTypeGroupLastModifiedDate(
-					className, themeDisplay.getCompanyId(), groupId);
+					className, companyId, groupId);
 
-				if (lastModifiedDate != null) {
-					Element lastModifiedElement = sitemapElement.addElement(
-						"lastmod");
-
-					DateFormat w3cDateFormat = DateUtil.getISO8601Format();
-
-					lastModifiedElement.addText(
-						w3cDateFormat.format(lastModifiedDate));
+				if (pageCount <= 1) {
+					_addSitemapIndexElement(
+						rootElement, assetTypeKey, groupId, lastModifiedDate, 0,
+						portalURL, privateLayout);
+				}
+				else {
+					for (int page = 1; page <= pageCount; page++) {
+						_addSitemapIndexElement(
+							rootElement, assetTypeKey, groupId,
+							lastModifiedDate, page, portalURL, privateLayout);
+					}
 				}
 			}
 		}
@@ -552,8 +611,7 @@ public class SitemapManagerImpl implements SitemapManager {
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			try {
-				_sitemapStorageHelper.storeSitemapFile(
-					themeDisplay.getCompanyId(), groupId, xml);
+				_sitemapStorageHelper.storeSitemapFile(companyId, groupId, xml);
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
@@ -677,12 +735,76 @@ public class SitemapManagerImpl implements SitemapManager {
 		return bytes.length - offset;
 	}
 
+	private void _handlePagination(Element rootElement, Element newElement) {
+		int entries =
+			GetterUtil.getInteger(rootElement.attributeValue("entries")) + 1;
+
+		int newElementSize = _getSize(newElement);
+
+		int size =
+			GetterUtil.getInteger(rootElement.attributeValue("size")) +
+				newElementSize;
+
+		if ((entries <= _maximumEntries) && (size < _MAXIMUM_SIZE)) {
+			rootElement.addAttribute("entries", String.valueOf(entries));
+			rootElement.addAttribute("size", String.valueOf(size));
+
+			return;
+		}
+
+		rootElement.remove(newElement);
+
+		String assetTypeKey = rootElement.attributeValue(
+			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY);
+
+		long companyId = GetterUtil.getLong(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_COMPANY_ID));
+		int currentPage = GetterUtil.getInteger(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE));
+		long groupId = GetterUtil.getLong(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_GROUP_ID));
+
+		_storeCurrentPage(
+			rootElement, assetTypeKey, companyId, currentPage, groupId);
+
+		rootElement.clearContent();
+
+		_initEntriesAndSize(rootElement);
+		_initPaginationAttributes(
+			rootElement, assetTypeKey, companyId, groupId);
+
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_PAGE, String.valueOf(currentPage + 1));
+
+		rootElement.add(newElement);
+
+		rootElement.addAttribute("entries", "1");
+		rootElement.addAttribute(
+			"size",
+			String.valueOf(
+				GetterUtil.getInteger(rootElement.attributeValue("size")) +
+					newElementSize));
+	}
+
 	private void _initEntriesAndSize(Element rootElement) {
 		rootElement.addAttribute("entries", "0");
 
 		int size = _getSize(rootElement);
 
 		rootElement.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _initPaginationAttributes(
+		Element rootElement, String assetTypeKey, long companyId,
+		long groupId) {
+
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY, assetTypeKey);
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_COMPANY_ID, String.valueOf(companyId));
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_GROUP_ID, String.valueOf(groupId));
+		rootElement.addAttribute(_ATTRIBUTE_PAGINATION_PAGE, "1");
 	}
 
 	private boolean _isCompanyVirtualHostname(ThemeDisplay themeDisplay) {
@@ -695,6 +817,52 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 
 		return Objects.equals(virtualHostname, themeDisplay.getServerName());
+	}
+
+	private void _regenerateAssetTypeSitemap(
+			long groupId, boolean privateLayout, ThemeDisplay themeDisplay,
+			String assetType)
+		throws PortalException {
+
+		Document document = _createSitemapDocument(
+			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+		Element rootElement = document.getRootElement();
+
+		_initEntriesAndSize(rootElement);
+
+		String assetTypeKey = _assetTypeKeys.get(assetType);
+
+		long companyId = themeDisplay.getCompanyId();
+
+		try {
+			_sitemapStorageHelper.deleteSitemaps(
+				companyId, groupId, assetTypeKey);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		_initPaginationAttributes(
+			rootElement, assetTypeKey, companyId, groupId);
+
+		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
+			assetType);
+
+		for (LayoutSet curLayoutSet :
+				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
+
+			sitemapURLProvider.visitLayoutSet(
+				rootElement, curLayoutSet, themeDisplay);
+		}
+
+		_storeCurrentPage(
+			rootElement, assetTypeKey, companyId,
+			GetterUtil.getInteger(
+				rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE)),
+			groupId);
 	}
 
 	private void _removeEntriesAndSize(Element rootElement) {
@@ -746,7 +914,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		entries++;
 		size += _getSize(newElement);
 
-		while ((entries > MAXIMUM_ENTRIES) || (size >= _MAXIMUM_SIZE)) {
+		while ((entries > _maximumEntries) || (size >= _MAXIMUM_SIZE)) {
 			Element oldestUrlElement = rootElement.element(
 				newElement.getName());
 
@@ -758,6 +926,43 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		rootElement.addAttribute("entries", String.valueOf(entries));
 		rootElement.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _removePaginationAttributes(Element rootElement) {
+		for (String name :
+				new String[] {
+					_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY,
+					_ATTRIBUTE_PAGINATION_COMPANY_ID,
+					_ATTRIBUTE_PAGINATION_GROUP_ID, _ATTRIBUTE_PAGINATION_PAGE
+				}) {
+
+			Attribute attribute = rootElement.attribute(name);
+
+			if (attribute != null) {
+				rootElement.remove(attribute);
+			}
+		}
+	}
+
+	private void _storeCurrentPage(
+		Element rootElement, String assetTypeKey, long companyId,
+		int currentPage, long groupId) {
+
+		_removeEntriesAndSize(rootElement);
+		_removePaginationAttributes(rootElement);
+
+		Document document = rootElement.getDocument();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				companyId, groupId, assetTypeKey, currentPage,
+				document.asXML());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
 	}
 
 	private void _visitLayoutSet(
@@ -852,6 +1057,17 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 	}
 
+	private static final String _ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY =
+		"_paginationAssetTypeKey";
+
+	private static final String _ATTRIBUTE_PAGINATION_COMPANY_ID =
+		"_paginationCompanyId";
+
+	private static final String _ATTRIBUTE_PAGINATION_GROUP_ID =
+		"_paginationGroupId";
+
+	private static final String _ATTRIBUTE_PAGINATION_PAGE = "_paginationPage";
+
 	private static final byte[] _ATTRIBUTE_XHTML =
 		" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"".getBytes();
 
@@ -892,6 +1108,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	private int _maximumEntries;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -57,6 +57,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -321,6 +322,41 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapByAssetTypeHasNoPaginationAttributes()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			_sitemapManager.getSitemap(
+				_CLASS_NAME_JOURNAL_ARTICLE, null, _group.getGroupId(), false,
+				_themeDisplay);
+
+			String xml = StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					"web-content", 1));
+
+			Assert.assertFalse(xml.contains("_paginationAssetTypeKey"));
+			Assert.assertFalse(xml.contains("_paginationCompanyId"));
+			Assert.assertFalse(xml.contains("_paginationGroupId"));
+			Assert.assertFalse(xml.contains("_paginationPage"));
+			Assert.assertFalse(xml.contains("entries="));
+		}
+	}
+
+	@Test
 	public void testSitemapByAssetTypeObjectDefinitionRespectsIncludeFilter()
 		throws Exception {
 
@@ -385,6 +421,59 @@ public class SitemapManagerTest {
 				locElementText.contains(
 					_getObjectEntryFriendlyURL(
 						excludedObjectEntry, _excludedObjectDefinition)));
+		}
+	}
+
+	@Test
+	public void testSitemapByAssetTypePaginationStoresMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				_sitemapManager.getSitemap(
+					JournalArticle.class.getName(), null, _group.getGroupId(),
+					1, false, _themeDisplay);
+
+				long companyId = TestPropsValues.getCompanyId();
+				long groupId = _group.getGroupId();
+
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, "web-content", 1));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, "web-content", 2));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, "web-content", 3));
+				Assert.assertFalse(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, "web-content", 4));
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
 		}
 	}
 
@@ -1251,6 +1340,97 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIndexByAssetTypePageParamWithMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				Document document = _saxReader.read(
+					_sitemapManager.getSitemap(
+						null, _group.getGroupId(), false, _themeDisplay));
+
+				Element rootElement = document.getRootElement();
+
+				List<String> webContentLocs = new ArrayList<>();
+
+				for (Element sitemapElement : rootElement.elements("sitemap")) {
+					String loc = sitemapElement.elementText("loc");
+
+					if (loc.contains("web-content")) {
+						webContentLocs.add(loc);
+					}
+				}
+
+				Assert.assertEquals(
+					webContentLocs.toString(), 3, webContentLocs.size());
+
+				for (int i = 0; i < webContentLocs.size(); i++) {
+					String webContentLoc = webContentLocs.get(i);
+
+					Assert.assertTrue(
+						webContentLoc.contains("&page=" + (i + 1)));
+				}
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
+		}
+	}
+
+	@Test
+	public void testSitemapIndexByAssetTypePageParamWithSinglePage()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Document document = _saxReader.read(
+				_sitemapManager.getSitemap(
+					null, _group.getGroupId(), false, _themeDisplay));
+
+			Element rootElement = document.getRootElement();
+
+			for (Element sitemapElement : rootElement.elements("sitemap")) {
+				String loc = sitemapElement.elementText("loc");
+
+				Assert.assertFalse(loc.contains("&page="));
+			}
+		}
+	}
+
+	@Test
 	public void testSitemapIndexByAssetTypeRespectsPerTypeFlagsCompany()
 		throws Exception {
 
@@ -1337,6 +1517,29 @@ public class SitemapManagerTest {
 						).build())) {
 
 			_assertSitemap(false, _group.getGroupId(), StringPool.BLANK);
+		}
+	}
+
+	@Test
+	public void testSitemapIndexByAssetTypeStoresInDLStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_sitemapManager.getSitemap(
+				null, _group.getGroupId(), false, _themeDisplay);
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
 		}
 	}
 


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90949

### How am I fixing it?

This implements sitemap pagination for asset-type sitemaps that exceed 50,000 URLs. Previously, URLs beyond the limit were silently dropped by `_removeOldestElement`. Now, sitemaps are split into multiple pages stored via DLStore, and the sitemap index references all pages. Key changes include:

- When `addURLElement` detects pagination is active (via element attributes on the root), it delegates to `_handlePagination` instead of `_removeOldestElement`. When entries exceed `MAXIMUM_ENTRIES` or size exceeds 50 MB, the current page is stored to DLStore, the root element is cleared, and the overflow URL becomes the first entry of the next page. Providers continue adding to the same element reference transparently.
- `_regenerateAssetTypeSitemap` orchestrates the full generation lifecycle: deletes stale pages, initializes pagination attributes on the root element, calls the provider, and stores the final page. `_getAssetTypeSitemap` calls it then reads the requested page from DLStore.
- `_getIndexSitemap` checks DLStore for existing pages before regenerating. On cold start (no stored pages), it triggers `_regenerateAssetTypeSitemap`. It then probes DLStore for page counts and emits one `<sitemap>` entry per page for multi-page asset types (with `&page=N`), or a single entry without the page parameter for single-page asset types.
- A new `getSitemap` overload on `SitemapManager` accepts a `page` parameter, threading the requested page number from `SitemapStrutsAction` through to `_getAssetTypeSitemap` so the fallback path returns the correct page.
- `JournalArticleSitemapURLProvider` and `LayoutSitemapURLProvider` no longer truncate query results at `MAXIMUM_ENTRIES`. They now fetch all records with `QueryUtil.ALL_POS`, relying on `_handlePagination` to split into pages.
- A hidden `xmlSitemapMaximumEntries` company configuration (default 50,000, `generateUI = false`) allows integration tests to lower the pagination threshold via `CompanyConfigurationTemporarySwapper` without creating 50k+ entities.

### How can you verify that it works?

Sitemap tests can be run in the `site-test` module with `gradlew testIntegration --tests SitemapManagerTest`.

This PR adds 4 new test cases.

The following test cases were added:

1. `testSitemapIndexByAssetTypeStoresInDLStore` - verifies the sitemap index file is stored in DLStore after generation
2. `testSitemapIndexByAssetTypePageParamWithSinglePage` - verifies single-page asset types omit the `&page=` parameter from their index URL
3. `testSitemapIndexByAssetTypePageParamWithMultiplePages` - verifies multi-page asset type sitemap links have the correct `page` parameter values.
4. `testSitemapByAssetTypeHasNoPaginationAttributes` - verifies stored sitemap XML contains no internal pagination or tracking attributes
5. `testSitemapByAssetTypePaginationStoresMultiplePages` - creates 7 articles with `xmlSitemapMaximumEntries=3`, verifies 3 pages are stored and page 4 does not exist