### PR TITLE
LPD-88837 Add scan name list type and API key field

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-names-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-names-list-type-definition.json
@@ -1,0 +1,13 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_NAMES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "PAGE_SPEED",
+			"key": "pageSpeed",
+			"name": "PageSpeed",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Names",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
@@ -1,0 +1,20 @@
+{
+	"object-actions": [
+		{
+			"active": true,
+			"errorMessage": {
+				"en_US": "PageSpeed scan failed. Please try again later or contact support."
+			},
+			"externalReferenceCode": "L_SEO_STUDIO_SCAN_PAGE_SPEED",
+			"label": {
+				"en_US": "PageSpeed Scan"
+			},
+			"name": "pageSpeedScan",
+			"objectActionExecutorKey": "function#liferay-seostudio-pagespeed-object-action-scan",
+			"objectActionTriggerKey": "onAfterAdd",
+			"parameters": {
+			}
+		}
+	],
+	"objectDefinitionId": "[$OBJECT_DEFINITION_ID:SEOStudioScan$]"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/01-seo-studio-instance-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/01-seo-studio-instance-object-definition.json
@@ -64,6 +64,18 @@
 			"type": "String"
 		},
 		{
+			"DBType": "Clob",
+			"businessType": "Encrypted",
+			"externalReferenceCode": "GOOGLE_PAGESPEED_API_KEY",
+			"indexed": false,
+			"label": {
+				"en_US": "Google PageSpeed API Key"
+			},
+			"name": "googlePageSpeedAPIKey",
+			"system": true,
+			"type": "Clob"
+		},
+		{
 			"DBType": "String",
 			"businessType": "Text",
 			"externalReferenceCode": "HOSTNAME",

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
@@ -36,6 +36,20 @@
 			"type": "Clob"
 		},
 		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "NAME",
+			"indexed": true,
+			"label": {
+				"en_US": "Name"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_NAMES",
+			"name": "name",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
 			"DBType": "DateTime",
 			"businessType": "DateTime",
 			"externalReferenceCode": "REQUEST_DATE",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

The SEO Studio PageSpeed integration needs object definition infrastructure to store scan configuration and API credentials. The scan object lacked a name field to identify the scan type, the instance object had no field for the Google PageSpeed API key, and no object action existed to trigger scans.

## How It Is Being Fixed

A scan name picklist (`L_SEO_STUDIO_SCAN_NAMES`) with a `pageSpeed` entry is added so scans can be identified by type. An encrypted `googlePageSpeedAPIKey` field is added to the SEOStudioInstance object definition to securely store the API credential. An object action definition is added to dispatch scans. The scan object definition gains a required `name` picklist field referencing the new list type.

## Why Are There No Tests?

These changes are purely declarative JSON — object definitions, list type definitions, and object actions processed by the site initializer. There is no executable code to test.

## PR Check

**pr-check: PASS** at `c8740f6f96dbdbb0597997610c4ec7a061c3b56a`

| Validation | Result |
|---|---|
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "c8740f6f96dbdbb0597997610c4ec7a061c3b56a"} -->