### PR TITLE
LPD-64610 Exclude publication scoped entities from user selectors

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
@@ -12,8 +12,10 @@ import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.GroupItemSelectorReturnType;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -23,8 +25,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletResponse;
@@ -241,9 +245,28 @@ public class DepotGroupItemSelectorView
 					(PortletResponse)_httpServletRequest.getAttribute(
 						JavaConstants.JAKARTA_PORTLET_RESPONSE);
 
-				return _depotEntryAdminSearchProvider.getGroupSearch(
-					_depotGroupItemSelectorCriterion, portletRequest,
-					portletResponse, _portletURL);
+				long ctCollectionId =
+					CTCollectionThreadLocal.getCTCollectionId();
+
+				String itemSelectedEventName = ParamUtil.getString(
+					portletRequest, "itemSelectedEventName");
+
+				if (itemSelectedEventName.contains(
+						UsersAdminPortletKeys.USERS_ADMIN)) {
+
+					ctCollectionId =
+						CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;
+				}
+
+				try (SafeCloseable safeCloseable =
+						CTCollectionThreadLocal.
+							setCTCollectionIdWithSafeCloseable(
+								ctCollectionId)) {
+
+					return _depotEntryAdminSearchProvider.getGroupSearch(
+						_depotGroupItemSelectorCriterion, portletRequest,
+						portletResponse, _portletURL);
+				}
 			}
 			catch (PortalException portalException) {
 				return ReflectionUtil.throwException(portalException);

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/display/context/SelectRoleManagementToolbarDisplayContext.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/display/context/SelectRoleManagementToolbarDisplayContext.java
@@ -7,7 +7,9 @@ package com.liferay.roles.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -28,6 +30,7 @@ import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
 import com.liferay.roles.admin.search.RoleSearch;
 import com.liferay.roles.admin.search.RoleSearchTerms;
 import com.liferay.roles.admin.web.internal.role.type.contributor.util.RoleTypeContributorRetrieverUtil;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import jakarta.portlet.PortletURL;
 import jakarta.portlet.RenderRequest;
@@ -139,34 +142,50 @@ public class SelectRoleManagementToolbarDisplayContext {
 		RoleSearchTerms roleSearchTerms =
 			(RoleSearchTerms)roleSearch.getSearchTerms();
 
-		if (filterManageableRoles) {
-			List<Role> results = RoleLocalServiceUtil.search(
-				themeDisplay.getCompanyId(), roleSearchTerms.getKeywords(),
-				new Integer[] {_currentRoleTypeContributor.getType()},
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				roleSearch.getOrderByComparator());
+		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
-			if (groupId == 0) {
-				results = UsersAdminUtil.filterRoles(
-					themeDisplay.getPermissionChecker(), results);
-			}
-			else {
-				results = UsersAdminUtil.filterGroupRoles(
-					themeDisplay.getPermissionChecker(), groupId, results);
-			}
+		if ((_eventName != null) &&
+			_eventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
 
-			roleSearch.setResultsAndTotal(results);
+			ctCollectionId =
+				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;
 		}
-		else {
-			roleSearch.setResultsAndTotal(
-				() -> RoleLocalServiceUtil.search(
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId)) {
+
+			if (filterManageableRoles) {
+				List<Role> results = RoleLocalServiceUtil.search(
 					themeDisplay.getCompanyId(), roleSearchTerms.getKeywords(),
 					new Integer[] {_currentRoleTypeContributor.getType()},
-					roleSearch.getStart(), roleSearch.getEnd(),
-					roleSearch.getOrderByComparator()),
-				RoleLocalServiceUtil.searchCount(
-					themeDisplay.getCompanyId(), roleSearchTerms.getKeywords(),
-					new Integer[] {_currentRoleTypeContributor.getType()}));
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					roleSearch.getOrderByComparator());
+
+				if (groupId == 0) {
+					results = UsersAdminUtil.filterRoles(
+						themeDisplay.getPermissionChecker(), results);
+				}
+				else {
+					results = UsersAdminUtil.filterGroupRoles(
+						themeDisplay.getPermissionChecker(), groupId, results);
+				}
+
+				roleSearch.setResultsAndTotal(results);
+			}
+			else {
+				roleSearch.setResultsAndTotal(
+					() -> RoleLocalServiceUtil.search(
+						themeDisplay.getCompanyId(),
+						roleSearchTerms.getKeywords(),
+						new Integer[] {_currentRoleTypeContributor.getType()},
+						roleSearch.getStart(), roleSearch.getEnd(),
+						roleSearch.getOrderByComparator()),
+					RoleLocalServiceUtil.searchCount(
+						themeDisplay.getCompanyId(),
+						roleSearchTerms.getKeywords(),
+						new Integer[] {_currentRoleTypeContributor.getType()}));
+			}
 		}
 
 		_roleSearch = roleSearch;

--- a/modules/apps/site/site-item-selector-web/build.gradle
+++ b/modules/apps/site/site-item-selector-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-item-selector-api")
+	compileOnly project(":apps:users-admin:users-admin-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
@@ -6,6 +6,8 @@
 package com.liferay.site.item.selector.web.internal.display.context;
 
 import com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -21,6 +23,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.provider.GroupSearchProvider;
 import com.liferay.site.search.GroupSearch;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletURL;
@@ -73,9 +76,26 @@ public class MySitesItemSelectorViewDisplayContext
 
 		_groupSearch = new GroupSearch(_portletRequest, portletURL);
 
-		GroupSearchProvider.setResultsAndTotal(
-			_getClassNames(), groupItemSelectorCriterion.getExcludedGroupIds(),
-			_groupSearch, _portletRequest);
+		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
+
+		String itemSelectedEventName = getItemSelectedEventName();
+
+		if ((itemSelectedEventName != null) &&
+			itemSelectedEventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
+
+			ctCollectionId =
+				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId)) {
+
+			GroupSearchProvider.setResultsAndTotal(
+				_getClassNames(),
+				groupItemSelectorCriterion.getExcludedGroupIds(), _groupSearch,
+				_portletRequest);
+		}
 
 		if (_groupSearch.getStart() == 0) {
 			if (groupItemSelectorCriterion.isIncludeUserPersonalSite()) {

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
@@ -10,7 +10,9 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:user-groups-admin:user-groups-admin-item-selector-api")
+	compileOnly project(":apps:users-admin:users-admin-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/display/context/UserGroupItemSelectorViewDisplayContext.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/display/context/UserGroupItemSelectorViewDisplayContext.java
@@ -5,6 +5,8 @@
 
 package com.liferay.user.groups.admin.item.selector.web.internal.display.context;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -17,6 +19,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.user.groups.admin.item.selector.UserGroupItemSelectorCriterion;
 import com.liferay.user.groups.admin.item.selector.web.internal.search.UserGroupItemSelectorChecker;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import jakarta.portlet.PortletURL;
 import jakarta.portlet.RenderRequest;
@@ -86,23 +89,40 @@ public class UserGroupItemSelectorViewDisplayContext {
 
 		String keywords = getKeywords();
 
-		if (_userGroupItemSelectorCriterion.isFilterManageableUserGroups()) {
-			_searchContainer.setResultsAndTotal(
-				UsersAdminUtil.filterUserGroups(
-					_themeDisplay.getPermissionChecker(),
-					UserGroupLocalServiceUtil.search(
-						_themeDisplay.getCompanyId(), keywords, null,
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-						_searchContainer.getOrderByComparator())));
+		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
+
+		String itemSelectedEventName = ParamUtil.getString(
+			_renderRequest, "itemSelectedEventName");
+
+		if (itemSelectedEventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
+			ctCollectionId =
+				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;
 		}
-		else {
-			_searchContainer.setResultsAndTotal(
-				() -> _userGroupLocalService.search(
-					_themeDisplay.getCompanyId(), keywords, null,
-					_searchContainer.getStart(), _searchContainer.getEnd(),
-					_searchContainer.getOrderByComparator()),
-				_userGroupLocalService.searchCount(
-					_themeDisplay.getCompanyId(), keywords, null));
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId)) {
+
+			if (_userGroupItemSelectorCriterion.
+					isFilterManageableUserGroups()) {
+
+				_searchContainer.setResultsAndTotal(
+					UsersAdminUtil.filterUserGroups(
+						_themeDisplay.getPermissionChecker(),
+						UserGroupLocalServiceUtil.search(
+							_themeDisplay.getCompanyId(), keywords, null,
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+							_searchContainer.getOrderByComparator())));
+			}
+			else {
+				_searchContainer.setResultsAndTotal(
+					() -> _userGroupLocalService.search(
+						_themeDisplay.getCompanyId(), keywords, null,
+						_searchContainer.getStart(), _searchContainer.getEnd(),
+						_searchContainer.getOrderByComparator()),
+					_userGroupLocalService.searchCount(
+						_themeDisplay.getCompanyId(), keywords, null));
+			}
 		}
 
 		_searchContainer.setRowChecker(

--- a/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
@@ -135,6 +135,10 @@ export class EditUserPage {
 	readonly screenNameError: Locator;
 	readonly screenNameInput: Locator;
 	readonly selectAccountsButton: Locator;
+	readonly selectAssetLibrariesButton: Locator;
+	readonly selectAssetLibrariesFrame: FrameLocator;
+	readonly selectAssetLibrariesFrameEntry: (name: string) => Locator;
+	readonly selectAssetLibrariesSearchBar: Locator;
 	readonly selectOrganizationRolesButton: Locator;
 	readonly selectOrganizationRolesChooseButton: (
 		name: string
@@ -185,6 +189,8 @@ export class EditUserPage {
 	readonly selectSitesTableRowButton: (siteName: string) => Promise<Locator>;
 	readonly selectTagsButton: Locator;
 	readonly selectUserGroupIFrame: FrameLocator;
+	readonly selectUserGroupFrameEntry: (name: string) => Locator;
+	readonly selectUserGroupSearchBar: Locator;
 	readonly selectUserGroupTable: DataTablePage;
 	readonly selectUserGroupsButton: Locator;
 	readonly selectUserLanguage: Locator;
@@ -579,6 +585,16 @@ export class EditUserPage {
 		);
 		this.screenNameInput = page.getByLabel('Screen Name');
 		this.selectAccountsButton = page.getByLabel('Select Accounts');
+		this.selectAssetLibrariesButton = page.locator(
+			'#_com_liferay_users_admin_web_portlet_UsersAdminPortlet_selectDepotGroupLink'
+		);
+		this.selectAssetLibrariesFrame = page.frameLocator(
+			'iframe[title^="Select Asset Librar"]'
+		);
+		this.selectAssetLibrariesFrameEntry = (name) =>
+			this.selectAssetLibrariesFrame.getByText(name, {exact: true});
+		this.selectAssetLibrariesSearchBar =
+			this.selectAssetLibrariesFrame.getByPlaceholder('Search for');
 		this.selectOrganizationRolesButton = page.locator(
 			'#_com_liferay_users_admin_web_portlet_UsersAdminPortlet_selectOrganizationRoleLink'
 		);
@@ -756,6 +772,10 @@ export class EditUserPage {
 		this.selectUserGroupIFrame = page.frameLocator(
 			'iframe[title="Select User Group"]'
 		);
+		this.selectUserGroupFrameEntry = (name) =>
+			this.selectUserGroupIFrame.getByText(name, {exact: true});
+		this.selectUserGroupSearchBar =
+			this.selectUserGroupIFrame.getByPlaceholder('Search for');
 		this.selectUserGroupTable = new DataTablePage(
 			this.selectUserGroupIFrame,
 			this.selectUserGroupIFrame.locator(

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsUserMembershipSelectors.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsUserMembershipSelectors.spec.ts
@@ -1,0 +1,271 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
+import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../utils/getRandomString';
+
+const test = mergeTests(
+	apiHelpersTest,
+	changeTrackingPagesTest,
+	usersAndOrganizationsPagesTest
+);
+
+test(
+	'Does not list a publication scoped role in the regular roles selector',
+	{tag: '@LPD-64610'},
+	async ({
+		apiHelpers,
+		changeTrackingPage,
+		ctCollection,
+		editUserPage,
+		usersAndOrganizationsPage,
+	}) => {
+		const productionRole = await apiHelpers.headlessAdminUser.postRole({
+			name: getRandomString(),
+		});
+
+		try {
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			const publicationRole = await apiHelpers.headlessAdminUser.postRole(
+				{
+					name: getRandomString(),
+				}
+			);
+
+			await usersAndOrganizationsPage.goToUsers();
+			await usersAndOrganizationsPage.goToUser('Test Test');
+
+			await editUserPage.rolesLink.click();
+
+			await clickAndExpectToBeVisible({
+				target: editUserPage.selectRegularRolesSearchInput,
+				trigger: editUserPage.selectRegularRolesButton,
+			});
+
+			await editUserPage.selectRegularRolesSearchInput.fill(
+				productionRole.name
+			);
+			await editUserPage.selectRegularRolesSearchInput.press('Enter');
+
+			await expect(
+				editUserPage.selectRegularRolesFrame.getByText(
+					productionRole.name,
+					{exact: true}
+				)
+			).toBeVisible();
+
+			await editUserPage.selectRegularRolesSearchInput.fill(
+				publicationRole.name
+			);
+			await editUserPage.selectRegularRolesSearchInput.press('Enter');
+
+			await expect(
+				editUserPage.selectRegularRolesFrame.getByText(
+					publicationRole.name,
+					{exact: true}
+				)
+			).toHaveCount(0);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.checkoutCTCollection(0);
+
+			await apiHelpers.headlessAdminUser.deleteRole(productionRole.id);
+		}
+	}
+);
+
+test(
+	'Does not list a publication scoped site in the sites selector',
+	{tag: '@LPD-64610'},
+	async ({
+		apiHelpers,
+		changeTrackingPage,
+		ctCollection,
+		editUserPage,
+		usersAndOrganizationsPage,
+	}) => {
+		const productionSite = await apiHelpers.headlessAdminSite.postSite({
+			name: getRandomString(),
+		});
+
+		try {
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			const publicationSite = await apiHelpers.headlessAdminSite.postSite(
+				{
+					name: getRandomString(),
+				}
+			);
+
+			await usersAndOrganizationsPage.goToUsers();
+			await usersAndOrganizationsPage.goToUser('Test Test');
+
+			await editUserPage.membershipsLink.click();
+
+			await clickAndExpectToBeVisible({
+				target: editUserPage.selectSiteSearchBar,
+				trigger: editUserPage.selectSiteButton,
+			});
+
+			await editUserPage.selectSiteSearchBar.fill(productionSite.name);
+			await editUserPage.selectSiteSearchBarButton.click();
+
+			await expect(
+				editUserPage.selectSiteFrameSiteLink(productionSite.name)
+			).toBeVisible();
+
+			await editUserPage.selectSiteSearchBar.fill(publicationSite.name);
+			await editUserPage.selectSiteSearchBarButton.click();
+
+			await expect(
+				editUserPage.selectSiteFrameSiteLink(publicationSite.name)
+			).toHaveCount(0);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.checkoutCTCollection(0);
+
+			await apiHelpers.headlessAdminSite.deleteSite(
+				productionSite.externalReferenceCode
+			);
+		}
+	}
+);
+
+test(
+	'Does not list a publication scoped user group in the user groups selector',
+	{tag: '@LPD-64610'},
+	async ({
+		apiHelpers,
+		changeTrackingPage,
+		ctCollection,
+		editUserPage,
+		usersAndOrganizationsPage,
+	}) => {
+		const productionUserGroup =
+			await apiHelpers.headlessAdminUser.postUserGroup({
+				name: getRandomString(),
+			});
+
+		try {
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			const publicationUserGroup =
+				await apiHelpers.headlessAdminUser.postUserGroup({
+					name: getRandomString(),
+				});
+
+			await usersAndOrganizationsPage.goToUsers();
+			await usersAndOrganizationsPage.goToUser('Test Test');
+
+			await editUserPage.membershipsLink.click();
+
+			await clickAndExpectToBeVisible({
+				target: editUserPage.selectUserGroupSearchBar,
+				trigger: editUserPage.selectUserGroupsButton,
+			});
+
+			await editUserPage.selectUserGroupSearchBar.fill(
+				productionUserGroup.name
+			);
+			await editUserPage.selectUserGroupSearchBar.press('Enter');
+
+			await expect(
+				editUserPage.selectUserGroupFrameEntry(productionUserGroup.name)
+			).toBeVisible();
+
+			await editUserPage.selectUserGroupSearchBar.fill(
+				publicationUserGroup.name
+			);
+			await editUserPage.selectUserGroupSearchBar.press('Enter');
+
+			await expect(
+				editUserPage.selectUserGroupFrameEntry(
+					publicationUserGroup.name
+				)
+			).toHaveCount(0);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.checkoutCTCollection(0);
+
+			await apiHelpers.headlessAdminUser.deleteUserGroup(
+				productionUserGroup.id
+			);
+		}
+	}
+);
+
+test(
+	'Does not list a publication scoped asset library in the asset libraries selector',
+	{tag: '@LPD-64610'},
+	async ({
+		apiHelpers,
+		changeTrackingPage,
+		ctCollection,
+		editUserPage,
+		usersAndOrganizationsPage,
+	}) => {
+		const productionAssetLibraryName = getRandomString();
+
+		const productionDepotEntry =
+			await apiHelpers.jsonWebServicesDepot.addDepotEntry(
+				productionAssetLibraryName
+			);
+
+		try {
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			const publicationAssetLibraryName = getRandomString();
+
+			await apiHelpers.jsonWebServicesDepot.addDepotEntry(
+				publicationAssetLibraryName
+			);
+
+			await usersAndOrganizationsPage.goToUsers();
+			await usersAndOrganizationsPage.goToUser('Test Test');
+
+			await editUserPage.membershipsLink.click();
+
+			await clickAndExpectToBeVisible({
+				target: editUserPage.selectAssetLibrariesSearchBar,
+				trigger: editUserPage.selectAssetLibrariesButton,
+			});
+
+			await editUserPage.selectAssetLibrariesSearchBar.fill(
+				productionAssetLibraryName
+			);
+			await editUserPage.selectAssetLibrariesSearchBar.press('Enter');
+
+			await expect(
+				editUserPage.selectAssetLibrariesFrameEntry(
+					productionAssetLibraryName
+				)
+			).toBeVisible();
+
+			await editUserPage.selectAssetLibrariesSearchBar.fill(
+				publicationAssetLibraryName
+			);
+			await editUserPage.selectAssetLibrariesSearchBar.press('Enter');
+
+			await expect(
+				editUserPage.selectAssetLibrariesFrameEntry(
+					publicationAssetLibraryName
+				)
+			).toHaveCount(0);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.checkoutCTCollection(0);
+
+			await apiHelpers.jsonWebServicesDepot.deleteDepotEntry(
+				productionDepotEntry.depotEntryId
+			);
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-64610

## What Is Being Fixed

When editing a user in Production, the Select dialogs for Regular Roles, Sites, User Groups, and Asset Libraries listed entities that belong to an unpublished publication. Those entities are change tracking enabled, and the selector renders in whatever publication the session has checked out, while the user edit screen and its save are forced to Production. Picking a publication scoped entity therefore failed to save and the change was lost.

## How It Is Being Fixed

Each selector now resolves the active change tracking collection from CTCollectionThreadLocal and, when the selector is opened from the Users portlet, overrides it to Production before running the entity query. The Users portlet is detected by testing whether the item selected event name starts with the Users portlet namespace (PortalUtil.getPortletNamespace(UsersAdminPortletKeys.USERS_ADMIN)). This keeps the listed entities aligned with what the Production scoped save can persist, while leaving the same selectors publication aware when opened from content scope pickers, the Segments rule editor, or the regular admin screens.

The roles selector reads the event name from its display context field; the user groups, sites, and asset libraries selectors read it from the item selected event name request parameter. Playwright tests in change-tracking-web cover all four selectors.

## PR Check

**pr-check: PASS** — tested on `510a2d06725444c1dfa9c4a8ce31aaebd5b31a8a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "510a2d06725444c1dfa9c4a8ce31aaebd5b31a8a"} -->