### PR TITLE
LPD-43418 Edit button in CTTimeline icon not working correctly after LPD-20556

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-api/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking REST API
 Bundle-SymbolicName: com.liferay.change.tracking.rest.api
-Bundle-Version: 8.0.4
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.change.tracking.rest.dto.v1_0,\
 	com.liferay.change.tracking.rest.resource.v1_0

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/CTEntry.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/CTEntry.java
@@ -428,6 +428,49 @@ public class CTEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<Date> _dateModifiedSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Portal URL to the edit page for this entry."
+	)
+	public String getEditURL() {
+		if (_editURLSupplier != null) {
+			editURL = _editURLSupplier.get();
+
+			_editURLSupplier = null;
+		}
+
+		return editURL;
+	}
+
+	public void setEditURL(String editURL) {
+		this.editURL = editURL;
+
+		_editURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setEditURL(
+		UnsafeSupplier<String, Exception> editURLUnsafeSupplier) {
+
+		_editURLSupplier = () -> {
+			try {
+				return editURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "Portal URL to the edit page for this entry.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String editURL;
+
+	@JsonIgnore
+	private Supplier<String> _editURLSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	public Boolean getHideable() {
 		if (_hideableSupplier != null) {
@@ -1083,6 +1126,22 @@ public class CTEntry implements Serializable {
 			sb.append("\"");
 		}
 
+		String editURL = getEditURL();
+
+		if (editURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"editURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(editURL));
+
+			sb.append("\"");
+		}
+
 		Boolean hideable = getHideable();
 
 		if (hideable != null) {
@@ -1348,4 +1407,4 @@ public class CTEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-590108986
+// LIFERAY-REST-BUILDER-HASH:1402194769

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/resources/com/liferay/change/tracking/rest/dto/v1_0/packageinfo
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/resources/com/liferay/change/tracking/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.1
+version 2.3.0

--- a/modules/apps/change-tracking/change-tracking-rest-client-js/src/models/CTEntry.ts
+++ b/modules/apps/change-tracking/change-tracking-rest-client-js/src/models/CTEntry.ts
@@ -20,6 +20,7 @@
 			"ctCollectionStatusUserName"?: string;
 			"dateCreated"?: Date;
 			"dateModified"?: Date;
+			"editURL"?: string;
 			"hideable"?: boolean;
 			"id"?: number;
 			"modelClassNameId"?: number;
@@ -84,6 +85,11 @@
 			baseName: "dateModified",
 			name: "dateModified",
 			type: "Date",
+		},
+		{
+			baseName: "editURL",
+			name: "editURL",
+			type: "string",
 		},
 		{
 			baseName: "hideable",

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/CTEntry.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/CTEntry.java
@@ -221,6 +221,27 @@ public class CTEntry implements Cloneable, Serializable {
 
 	protected Date dateModified;
 
+	public String getEditURL() {
+		return editURL;
+	}
+
+	public void setEditURL(String editURL) {
+		this.editURL = editURL;
+	}
+
+	public void setEditURL(
+		UnsafeSupplier<String, Exception> editURLUnsafeSupplier) {
+
+		try {
+			editURL = editURLUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String editURL;
+
 	public Boolean getHideable() {
 		return hideable;
 	}
@@ -503,4 +524,4 @@ public class CTEntry implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1257096928
+// LIFERAY-REST-BUILDER-HASH:1753145406

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CTEntrySerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CTEntrySerDes.java
@@ -167,6 +167,20 @@ public class CTEntrySerDes {
 			sb.append("\"");
 		}
 
+		if (ctEntry.getEditURL() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"editURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(ctEntry.getEditURL()));
+
+			sb.append("\"");
+		}
+
 		if (ctEntry.getHideable() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -405,6 +419,13 @@ public class CTEntrySerDes {
 				liferayToJSONDateFormat.format(ctEntry.getDateModified()));
 		}
 
+		if (ctEntry.getEditURL() == null) {
+			map.put("editURL", null);
+		}
+		else {
+			map.put("editURL", String.valueOf(ctEntry.getEditURL()));
+		}
+
 		if (ctEntry.getHideable() == null) {
 			map.put("hideable", null);
 		}
@@ -542,6 +563,9 @@ public class CTEntrySerDes {
 			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "editURL")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "hideable")) {
 				return false;
 			}
@@ -643,6 +667,11 @@ public class CTEntrySerDes {
 				if (jsonParserFieldValue != null) {
 					ctEntry.setDateModified(
 						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "editURL")) {
+				if (jsonParserFieldValue != null) {
+					ctEntry.setEditURL((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "hideable")) {
@@ -791,4 +820,4 @@ public class CTEntrySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1485797171
+// LIFERAY-REST-BUILDER-HASH:-254688070

--- a/modules/apps/change-tracking/change-tracking-rest-impl/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations-jakarta", version: "2.2.28"

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -91,6 +91,11 @@ components:
                     format: date-time
                     readOnly: true
                     type: string
+                editURL:
+                    description:
+                        Portal URL to the edit page for this entry.
+                    readOnly: true
+                    type: string
                 hideable:
                     readOnly: true
                     type: boolean

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -8,6 +8,7 @@ package com.liferay.change.tracking.rest.internal.dto.v1_0.converter;
 import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.rest.dto.v1_0.CTEntry;
 import com.liferay.change.tracking.rest.dto.v1_0.Status;
+import com.liferay.change.tracking.spi.display.CTDisplayRendererRegistry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -15,10 +16,12 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -153,6 +156,35 @@ public class CTEntryDTOConverter
 					});
 				setDateCreated(ctEntry::getCreateDate);
 				setDateModified(ctEntry::getModifiedDate);
+				setEditURL(
+					() -> {
+						if (!document.hasField(Field.GROUP_ID)) {
+							return null;
+						}
+
+						long groupId = GetterUtil.getLong(
+							document.get(Field.GROUP_ID));
+
+						if (groupId <= 0) {
+							return null;
+						}
+
+						HttpServletRequest httpServletRequest =
+							dtoConverterContext.getHttpServletRequest();
+
+						ThemeDisplay themeDisplay =
+							(ThemeDisplay)httpServletRequest.getAttribute(
+								WebKeys.THEME_DISPLAY);
+
+						if (themeDisplay == null) {
+							return null;
+						}
+
+						themeDisplay.setScopeGroupId(groupId);
+
+						return _ctDisplayRendererRegistry.getEditURL(
+							httpServletRequest, ctEntry);
+					});
 				setHideable(
 					() -> GetterUtil.getBoolean(document.get("hideable")));
 				setId(ctEntry::getCtEntryId);
@@ -220,6 +252,9 @@ public class CTEntryDTOConverter
 			}
 		};
 	}
+
+	@Reference
+	private CTDisplayRendererRegistry _ctDisplayRendererRegistry;
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
@@ -208,7 +208,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cTEntry(ctEntryId: ___){actions, changeType, ctCollectionId, ctCollectionName, ctCollectionStatus, ctCollectionStatusDate, ctCollectionStatusUserName, dateCreated, dateModified, hideable, id, modelClassNameId, modelClassPK, ownerId, ownerName, siteId, siteName, status, statusMessage, title, typeName}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cTEntry(ctEntryId: ___){actions, changeType, ctCollectionId, ctCollectionName, ctCollectionStatus, ctCollectionStatusDate, ctCollectionStatusUserName, dateCreated, dateModified, editURL, hideable, id, modelClassNameId, modelClassPK, ownerId, ownerName, siteId, siteName, status, statusMessage, title, typeName}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public CTEntry cTEntry(@GraphQLName("ctEntryId") Long ctEntryId)
@@ -250,7 +250,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {ctCollectionCTEntryByModelClassNameByModelClassPkModelClassPK(ctCollectionId: ___, modelClassNameId: ___, modelClassPK: ___){actions, changeType, ctCollectionId, ctCollectionName, ctCollectionStatus, ctCollectionStatusDate, ctCollectionStatusUserName, dateCreated, dateModified, hideable, id, modelClassNameId, modelClassPK, ownerId, ownerName, siteId, siteName, status, statusMessage, title, typeName}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {ctCollectionCTEntryByModelClassNameByModelClassPkModelClassPK(ctCollectionId: ___, modelClassNameId: ___, modelClassPK: ___){actions, changeType, ctCollectionId, ctCollectionName, ctCollectionStatus, ctCollectionStatusDate, ctCollectionStatusUserName, dateCreated, dateModified, editURL, hideable, id, modelClassNameId, modelClassPK, ownerId, ownerName, siteId, siteName, status, statusMessage, title, typeName}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public CTEntry
@@ -724,4 +724,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-602052383
+// LIFERAY-REST-BUILDER-HASH:-721888377

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
@@ -16,6 +16,8 @@ import com.liferay.change.tracking.spi.history.CTCollectionHistoryProvider;
 import com.liferay.change.tracking.spi.history.CTCollectionHistoryProviderRegistry;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.events.ServicePreAction;
+import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.BooleanClause;
@@ -28,10 +30,14 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -39,6 +45,8 @@ import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -132,6 +140,8 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			Long classNameId, Long classPK, String search, Long siteId,
 			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
+
+		_initThemeDisplay();
 
 		if (ArrayUtil.isEmpty(sorts)) {
 			sorts = new Sort[] {
@@ -290,6 +300,34 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			null, contextHttpServletRequest, ctEntry.getCtCollectionId(),
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
+	}
+
+	private void _initThemeDisplay() throws Exception {
+		contextHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL,
+			ParamUtil.getString(contextHttpServletRequest, "currentURL"));
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)contextHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay != null) {
+			return;
+		}
+
+		HttpServletResponse httpServletResponse =
+			new DummyHttpServletResponse();
+
+		ServicePreAction servicePreAction = new ServicePreAction();
+
+		servicePreAction.servicePre(
+			contextHttpServletRequest, httpServletResponse, false);
+
+		ThemeServicePreAction themeServicePreAction =
+			new ThemeServicePreAction();
+
+		themeServicePreAction.run(
+			contextHttpServletRequest, httpServletResponse);
 	}
 
 	private CTEntry _toCTEntry(Long ctEntryId) throws Exception {

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTEntryResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTEntryResourceTestCase.java
@@ -200,6 +200,7 @@ public abstract class BaseCTEntryResourceTestCase {
 		ctEntry.setChangeType(regex);
 		ctEntry.setCtCollectionName(regex);
 		ctEntry.setCtCollectionStatusUserName(regex);
+		ctEntry.setEditURL(regex);
 		ctEntry.setOwnerName(regex);
 		ctEntry.setSiteName(regex);
 		ctEntry.setStatusMessage(regex);
@@ -215,6 +216,7 @@ public abstract class BaseCTEntryResourceTestCase {
 		Assert.assertEquals(regex, ctEntry.getChangeType());
 		Assert.assertEquals(regex, ctEntry.getCtCollectionName());
 		Assert.assertEquals(regex, ctEntry.getCtCollectionStatusUserName());
+		Assert.assertEquals(regex, ctEntry.getEditURL());
 		Assert.assertEquals(regex, ctEntry.getOwnerName());
 		Assert.assertEquals(regex, ctEntry.getSiteName());
 		Assert.assertEquals(regex, ctEntry.getStatusMessage());
@@ -1587,6 +1589,14 @@ public abstract class BaseCTEntryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("editURL", additionalAssertFieldName)) {
+				if (ctEntry.getEditURL() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("hideable", additionalAssertFieldName)) {
 				if (ctEntry.getHideable() == null) {
 					valid = false;
@@ -1886,6 +1896,16 @@ public abstract class BaseCTEntryResourceTestCase {
 				if (!Objects.deepEquals(
 						ctEntry1.getDateModified(),
 						ctEntry2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("editURL", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						ctEntry1.getEditURL(), ctEntry2.getEditURL())) {
 
 					return false;
 				}
@@ -2351,6 +2371,52 @@ public abstract class BaseCTEntryResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("editURL")) {
+			Object object = ctEntry.getEditURL();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("hideable")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2673,6 +2739,7 @@ public abstract class BaseCTEntryResourceTestCase {
 					RandomTestUtil.randomString());
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
+				editURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				hideable = RandomTestUtil.randomBoolean();
 				id = RandomTestUtil.randomLong();
 				modelClassNameId = RandomTestUtil.randomLong();
@@ -2936,4 +3003,4 @@ public abstract class BaseCTEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1502908298
+// LIFERAY-REST-BUILDER-HASH:-1452172856

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewTimelineHistoryDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewTimelineHistoryDisplayContext.java
@@ -80,18 +80,15 @@ public class ViewTimelineHistoryDisplayContext {
 				_language.get(_httpServletRequest, "discard"), "get",
 				"view-discard", null),
 			new FDSActionDropdownItem(
-				StringBundler.concat(
-					"javascript:window.open('",
-					PortletURLBuilder.createActionURL(
-						_renderResponse
-					).setActionName(
-						"/change_tracking/checkout_ct_collection"
-					).setRedirect(
-						ParamUtil.getString(_renderRequest, "redirect")
-					).setParameter(
-						"ctCollectionId", "{ctCollectionId}"
-					).buildString(),
-					"', '_top');"),
+				PortletURLBuilder.createActionURL(
+					_renderResponse
+				).setActionName(
+					"/change_tracking/checkout_ct_collection"
+				).setRedirect(
+					"{editURL}"
+				).setParameter(
+					"ctCollectionId", "{ctCollectionId}"
+				).buildString(),
 				"pencil", "edit",
 				_language.format(
 					_httpServletRequest, "edit-in-x",

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/ChangeTrackingIndicatorDynamicInclude.java
@@ -746,21 +746,24 @@ public class ChangeTrackingIndicatorDynamicInclude extends BaseDynamicInclude {
 						PortletRequest.ACTION_PHASE)
 				).setActionName(
 					"/change_tracking/checkout_ct_collection"
-				).setRedirect(
-					_portal.getCurrentURL(httpServletRequest)
 				).buildString());
 
 			data.put("timelineIconClass", "change-tracking-timeline-icon");
 			data.put("timelineIconName", "time");
 
-			String timelineItemsURL = StringBundler.concat(
-				_portal.getPortalURL(themeDisplay),
-				"/o/change-tracking-rest/v1.0/ct-entries/history?",
-				"classNameId=", classNameId);
+			String timelineItemsURL =
+				_portal.getPortalURL(themeDisplay) +
+					"/o/change-tracking-rest/v1.0/ct-entries/history";
+
+			timelineItemsURL = HttpComponentsUtil.addParameter(
+				timelineItemsURL, "classNameId", classNameId);
+			timelineItemsURL = HttpComponentsUtil.addParameter(
+				timelineItemsURL, "currentURL",
+				_portal.getCurrentURL(httpServletRequest));
 
 			if (classPK != 0) {
-				timelineItemsURL = StringBundler.concat(
-					timelineItemsURL, "&classPK=", classPK);
+				timelineItemsURL = HttpComponentsUtil.addParameter(
+					timelineItemsURL, "classPK", classPK);
 			}
 
 			data.put("timelineItemsURL", timelineItemsURL);

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -708,7 +708,6 @@ export default function ChangeTrackingIndicator({
 				>
 					<PublicationTimeline
 						namespace={namespace}
-						navigate={navigate}
 						spritemap={spritemap}
 						timelineClassNameId={timelineClassNameId}
 						timelineClassPK={timelineClassPK}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -21,7 +21,6 @@ import {
 
 const PublicationTimeline = ({
 	namespace,
-	navigate,
 	spritemap,
 	timelineClassNameId,
 	timelineClassPK,
@@ -94,7 +93,6 @@ const PublicationTimeline = ({
 							>
 								<TimelineDropdownMenu
 									namespace={namespace}
-									navigate={navigate}
 									timelineClassNameId={timelineClassNameId}
 									timelineClassPK={timelineItem.modelClassPK}
 									timelineEditURL={timelineEditURL}
@@ -169,12 +167,17 @@ const PublicationTimeline = ({
 												),
 												onClick: ({processClose}) => {
 													processClose();
+
+													window.top.location.reload();
 												},
 											},
 										],
 										id: `${namespace}publication-timeline-history-modal`,
 										iframeBodyCssClass:
 											'entity-history-modal',
+										onClose: function destroy() {
+											window.top.location.reload();
+										},
 										size: 'full-screen',
 										title: Liferay.Language.get(
 											'view-entity-modification-history'

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/TimelineDropdownMenu.js
@@ -5,12 +5,16 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import {createPortletURL, getPortletId, sub} from 'frontend-js-web';
+import {
+	createPortletURL,
+	getPortletId,
+	navigate as navigateUtil,
+	sub,
+} from 'frontend-js-web';
 import React from 'react';
 
 export default function TimelineDropdownMenu({
 	namespace,
-	navigate,
 	spritemap,
 	timelineClassNameId,
 	timelineClassPK,
@@ -34,6 +38,19 @@ export default function TimelineDropdownMenu({
 		).toString();
 	};
 
+	const checkoutParameters = {
+		ctCollectionId: timelineItem.ctCollectionId,
+	};
+
+	if (timelineItem.editURL) {
+		checkoutParameters.redirect = createPortletURL(timelineItem.editURL);
+	}
+
+	const checkoutURL = createPortletURL(
+		timelineEditURL,
+		checkoutParameters
+	).toString();
+
 	const discardURL = createMVCRenderCommandURL(
 		'/change_tracking/view_discard',
 		{
@@ -41,10 +58,6 @@ export default function TimelineDropdownMenu({
 			modelClassPK: timelineClassPK,
 		}
 	);
-
-	const checkoutURL = createPortletURL(timelineEditURL, {
-		ctCollectionId: timelineItem.ctCollectionId,
-	}).toString();
 
 	const moveURL = createMVCRenderCommandURL(
 		'/change_tracking/view_move_changes',
@@ -59,7 +72,6 @@ export default function TimelineDropdownMenu({
 
 	if (!!timelineItem.actions.update && checkoutURL) {
 		dropdownItems.push({
-			action: true,
 			href: checkoutURL,
 			label: sub(
 				Liferay.Language.get('edit-in-x'),
@@ -102,9 +114,7 @@ export default function TimelineDropdownMenu({
 						borderless
 						className="dropdown-item"
 						displayType="unstyled"
-						onClick={() =>
-							navigate(dropdownItem.href, dropdownItem.action)
-						}
+						onClick={() => navigateUtil(dropdownItem.href)}
 					>
 						<span className="inline-item inline-item-before">
 							<ClayIcon

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/InstanceDetails.js
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/InstanceDetails.js
@@ -98,7 +98,7 @@ function handlePublish({WORKFLOW_ACTION_PUBLISH, namespace}) {
 				workflowActionInput.value = WORKFLOW_ACTION_PUBLISH;
 			}
 
-			submitForm(form);
+			form.requestSubmit();
 		};
 
 		const skuInput = document.getElementById(`${namespace}sku`);

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
@@ -116,7 +116,8 @@ public abstract class BaseFDSSerializer {
 					"items", _toJSONArray(ownedObjectEntries)
 				).put(
 					"label",
-					language.get(httpServletRequest.getLocale(), "owned")
+					language.get(
+						PortalUtil.getLocale(httpServletRequest), "owned")
 				));
 
 			if (!sharedObjectEntries.isEmpty()) {
@@ -128,7 +129,8 @@ public abstract class BaseFDSSerializer {
 					).put(
 						"label",
 						language.get(
-							httpServletRequest.getLocale(), "shared-with-me")
+							PortalUtil.getLocale(httpServletRequest),
+							"shared-with-me")
 					));
 			}
 

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/bnd.bnd
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless DSR API
 Bundle-SymbolicName: com.liferay.headless.dsr.api
-Bundle-Version: 1.1.1
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.headless.dsr.dto.v1_0,\
 	com.liferay.headless.dsr.resource.v1_0

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/dto/v1_0/Room.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/dto/v1_0/Room.java
@@ -1,0 +1,456 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Room")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Room")
+public class Room implements Serializable {
+
+	public static Room toDTO(String json) {
+		return ObjectMapperUtil.readValue(Room.class, json);
+	}
+
+	public static Room unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Room.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long[] getFileEntryIds() {
+		if (_fileEntryIdsSupplier != null) {
+			fileEntryIds = _fileEntryIdsSupplier.get();
+
+			_fileEntryIdsSupplier = null;
+		}
+
+		return fileEntryIds;
+	}
+
+	public void setFileEntryIds(Long[] fileEntryIds) {
+		this.fileEntryIds = fileEntryIds;
+
+		_fileEntryIdsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFileEntryIds(
+		UnsafeSupplier<Long[], Exception> fileEntryIdsUnsafeSupplier) {
+
+		_fileEntryIdsSupplier = () -> {
+			try {
+				return fileEntryIdsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long[] fileEntryIds;
+
+	@JsonIgnore
+	private Supplier<Long[]> _fileEntryIdsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getFriendlyURL() {
+		if (_friendlyURLSupplier != null) {
+			friendlyURL = _friendlyURLSupplier.get();
+
+			_friendlyURLSupplier = null;
+		}
+
+		return friendlyURL;
+	}
+
+	public void setFriendlyURL(String friendlyURL) {
+		this.friendlyURL = friendlyURL;
+
+		_friendlyURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFriendlyURL(
+		UnsafeSupplier<String, Exception> friendlyURLUnsafeSupplier) {
+
+		_friendlyURLSupplier = () -> {
+			try {
+				return friendlyURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String friendlyURL;
+
+	@JsonIgnore
+	private Supplier<String> _friendlyURLSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getGroupId() {
+		if (_groupIdSupplier != null) {
+			groupId = _groupIdSupplier.get();
+
+			_groupIdSupplier = null;
+		}
+
+		return groupId;
+	}
+
+	public void setGroupId(Long groupId) {
+		this.groupId = groupId;
+
+		_groupIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setGroupId(
+		UnsafeSupplier<Long, Exception> groupIdUnsafeSupplier) {
+
+		_groupIdSupplier = () -> {
+			try {
+				return groupIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long groupId;
+
+	@JsonIgnore
+	private Supplier<Long> _groupIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Room)) {
+			return false;
+		}
+
+		Room room = (Room)object;
+
+		return Objects.equals(toString(), room.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long[] fileEntryIds = getFileEntryIds();
+
+		if (fileEntryIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileEntryIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < fileEntryIds.length; i++) {
+				sb.append(fileEntryIds[i]);
+
+				if ((i + 1) < fileEntryIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		String friendlyURL = getFriendlyURL();
+
+		if (friendlyURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(friendlyURL));
+
+			sb.append("\"");
+		}
+
+		Long groupId = getGroupId();
+
+		if (groupId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupId\": ");
+
+			sb.append(groupId);
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.dsr.dto.v1_0.Room",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:393804324

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/resource/v1_0/RoomResource.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/resource/v1_0/RoomResource.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-dsr/v1.0
+ *
+ * @author Stefano Motta
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface RoomResource {
+
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public RoomResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:457732909

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/dto/v1_0/Room.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/dto/v1_0/Room.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.dto.v1_0;
+
+import com.liferay.headless.dsr.client.function.UnsafeSupplier;
+import com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public class Room implements Cloneable, Serializable {
+
+	public static Room toDTO(String json) {
+		return RoomSerDes.toDTO(json);
+	}
+
+	public Long[] getFileEntryIds() {
+		return fileEntryIds;
+	}
+
+	public void setFileEntryIds(Long[] fileEntryIds) {
+		this.fileEntryIds = fileEntryIds;
+	}
+
+	public void setFileEntryIds(
+		UnsafeSupplier<Long[], Exception> fileEntryIdsUnsafeSupplier) {
+
+		try {
+			fileEntryIds = fileEntryIdsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long[] fileEntryIds;
+
+	public String getFriendlyURL() {
+		return friendlyURL;
+	}
+
+	public void setFriendlyURL(String friendlyURL) {
+		this.friendlyURL = friendlyURL;
+	}
+
+	public void setFriendlyURL(
+		UnsafeSupplier<String, Exception> friendlyURLUnsafeSupplier) {
+
+		try {
+			friendlyURL = friendlyURLUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String friendlyURL;
+
+	public Long getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(Long groupId) {
+		this.groupId = groupId;
+	}
+
+	public void setGroupId(
+		UnsafeSupplier<Long, Exception> groupIdUnsafeSupplier) {
+
+		try {
+			groupId = groupIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long groupId;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public Room clone() throws CloneNotSupportedException {
+		return (Room)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Room)) {
+			return false;
+		}
+
+		Room room = (Room)object;
+
+		return Objects.equals(toString(), room.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return RoomSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:145553694

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/resource/v1_0/RoomResource.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/resource/v1_0/RoomResource.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.resource.v1_0;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.http.HttpInvoker;
+import com.liferay.headless.dsr.client.problem.Problem;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public interface RoomResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception;
+
+	public HttpInvoker.HttpResponse postRoomDuplicateHttpResponse(
+			Long roomId, Room room)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public RoomResource build() {
+			return new RoomResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class RoomResourceImpl implements RoomResource {
+
+		public Room postRoomDuplicate(Long roomId, Room room) throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				postRoomDuplicateHttpResponse(roomId, room);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes.
+					toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postRoomDuplicateHttpResponse(
+				Long roomId, Room room)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(room.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-dsr/v1.0/rooms/{roomId}/duplicate");
+
+			httpInvoker.path("roomId", roomId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private RoomResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			RoomResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-899476169

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/serdes/v1_0/RoomSerDes.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/serdes/v1_0/RoomSerDes.java
@@ -1,0 +1,316 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.serdes.v1_0;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public class RoomSerDes {
+
+	public static Room toDTO(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToDTO(json);
+	}
+
+	public static Room[] toDTOs(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Room room) {
+		if (room == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (room.getFileEntryIds() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileEntryIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < room.getFileEntryIds().length; i++) {
+				sb.append(room.getFileEntryIds()[i]);
+
+				if ((i + 1) < room.getFileEntryIds().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (room.getFriendlyURL() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(room.getFriendlyURL()));
+
+			sb.append("\"");
+		}
+
+		if (room.getGroupId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupId\": ");
+
+			sb.append(room.getGroupId());
+		}
+
+		if (room.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(room.getId());
+		}
+
+		if (room.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(room.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Room room) {
+		if (room == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (room.getFileEntryIds() == null) {
+			map.put("fileEntryIds", null);
+		}
+		else {
+			map.put("fileEntryIds", String.valueOf(room.getFileEntryIds()));
+		}
+
+		if (room.getFriendlyURL() == null) {
+			map.put("friendlyURL", null);
+		}
+		else {
+			map.put("friendlyURL", String.valueOf(room.getFriendlyURL()));
+		}
+
+		if (room.getGroupId() == null) {
+			map.put("groupId", null);
+		}
+		else {
+			map.put("groupId", String.valueOf(room.getGroupId()));
+		}
+
+		if (room.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(room.getId()));
+		}
+
+		if (room.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(room.getName()));
+		}
+
+		return map;
+	}
+
+	public static class RoomJSONParser extends BaseJSONParser<Room> {
+
+		@Override
+		protected Room createDTO() {
+			return new Room();
+		}
+
+		@Override
+		protected Room[] createDTOArray(int size) {
+			return new Room[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "fileEntryIds")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "friendlyURL")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "groupId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Room room, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "fileEntryIds")) {
+				if (jsonParserFieldValue != null) {
+					room.setFileEntryIds(
+						toLongs((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "friendlyURL")) {
+				if (jsonParserFieldValue != null) {
+					room.setFriendlyURL((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "groupId")) {
+				if (jsonParserFieldValue != null) {
+					room.setGroupId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					room.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					room.setName((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:712251575

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-openapi.yaml
@@ -15,6 +15,26 @@ components:
                     type: integer
                 roleKey:
                     type: string
+        Room:
+            properties:
+                fileEntryIds:
+                    items:
+                        format: int64
+                        type: integer
+                    type: array
+                friendlyURL:
+                    readOnly: true
+                    type: string
+                groupId:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                name:
+                    type: string
         UserAccount:
             properties:
                 alternateName:
@@ -42,6 +62,34 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/rooms/{roomId}/duplicate":
+        post:
+            operationId: postRoomDuplicate
+            parameters:
+                -   in: path
+                    name: roomId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Room"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Room"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Room"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Room"
+            tags: ["Room"]
     "/rooms/{roomId}/invited-members":
         get:
             operationId: getRoomInvitedMembersPage

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/BaseRoomResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/BaseRoomResourceImpl.java
@@ -1,0 +1,521 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseRoomResourceImpl implements RoomResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-dsr/v1.0/rooms/{roomId}/duplicate' -d $'{"fileEntryIds": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "roomId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Room")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/rooms/{roomId}/duplicate")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Room postRoomDuplicate(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("roomId")
+			Long roomId,
+			Room room)
+		throws Exception {
+
+		return new Room();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-dsr";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseRoomResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:113858518

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -87,6 +87,8 @@ public class OpenAPIResourceImpl {
 		{
 			add(InvitedMemberResourceImpl.class);
 
+			add(RoomResourceImpl.class);
+
 			add(UserAccountResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);
@@ -94,4 +96,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1468967523
+// LIFERAY-REST-BUILDER-HASH:1610006332

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/RoomResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/RoomResourceImpl.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.definition.security.permission.resource.ObjectDefinitionPortletResourcePermissionRegistryUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.site.dsr.site.initializer.thread.local.DSRRoomThreadLocal;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Stefano Motta
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/room.properties",
+	scope = ServiceScope.PROTOTYPE, service = RoomResource.class
+)
+public class RoomResourceImpl extends BaseRoomResourceImpl {
+
+	@Override
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-66359")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(roomId);
+
+		_checkPermission(objectEntry);
+
+		DSRRoomThreadLocal.setFileEntryIds(
+			GetterUtil.getLongValues(room.getFileEntryIds()));
+		DSRRoomThreadLocal.setObjectEntryId(objectEntry.getObjectEntryId());
+
+		try {
+			ServiceContext serviceContext = new ServiceContext();
+
+			serviceContext.setCompanyId(contextCompany.getCompanyId());
+			serviceContext.setUserId(contextUser.getUserId());
+
+			return _toRoom(
+				_objectEntryLocalService.addObjectEntry(
+					0, contextUser.getUserId(),
+					objectEntry.getObjectDefinitionId(), 0, null,
+					HashMapBuilder.<String, Serializable>put(
+						"description",
+						MapUtil.getString(
+							objectEntry.getValues(), "description")
+					).put(
+						"name",
+						GetterUtil.getString(
+							room.getName(),
+							MapUtil.getString(objectEntry.getValues(), "name"))
+					).put(
+						"r_accountToDSRRooms_accountEntryId",
+						MapUtil.getLong(
+							objectEntry.getValues(),
+							"r_accountToDSRRooms_accountEntryId")
+					).build(),
+					serviceContext));
+		}
+		finally {
+			DSRRoomThreadLocal.setFileEntryIds(new long[0]);
+			DSRRoomThreadLocal.setObjectEntryId(0);
+		}
+	}
+
+	private void _checkPermission(ObjectEntry objectEntry) throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isCompanyAdmin()) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		PortletResourcePermission portletResourcePermission =
+			ObjectDefinitionPortletResourcePermissionRegistryUtil.getService(
+				objectDefinition.getResourceName());
+
+		if ((objectEntry.getUserId() == permissionChecker.getUserId()) &&
+			portletResourcePermission.contains(
+				permissionChecker, objectEntry.getGroupId(),
+				ObjectActionKeys.ADD_OBJECT_ENTRY)) {
+
+			return;
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			permissionChecker, objectDefinition.getResourceName(),
+			objectEntry.getGroupId(), ObjectActionKeys.ADD_OBJECT_ENTRY);
+	}
+
+	private Room _toRoom(ObjectEntry objectEntry) throws Exception {
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		Group group = _groupLocalService.fetchGroup(
+			objectEntry.getCompanyId(),
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()),
+			objectEntry.getObjectEntryId());
+
+		return new Room() {
+			{
+				setFriendlyURL(group::getFriendlyURL);
+				setGroupId(group::getGroupId);
+				setId(objectEntry::getObjectEntryId);
+				setName(
+					() -> MapUtil.getString(objectEntry.getValues(), "name"));
+			}
+		};
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+}

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/factory/RoomResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/factory/RoomResourceFactoryImpl.java
@@ -1,0 +1,326 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0.factory;
+
+import com.liferay.headless.dsr.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-dsr/v1.0/Room",
+	service = RoomResource.Factory.class
+)
+@Generated("")
+public class RoomResourceFactoryImpl implements RoomResource.Factory {
+
+	@Override
+	public RoomResource.Builder create() {
+		return new RoomResource.Builder() {
+
+			@Override
+			public RoomResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, RoomResource>
+					roomResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_roomResourceProxyProviderFunction;
+
+				return roomResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public RoomResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, RoomResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			RoomResource.class.getClassLoader(), RoomResource.class);
+
+		try {
+			Constructor<RoomResource> constructor =
+				(Constructor<RoomResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		RoomResource roomResource = _componentServiceObjects.getService();
+
+		roomResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		roomResource.setContextCompany(company);
+
+		roomResource.setContextHttpServletRequest(httpServletRequest);
+		roomResource.setContextHttpServletResponse(httpServletResponse);
+		roomResource.setContextUriInfo(uriInfo);
+		roomResource.setContextUser(user);
+		roomResource.setExpressionConvert(_expressionConvert);
+		roomResource.setFilterParserProvider(_filterParserProvider);
+		roomResource.setGroupLocalService(_groupLocalService);
+		roomResource.setResourceActionLocalService(_resourceActionLocalService);
+		roomResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		roomResource.setRoleLocalService(_roleLocalService);
+		roomResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(roomResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(roomResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<RoomResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, RoomResource>
+			_roomResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:228301270

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/room.properties
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/room.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.dsr.dto.v1_0.Room
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.DSR)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/build.gradle
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:headless:headless-dsr:headless-dsr-api")
 	testIntegrationImplementation project(":apps:headless:headless-dsr:headless-dsr-client")

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
@@ -1,0 +1,950 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.http.HttpInvoker;
+import com.liferay.headless.dsr.client.pagination.Page;
+import com.liferay.headless.dsr.client.resource.v1_0.RoomResource;
+import com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public abstract class BaseRoomResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_roomResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		roomResource = RoomResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Room room1 = randomRoom();
+
+		String json = objectMapper.writeValueAsString(room1);
+
+		Room room2 = RoomSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(room1, room2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Room room = randomRoom();
+
+		String json1 = objectMapper.writeValueAsString(room);
+		String json2 = RoomSerDes.toJSON(room);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Room room = randomRoom();
+
+		room.setFriendlyURL(regex);
+		room.setName(regex);
+
+		String json = RoomSerDes.toJSON(room);
+
+		Assert.assertFalse(json.contains(regex));
+
+		room = RoomSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, room.getFriendlyURL());
+		Assert.assertEquals(regex, room.getName());
+	}
+
+	@Test
+	public void testPostRoomDuplicate() throws Exception {
+		Room randomRoom = randomRoom();
+
+		Room postRoom = testPostRoomDuplicate_addRoom(randomRoom);
+
+		assertEquals(randomRoom, postRoom);
+		assertValid(postRoom);
+	}
+
+	protected Room testPostRoomDuplicate_addRoom(Room room) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(Room room, List<Room> rooms) {
+		boolean contains = false;
+
+		for (Room item : rooms) {
+			if (equals(room, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(rooms + " does not contain " + room, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(Room room1, Room room2) {
+		Assert.assertTrue(
+			room1 + " does not equal " + room2, equals(room1, room2));
+	}
+
+	protected void assertEquals(List<Room> rooms1, List<Room> rooms2) {
+		Assert.assertEquals(rooms1.size(), rooms2.size());
+
+		for (int i = 0; i < rooms1.size(); i++) {
+			Room room1 = rooms1.get(i);
+			Room room2 = rooms2.get(i);
+
+			assertEquals(room1, room2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Room> rooms1, List<Room> rooms2) {
+
+		Assert.assertEquals(rooms1.size(), rooms2.size());
+
+		for (Room room1 : rooms1) {
+			boolean contains = false;
+
+			for (Room room2 : rooms2) {
+				if (equals(room1, room2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(rooms2 + " does not contain " + room1, contains);
+		}
+	}
+
+	protected void assertValid(Room room) throws Exception {
+		boolean valid = true;
+
+		if (room.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("fileEntryIds", additionalAssertFieldName)) {
+				if (room.getFileEntryIds() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("friendlyURL", additionalAssertFieldName)) {
+				if (room.getFriendlyURL() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("groupId", additionalAssertFieldName)) {
+				if (room.getGroupId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (room.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Room> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<Room> page, Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<Room> rooms = page.getItems();
+
+		int size = rooms.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.dsr.dto.v1_0.Room.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Room room1, Room room2) {
+		if (room1 == room2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("fileEntryIds", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getFileEntryIds(), room2.getFileEntryIds())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("friendlyURL", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getFriendlyURL(), room2.getFriendlyURL())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("groupId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getGroupId(), room2.getGroupId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(room1.getId(), room2.getId())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(room1.getName(), room2.getName())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_roomResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_roomResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Room room) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("fileEntryIds")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("friendlyURL")) {
+			Object object = room.getFriendlyURL();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("groupId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("name")) {
+			Object object = room.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected Room randomRoom() throws Exception {
+		return new Room() {
+			{
+				friendlyURL = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				groupId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected Room randomIrrelevantRoom() throws Exception {
+		Room randomIrrelevantRoom = randomRoom();
+
+		return randomIrrelevantRoom;
+	}
+
+	protected Room randomPatchRoom() throws Exception {
+		return randomRoom();
+	}
+
+	protected RoomResource roomResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseRoomResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.dsr.resource.v1_0.RoomResource _roomResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:381240240

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/RoomResourceTest.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/RoomResourceTest.java
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0.test;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.problem.Problem;
+import com.liferay.headless.dsr.client.resource.v1_0.RoomResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.site.dsr.site.initializer.constants.DSRFolderConstants;
+import com.liferay.site.dsr.site.initializer.constants.DSRRoleConstants;
+import com.liferay.site.dsr.site.initializer.test.util.DSRTestUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Stefano Motta
+ */
+@FeatureFlag("LPD-66359")
+@RunWith(Arquillian.class)
+public class RoomResourceTest extends BaseRoomResourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		DSRTestUtil.getOrAddGroup(RoomResourceTest.class);
+
+		_accountEntry = _accountEntryLocalService.addAccountEntry(
+			StringPool.BLANK, TestPropsValues.getUserId(), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			"business", 1, ServiceContextTestUtil.getServiceContext());
+		_objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_DSR_ROOM", TestPropsValues.getCompanyId());
+	}
+
+	@Override
+	@Test
+	public void testPostRoomDuplicate() throws Exception {
+		ObjectEntry objectEntry1 = _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"name",
+				StringUtil.toLowerCase("A" + RandomTestUtil.randomString())
+			).put(
+				"r_accountToDSRRooms_accountEntryId",
+				_accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group1 = _groupLocalService.fetchGroup(
+			TestPropsValues.getCompanyId(),
+			_classNameLocalService.getClassNameId(
+				_objectDefinition.getClassName()),
+			objectEntry1.getObjectEntryId());
+
+		DLFolder dlFolder1 =
+			_dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				DSRFolderConstants.EXTERNAL_REFERENCE_CODE_DSR_DOCUMENTS,
+				group1.getGroupId());
+
+		DLFileEntry dlFileEntry1 = _addFileEntry(
+			dlFolder1.getFolderId(), group1);
+
+		Room room = roomResource.postRoomDuplicate(
+			objectEntry1.getObjectEntryId(),
+			new Room() {
+				{
+					setFileEntryIds(new Long[] {dlFileEntry1.getFileEntryId()});
+					setName(
+						StringUtil.toLowerCase(
+							"A" + RandomTestUtil.randomString()));
+				}
+			});
+
+		Assert.assertTrue(room.getGroupId() > 0);
+		Assert.assertTrue(room.getId() != objectEntry1.getObjectEntryId());
+
+		DLFolder dlFolder2 =
+			_dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				DSRFolderConstants.EXTERNAL_REFERENCE_CODE_DSR_DOCUMENTS,
+				room.getGroupId());
+
+		Assert.assertTrue(
+			ListUtil.exists(
+				_dlFileEntryLocalService.getFileEntries(
+					room.getGroupId(), dlFolder2.getFolderId()),
+				dlFileEntry2 -> Objects.equals(
+					dlFileEntry2.getTitle(), dlFileEntry1.getTitle())));
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[0], ServiceContextTestUtil.getServiceContext());
+
+		objectEntry1 = _objectEntryLocalService.getObjectEntry(
+			objectEntry1.getObjectEntryId());
+
+		objectEntry1.setUserId(user.getUserId());
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(objectEntry1);
+
+		RoomResource roomResource = RoomResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		try {
+			roomResource.postRoomDuplicate(
+				objectEntry1.getObjectEntryId(),
+				new Room() {
+					{
+						setName(
+							StringUtil.toLowerCase(
+								"A" + RandomTestUtil.randomString()));
+					}
+				});
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			String message = problemException.getMessage();
+
+			Assert.assertTrue(message, message.contains("Forbidden"));
+		}
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), DSRRoleConstants.NAME_DSR_SELLER);
+
+		_userLocalService.addRoleUsers(
+			role.getRoleId(), new long[] {user.getUserId()});
+
+		room = roomResource.postRoomDuplicate(
+			objectEntry1.getObjectEntryId(),
+			new Room() {
+				{
+					setName(
+						StringUtil.toLowerCase(
+							"A" + RandomTestUtil.randomString()));
+				}
+			});
+
+		Assert.assertTrue(room.getGroupId() > 0);
+		Assert.assertTrue(room.getId() != objectEntry1.getObjectEntryId());
+	}
+
+	private DLFileEntry _addFileEntry(long folderId, Group group)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			return _dlFileEntryLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), group.getGroupId(),
+				group.getGroupId(), folderId, RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), null, null,
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+				null, null,
+				new ByteArrayInputStream(TestDataConstants.TEST_BYTE_ARRAY),
+				TestDataConstants.TEST_BYTE_ARRAY.length, null, null, null,
+				serviceContext);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	private AccountEntry _accountEntry;
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -1490,6 +1490,9 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 	public void testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler()
 		throws Exception {
 
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
 		try (ServiceRegistrationHolder serviceRegistrationHolder =
 				registryWorkflowHandler()) {
 

--- a/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/changeTrackingTimeline.spec.ts
@@ -177,6 +177,61 @@ test('LPD-25853 Edit in x publication is added in the timeline dropdown actions'
 	).toBeVisible();
 });
 
+test('LPD-43418 Edit in publication action from the table view timeline redirects to the asset edit page', async ({
+	changeTrackingPage,
+	ctCollection,
+	journalEditArticlePage,
+	journalPage,
+	page,
+	site,
+}) => {
+	const articleTitle = getRandomString();
+
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+	await journalEditArticlePage.fillTitle(articleTitle);
+	await journalEditArticlePage.fillContent(getRandomString());
+	await journalEditArticlePage.publishArticle();
+
+	await waitForAlert(
+		page,
+		`Success:${articleTitle} was created successfully.`
+	);
+
+	await changeTrackingPage.workOnProduction();
+
+	await journalPage.goto(site.friendlyUrlPath);
+
+	const timelineButton = page.getByLabel('timeline-button');
+	await timelineButton.waitFor();
+	await timelineButton.click();
+
+	const timelineActionsButton = page
+		.getByRole('menuitem')
+		.filter({hasText: articleTitle})
+		.getByLabel('timeline-actions');
+
+	const editButton = page.getByRole('button', {
+		name: `Edit in ${ctCollection.body.name}`,
+	});
+
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: editButton,
+		trigger: timelineActionsButton,
+	});
+
+	await expect(journalPage.articleTitleInput).toHaveValue(articleTitle);
+
+	await expect(
+		page
+			.locator('.change-tracking-indicator-title')
+			.filter({hasText: ctCollection.body.name})
+	).toBeVisible();
+});
+
 test('LPD-25853 Review Change is added in the timeline dropdown actions', async ({
 	changeTrackingPage,
 	ctCollection,


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43418

The "Edit in <publication>" action in the change-tracking timeline did not open the asset edit page from the table/list view (for example the Web Content table view). On those pages the portlet exposes a class name but no `classPK` (it is `0`) since those are aggregate views. Therefore, the original implementation only checked out the Publication without redirecting. The URL to edit the asset needed to be derived per timeline item. After examining git history and [requirements in the original epic's tickets](https://liferay.atlassian.net/browse/LPD-20556), this is more of an implementation gap due to lack of requirement clarity than an actual bug - it was implemented to only check out from the beginning.

### How am I fixing it?

This computes the edit URL per change-tracking entry and threads it through to the timeline action so each row redirects to its own asset edit page. Key changes include:

- A new `editURL` property on the `CTEntry` REST DTO (`rest-openapi.yaml` exposes the asset edit URL for each change-tracking entry.
- `CTEntryDTOConverter` populates `editURL` lazily through `CTDisplayRendererRegistry.getEditURL`, and sets the ThemeDisplay scope group from the entry's own `Field.GROUP_ID` immediately before the URL resolves. Because the value suppliers resolve at serialization time (after the conversion loop), setting the scope group per entry prevents every entry from being pinned to the first entry's group.
- `CTEntryResourceImpl` bootstraps a `ThemeDisplay` once per request and seeds `currentURL` from the root entrypoint in `ChangeTrackingIndicatorDynamicInclude` so that `getEditURL` can build control-panel URLs from a REST request that otherwise has no theme context.
- `TimelineDropdownMenu` builds the checkout URL with `redirect` set to the item's `editURL`, adding the redirect only when an edit URL is present. 
- `ViewTimelineHistoryDisplayContext` now sets `{editURL}` as a redirect that FDS can interpolate. This is the primary reason for creating a new `editURL` property in the DTO. 
- I couldn't find a way to make the previous `javascript:window.open(...)` wrapper work with the redirect, so I chose to remove it in favor of having the `Edit in x` button actually redirect to the edit. To support this, I added reloads to the `PublicationTimeline` modal - a top window reload is triggered when the history modal closes (by clicking the "Done" button, the corner "X", or outside the modal) so the top window reflects correct current state.

### How can you verify that it works?

This PR adds 1 new test case:

1. `LPD-43418 Edit in publication action from the table view timeline redirects to the asset edit page` - publishes a web content article on production, edits it inside a publication, then opens the timeline from the production table view and clicks "Edit in <publication>"; asserts the article edit page opens within the publication instead of the table view refreshing in place.

The scenario is covered by the new Playwright test in the `change-tracking-web` suite. Run it from the `modules/test/playwright` directory:

```bash
npx playwright test -g 'LPD-43418 Edit in publication action from the table view timeline redirects to the asset edit page'
```

  ---
  pr-check: PASS — tested on 93e527aed5354

  ┌──────────────────────────┬────────┐
  │        Validation                                              │ Result │
  ├──────────────────────────┼────────┤
  │ REST Builder             │ PASS   │
  ├──────────────────────────┼────────┤
  │ Source Format            │ PASS   │
  ├──────────────────────────┼────────┤
  │ Per-Module Deploy        │ PASS   │
  ├──────────────────────────┼────────┤
  │ Integration Test Compile │ PASS   │
  ├──────────────────────────┼────────┤
  │ Structural Smoke         │ PASS   │
  └──────────────────────────┴────────┘
