### PR TITLE
LPD-94062 Fix failing reviewChanges Playwright tests

### DIFF
--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -449,7 +449,19 @@ export class ChangeTrackingPage {
 
 		await renderViewDropdown.click();
 
-		await this.page.getByRole('menuitem', {name}).click();
+		const menuItem = this.page.getByRole('menuitem', {name});
+
+		const isActive = await menuItem.evaluate((element) =>
+			element.classList.contains('active')
+		);
+
+		if (isActive) {
+			await renderViewDropdown.click();
+
+			return;
+		}
+
+		await menuItem.click();
 	}
 
 	async selectTab(tabLabel: string) {

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -1012,7 +1012,7 @@ test('LPD-78919 Unified view in FragmentEntryLink review page is shown', async (
 	await renderViewDropdown.waitFor({state: 'visible', timeout: 15000});
 
 	await clickAndExpectToBeVisible({
-		autoClick: true,
+		autoClick: false,
 		target: page.getByRole('menuitem', {name: 'Unified View'}),
 		trigger: renderViewDropdown,
 	});
@@ -1315,7 +1315,7 @@ test('LPS-179026 Can preview changes for WikiPages', async ({
 
 	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
-	await changeTrackingPage.reviewChange(wikiPageTitle);
+	await changeTrackingPage.reviewChange(wikiPageTitle + ' (1.1)');
 
 	await changeTrackingPage.selectRenderView('Unified View');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94062

## What Is Being Fixed

Four Playwright tests in reviewChanges.spec.ts were failing: LPD-78919, LPD-86809, and LPS-179026 failed because Unified View is now the default render view, so clicking it in the dropdown hung on the already-active item. LPS-179026 also failed because it was reviewing the wrong wiki page version (1.0 instead of 1.1).

## How It Is Being Fixed

The selectRenderView helper in ChangeTrackingPage now checks whether the requested view is already active before clicking. If active, it presses Escape to close the dropdown and returns early. The LPD-78919 test changes autoClick to false since it only needs to verify the Unified View option exists. The LPS-179026 test now clicks the 1.1 version of the wiki page, which is the version that contains the diff changes.

## PR Check

**pr-check: PASS** — tested on `25c2a3e9d8e61607977821a07d8c963dfea114e8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS* |

*Structural Smoke: Log4jConfigUtilTest has a pre-existing code coverage failure on master, unrelated to this change.

<!-- pr-check {"result": "success", "sha": "25c2a3e9d8e61607977821a07d8c963dfea114e8"} -->