### PR TITLE
LPD-88837 Add PageSpeed client extension scaffold and score provider

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -6898,7 +6898,11 @@
         modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
-        semantic-versioning
+        semantic-versioning,\
+        workspaces-compile
+
+    workspaces.names[workspaces-compile][site-management]=\
+        liferay-seostudio-workspace
 
     #
     # Source Formatter

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/Dockerfile
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/jar-runner:latest
+
+COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/LCP.json
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/LCP.json
@@ -1,0 +1,31 @@
+{
+	"cpu": 1,
+	"env": {
+		"LIFERAY_ROUTES_CLIENT_EXTENSION": "/etc/liferay/lxc/ext-init-metadata",
+		"LIFERAY_ROUTES_DXP": "/etc/liferay/lxc/dxp-metadata"
+	},
+	"environments": {
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "__PROJECT_ID__",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"loadBalancer": {
+		"targetPort": 58081
+	},
+	"memory": 1024,
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"scale": 1
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.18"
+	}
+
+	repositories {
+		maven {
+			url new File(rootProject.projectDir, "../../.m2-tmp")
+		}
+
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.source.formatter"
+apply plugin: "java-library"
+apply plugin: "org.springframework.boot"
+
+dependencies {
+	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "org.json", name: "json", version: "20231013"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
+	testImplementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: "2.7.18"
+}
+
+repositories {
+	maven {
+		url new File(rootProject.projectDir, "../../.m2-tmp")
+	}
+
+	maven {
+		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+	}
+}
+
+test {
+	useJUnitPlatform()
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/client-extension.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/client-extension.yaml
@@ -1,0 +1,22 @@
+assemble:
+    -   fromTask: bootJar
+liferay-seostudio-pagespeed-oahs:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio PageSpeed OAuth Application Headless Server
+    scopes:
+        -   Liferay.Headless.Portal.Instances.read
+        -   c_seostudiodomain.read
+        -   c_seostudioinstance.read
+        -   c_seostudioscan.write
+    type: oAuthApplicationHeadlessServer
+liferay-seostudio-pagespeed-oaua:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio PageSpeed OAuth Application User Agent
+    type: oAuthApplicationUserAgent
+liferay-seostudio-pagespeed-object-action-pagespeed:
+    name: Liferay SEO Studio PageSpeed Object Action PageSpeed
+    oAuth2ApplicationExternalReferenceCode: liferay-seostudio-pagespeed-oaua
+    resourcePath: /object/action/pagespeed
+    type: objectAction

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/ReadyRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/ReadyRestController.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kiana Suetani
+ */
+@RequestMapping("/ready")
+@RestController
+public class ReadyRestController extends BaseRestController {
+
+	@GetMapping
+	public String get() {
+		return "READY";
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/SEOStudioSpringBootApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/SEOStudioSpringBootApplication.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed;
+
+import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Kiana Suetani
+ */
+@Import(ClientExtensionUtilSpringBootComponentScan.class)
+@SpringBootApplication
+public class SEOStudioSpringBootApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SEOStudioSpringBootApplication.class, args);
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProvider.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProvider.java
@@ -1,0 +1,248 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.nio.charset.StandardCharsets;
+
+import java.time.Duration;
+
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProvider {
+
+	public PageSpeedScoreProvider(
+		HttpClient httpClient, String pageSpeedAPIKey, String strategy) {
+
+		if (!Objects.equals(strategy, "DESKTOP") &&
+			!Objects.equals(strategy, "MOBILE")) {
+
+			strategy = "DESKTOP";
+		}
+
+		_httpClient = httpClient;
+		_pageSpeedAPIKey = pageSpeedAPIKey;
+		_strategy = strategy;
+	}
+
+	public PageSpeedScores getScores(String url)
+		throws PageSpeedScoreProviderException {
+
+		try {
+			return _getScores(url);
+		}
+		catch (InterruptedException interruptedException) {
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+
+			throw new PageSpeedScoreProviderException(
+				"Unable to get PageSpeed scores for " + url,
+				interruptedException);
+		}
+		catch (PageSpeedScoreProviderException
+					pageSpeedScoreProviderException) {
+
+			throw pageSpeedScoreProviderException;
+		}
+		catch (Exception exception) {
+			throw new PageSpeedScoreProviderException(
+				"Unable to get PageSpeed scores for " + url, exception);
+		}
+	}
+
+	public boolean isValidConnection() {
+		if (_pageSpeedAPIKey != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static class PageSpeedScoreProviderException extends Exception {
+
+		public PageSpeedScoreProviderException(
+			JSONObject googlePageSpeedErrorJSONObject, String message) {
+
+			super(message);
+
+			_googlePageSpeedErrorJSONObject = googlePageSpeedErrorJSONObject;
+		}
+
+		public PageSpeedScoreProviderException(String message) {
+			super(message);
+
+			_googlePageSpeedErrorJSONObject = null;
+		}
+
+		public PageSpeedScoreProviderException(
+			String message, Throwable throwable) {
+
+			super(message, throwable);
+
+			_googlePageSpeedErrorJSONObject = null;
+		}
+
+		public JSONObject getGooglePageSpeedErrorJSONObject() {
+			return _googlePageSpeedErrorJSONObject;
+		}
+
+		public boolean isQuotaExceeded() {
+			if (_googlePageSpeedErrorJSONObject == null) {
+				return false;
+			}
+
+			JSONObject errorDetailJSONObject =
+				_googlePageSpeedErrorJSONObject.optJSONObject("error");
+
+			if ((errorDetailJSONObject != null) &&
+				(errorDetailJSONObject.optInt("code", -1) == 429)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private final JSONObject _googlePageSpeedErrorJSONObject;
+
+	}
+
+	private String _buildGooglePageSpeedURL(String url) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("https://content-pagespeedonline.googleapis.com");
+		sb.append("/pagespeedonline/v5/runPagespeed");
+		sb.append("?category=ACCESSIBILITY&category=BEST_PRACTICES");
+		sb.append("&category=PERFORMANCE&category=SEO&fields=");
+		sb.append(
+			URLEncoder.encode(
+				"lighthouseResult/categories/*/score", StandardCharsets.UTF_8));
+		sb.append("&key=");
+		sb.append(URLEncoder.encode(_pageSpeedAPIKey, StandardCharsets.UTF_8));
+		sb.append("&strategy=");
+		sb.append(URLEncoder.encode(_strategy, StandardCharsets.UTF_8));
+		sb.append("&url=");
+		sb.append(URLEncoder.encode(url, StandardCharsets.UTF_8));
+
+		return sb.toString();
+	}
+
+	private int _getScore(JSONObject categoriesJSONObject, String category) {
+		JSONObject categoryJSONObject = categoriesJSONObject.optJSONObject(
+			category);
+
+		if (categoryJSONObject == null) {
+			return 0;
+		}
+
+		double score = categoryJSONObject.optDouble("score", 0);
+
+		return (int)Math.round(score * 100);
+	}
+
+	private PageSpeedScores _getScores(String url)
+		throws InterruptedException, PageSpeedScoreProviderException {
+
+		if (!isValidConnection()) {
+			throw new PageSpeedScoreProviderException("Invalid Connection");
+		}
+
+		HttpResponse<String> httpResponse;
+
+		try {
+			HttpRequest httpRequest = HttpRequest.newBuilder(
+			).GET(
+			).timeout(
+				Duration.ofSeconds(120)
+			).uri(
+				URI.create(_buildGooglePageSpeedURL(url))
+			).build();
+
+			httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+		}
+		catch (IOException ioException) {
+			throw new PageSpeedScoreProviderException(
+				"Unable to reach Google PageSpeed API for " + url, ioException);
+		}
+
+		int statusCode = httpResponse.statusCode();
+
+		if (statusCode != HttpURLConnection.HTTP_OK) {
+			JSONObject errorJSONObject = null;
+
+			try {
+				errorJSONObject = new JSONObject(httpResponse.body());
+			}
+			catch (JSONException jsonException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to parse error response as JSON",
+						jsonException);
+				}
+			}
+
+			throw new PageSpeedScoreProviderException(
+				errorJSONObject, "Response code " + statusCode);
+		}
+
+		return _parseScores(httpResponse.body());
+	}
+
+	private PageSpeedScores _parseScores(String responseJSON)
+		throws PageSpeedScoreProviderException {
+
+		JSONObject responseJSONObject = new JSONObject(responseJSON);
+
+		JSONObject lighthouseResultJSONObject =
+			responseJSONObject.optJSONObject("lighthouseResult");
+
+		if (lighthouseResultJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"lighthouseResult\" in response");
+		}
+
+		JSONObject categoriesJSONObject =
+			lighthouseResultJSONObject.optJSONObject("categories");
+
+		if (categoriesJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"categories\" in \"lighthouseResult\"");
+		}
+
+		return new PageSpeedScores(
+			_getScore(categoriesJSONObject, "accessibility"),
+			_getScore(categoriesJSONObject, "best-practices"),
+			_getScore(categoriesJSONObject, "performance"),
+			_getScore(categoriesJSONObject, "seo"));
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		PageSpeedScoreProvider.class);
+
+	private final HttpClient _httpClient;
+	private final String _pageSpeedAPIKey;
+	private final String _strategy;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScores.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScores.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScores {
+
+	public PageSpeedScores(
+		int accessibility, int bestPractices, int performance, int seo) {
+
+		_accessibility = accessibility;
+		_bestPractices = bestPractices;
+		_performance = performance;
+		_seo = seo;
+	}
+
+	public int getAccessibility() {
+		return _accessibility;
+	}
+
+	public int getBestPractices() {
+		return _bestPractices;
+	}
+
+	public int getPerformance() {
+		return _performance;
+	}
+
+	public int getSEO() {
+		return _seo;
+	}
+
+	private final int _accessibility;
+	private final int _bestPractices;
+	private final int _performance;
+	private final int _seo;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/resources/application-default.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/resources/application-default.properties
@@ -1,0 +1,25 @@
+#
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
+# OAuth
+#
+
+liferay-seostudio-pagespeed-oahs.oauth2.headless.server.client.secret=${LIFERAY_SEOSTUDIO_PAGESPEED_OAHS_CLIENT_SECRET:myfancypassword}
+
+liferay.oauth.application.external.reference.codes=\
+    liferay-seostudio-pagespeed-oahs,\
+    liferay-seostudio-pagespeed-oaua
+
+liferay.oauth.urls.excludes=/ready
+
+#
+# Spring Boot
+#
+
+server.port=58081

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/resources/application.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.config.import=\
+    classpath:/application-default.properties,\
+    optional:configtree:${LIFERAY_ROUTES_CLIENT_EXTENSION}/,\
+    optional:configtree:${LIFERAY_ROUTES_DXP}/

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProviderTest.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProviderTest.java
@@ -1,0 +1,154 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProviderTest {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetScores() throws Exception {
+		HttpClient httpClient = Mockito.mock(HttpClient.class);
+
+		HttpResponse<String> httpResponse = Mockito.mock(HttpResponse.class);
+
+		JSONObject responseJSONObject = new JSONObject();
+
+		responseJSONObject.put(
+			"lighthouseResult",
+			new JSONObject(
+			).put(
+				"categories",
+				new JSONObject(
+				).put(
+					"accessibility",
+					new JSONObject(
+					).put(
+						"score", 0.92
+					)
+				).put(
+					"best-practices",
+					new JSONObject(
+					).put(
+						"score", 0.85
+					)
+				).put(
+					"performance",
+					new JSONObject(
+					).put(
+						"score", 0.78
+					)
+				).put(
+					"seo",
+					new JSONObject(
+					).put(
+						"score", 0.95
+					)
+				)
+			));
+
+		Mockito.when(
+			httpResponse.body()
+		).thenReturn(
+			responseJSONObject.toString()
+		);
+
+		Mockito.when(
+			httpResponse.statusCode()
+		).thenReturn(
+			200
+		);
+
+		Mockito.doReturn(
+			httpResponse
+		).when(
+			httpClient
+		).send(
+			Mockito.any(), Mockito.any()
+		);
+
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider(httpClient, "", "DESKTOP");
+
+		PageSpeedScores pageSpeedScores = pageSpeedScoreProvider.getScores("");
+
+		Assertions.assertEquals(92, pageSpeedScores.getAccessibility());
+		Assertions.assertEquals(85, pageSpeedScores.getBestPractices());
+		Assertions.assertEquals(78, pageSpeedScores.getPerformance());
+		Assertions.assertEquals(95, pageSpeedScores.getSEO());
+	}
+
+	@Test
+	public void testIsQuotaExceededWhenErrorIsNonquota() {
+		JSONObject errorJSONObject = new JSONObject();
+
+		errorJSONObject.put(
+			"error",
+			new JSONObject(
+			).put(
+				"code", 403
+			).put(
+				"message", ""
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "");
+
+		Assertions.assertFalse(
+			pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+	@Test
+	public void testIsQuotaExceededWhenErrorJSONIsPresent() {
+		JSONObject errorJSONObject = new JSONObject();
+
+		errorJSONObject.put(
+			"error",
+			new JSONObject(
+			).put(
+				"code", 429
+			).put(
+				"message", ""
+			));
+
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException(
+					errorJSONObject, "");
+
+		Assertions.assertEquals(
+			errorJSONObject,
+			pageSpeedScoreProviderException.
+				getGooglePageSpeedErrorJSONObject());
+		Assertions.assertTrue(
+			pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+	@Test
+	public void testIsQuotaExceededWhenJSONIsNull() {
+		PageSpeedScoreProvider.PageSpeedScoreProviderException
+			pageSpeedScoreProviderException =
+				new PageSpeedScoreProvider.PageSpeedScoreProviderException("");
+
+		Assertions.assertFalse(
+			pageSpeedScoreProviderException.isQuotaExceeded());
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/package.json
+++ b/workspaces/liferay-seostudio-workspace/package.json
@@ -1,0 +1,14 @@
+{
+	"devDependencies": {
+		"@liferay/eslint-plugin": "1.6.0",
+		"@liferay/prettier-plugin": "1.1.5",
+		"@liferay/stylelint-plugin": "1.1.0",
+		"@typescript-eslint/eslint-plugin": "^5.12.1",
+		"@typescript-eslint/parser": "^7.8.0",
+		"babel-eslint": "^10.1.0",
+		"eslint": "7.32.0",
+		"prettier": "3.2.5",
+		"typescript": "4.4.2"
+	},
+	"private": true
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

SEO Studio needs a Spring Boot client extension to call the Google PageSpeed Insights API and return accessibility, best practices, performance, and SEO scores for site pages. No client extension infrastructure existed for this feature.

## How It Is Being Fixed

A new Spring Boot client extension is scaffolded under `workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-pagespeed` with OAuth application definitions (headless server and user agent), a health check endpoint, and a Dockerfile for LXC deployment. The `PageSpeedScoreProvider` calls the Google PageSpeed Insights API for a given URL and parses the lighthouse result categories into discrete scores. Unit tests verify score parsing, error handling, API quota detection, and connection validation.

## PR Check

**pr-check: PASS** — tested on `b28727ef557f5881f15487da2d5592746f80e5a3`

| Validation | Result |
| --- | --- |
| Source Format (gradlew) | PASS |
| Source Format (ant) | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "b28727ef557f5881f15487da2d5592746f80e5a3"} -->