### PR TITLE
LPD-88536 Skip navigation menu propagation during site template merge

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.exportimport.constants.ExportImportConstants;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.headless.admin.site.dto.v1_0.NavigationMenu;
 import com.liferay.headless.admin.site.dto.v1_0.NavigationMenuItem;
@@ -48,7 +49,10 @@ import com.liferay.site.navigation.type.SiteNavigationMenuItemTypeRegistry;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.io.Serializable;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +73,19 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class NavigationMenuResourceImpl
 	extends BaseNavigationMenuResourceImpl
 	implements ExportImportVulcanBatchEngineTaskItemDelegate<NavigationMenu> {
+
+	@Override
+	public void create(
+			Collection<NavigationMenu> navigationMenus,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		if (MergeLayoutPrototypesThreadLocal.isInProgress()) {
+			return;
+		}
+
+		super.create(navigationMenus, parameters);
+	}
 
 	@Override
 	public void deleteSiteNavigationMenu(

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -28,8 +30,10 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.navigation.constants.SiteNavigationConstants;
 import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
 import com.liferay.sites.kernel.util.Sites;
 
@@ -95,13 +99,18 @@ public class SiteNavigationMenuPropagationTest {
 
 		String name = RandomTestUtil.randomString();
 
-		SiteNavigationMenuTestUtil.addSiteNavigationMenu(_group, name);
+		SiteNavigationMenu groupSiteNavigationMenu =
+			SiteNavigationMenuTestUtil.addSiteNavigationMenu(_group, name);
 
 		Group layoutSetPrototypeGroup = _layoutSetPrototype.getGroup();
 
 		SiteNavigationMenu siteNavigationMenu =
-			SiteNavigationMenuTestUtil.addSiteNavigationMenu(
-				layoutSetPrototypeGroup, name);
+			_siteNavigationMenuLocalService.addSiteNavigationMenu(
+				null, TestPropsValues.getUserId(),
+				layoutSetPrototypeGroup.getGroupId(), name,
+				SiteNavigationConstants.TYPE_DEFAULT, true,
+				ServiceContextTestUtil.getServiceContext(
+					layoutSetPrototypeGroup.getGroupId()));
 
 		_addSiteNavigationMenuWidgetToPage(
 			siteNavigationMenu.getExternalReferenceCode());
@@ -118,6 +127,15 @@ public class SiteNavigationMenuPropagationTest {
 			GetterUtil.getInteger(
 				layoutSetPrototypeSettingsUnicodeProperties.getProperty(
 					Sites.MERGE_FAIL_COUNT)));
+
+		SiteNavigationMenu propagatedSiteNavigationMenu =
+			_siteNavigationMenuLocalService.fetchSiteNavigationMenuByName(
+				_group.getGroupId(), name);
+
+		Assert.assertEquals(
+			groupSiteNavigationMenu.getSiteNavigationMenuId(),
+			propagatedSiteNavigationMenu.getSiteNavigationMenuId());
+		Assert.assertFalse(propagatedSiteNavigationMenu.isAuto());
 	}
 
 	@Test
@@ -253,6 +271,9 @@ public class SiteNavigationMenuPropagationTest {
 	private Layout _prototypeLayout;
 	private SiteNavigationMenu _siteNavigationMenu1;
 	private SiteNavigationMenu _siteNavigationMenu2;
+
+	@Inject
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
 
 	@Inject
 	private Sites _sites;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88536

## What Is Being Fixed

`PortalLogAssertorTest` fails because a `DuplicateSiteNavigationMenuException` is logged during site-template propagation. The scenario (originally reported in LPS-173790) is that a site and the site template it inherits from each have a navigation menu with the same name, and a template page references its own menu. During propagation the new headless flow re-imports the template's navigation menu entity, collides with the inheriting site's same-named menu, and throws. Per LPS-173790 the expected behavior is that a navigation menu should not be propagated from a site template at all.

## How It Is Being Fixed

In the headless flow, `NavigationMenuResourceImpl` is an `ExportImportVulcanBatchEngineTaskItemDelegate`, so a layout-set-prototype merge re-applies navigation menus through its batch `create(...)` method. The fix overrides `create(...)` to return early when `MergeLayoutPrototypesThreadLocal.isInProgress()`, so navigation menu entities are skipped entirely during a merge — short-circuiting the whole post/put/permissions chain rather than just the persistence call. This is the correct layer: guarding the deeper `doPost`/`doPut` methods left the permission lookup (which resolves the menu by external reference code) to run first and throw `NoSuchMenuException` instead. The earlier branch attempt that reused the same-named menu was also reverted, since updating it would propagate the template's menu over the site's — the very behavior LPS-173790 forbids. Navigation menu *references* in portlet preferences continue to be handled by the existing export-import processor. The regression test in `SiteNavigationMenuPropagationTest` was strengthened to give the two same-named menus a distinguishing `auto` flag and assert the inheriting site's menu is left untouched after propagation.

## PR Check

**pr-check: PASS** — tested on `a258f22c1a5497b09fa2a3afd451caec9cbeaa34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a258f22c1a5497b09fa2a3afd451caec9cbeaa34"} -->
