### PR TITLE
LPD-88837 Add PageSpeed client extension scaffold and score provider

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -6916,7 +6916,11 @@
         modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
-        semantic-versioning
+        semantic-versioning,\
+        workspaces-compile
+
+    workspaces.names[workspaces-compile][site-management]=\
+        liferay-seostudio-workspace
 
     #
     # Source Formatter

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/Dockerfile
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/jar-runner:latest
+
+COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/LCP.json
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/LCP.json
@@ -1,0 +1,31 @@
+{
+	"cpu": 1,
+	"env": {
+		"LIFERAY_ROUTES_CLIENT_EXTENSION": "/etc/liferay/lxc/ext-init-metadata",
+		"LIFERAY_ROUTES_DXP": "/etc/liferay/lxc/dxp-metadata"
+	},
+	"environments": {
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "__PROJECT_ID__",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"loadBalancer": {
+		"targetPort": 58081
+	},
+	"memory": 1024,
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"scale": 1
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -1,0 +1,47 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.18"
+	}
+
+	repositories {
+		maven {
+			url new File(rootProject.projectDir, "../../.m2-tmp")
+		}
+
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.source.formatter"
+apply plugin: "java-library"
+apply plugin: "org.springframework.boot"
+
+dependencies {
+	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
+	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "org.json", name: "json", version: "20231013"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
+	testImplementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: "2.7.18"
+}
+
+repositories {
+	maven {
+		url new File(rootProject.projectDir, "../../.m2-tmp")
+	}
+
+	maven {
+		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+	}
+}
+
+test {
+	jvmArgs "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+	"--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED"
+
+	useJUnitPlatform()
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/client-extension.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/client-extension.yaml
@@ -1,0 +1,22 @@
+assemble:
+    -   fromTask: bootJar
+liferay-seostudio-etc-pagespeed-oahs:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio PageSpeed OAuth Application Headless Server
+    scopes:
+        -   Liferay.Headless.Portal.Instances.read
+        -   c_seostudiodomain.read
+        -   c_seostudioinstance.read
+        -   c_seostudioscan.write
+    type: oAuthApplicationHeadlessServer
+liferay-seostudio-etc-pagespeed-oaua:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio PageSpeed OAuth Application User Agent
+    type: oAuthApplicationUserAgent
+liferay-seostudio-etc-pagespeed-object-action-pagespeed:
+    name: Liferay SEO Studio PageSpeed Object Action PageSpeed
+    oAuth2ApplicationExternalReferenceCode: liferay-seostudio-etc-pagespeed-oaua
+    resourcePath: /object/action/pagespeed
+    type: objectAction

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/ReadyRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/ReadyRestController.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kiana Suetani
+ */
+@RequestMapping("/ready")
+@RestController
+public class ReadyRestController extends BaseRestController {
+
+	@GetMapping
+	public String get() {
+		return "READY";
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/SEOStudioSpringBootApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/SEOStudioSpringBootApplication.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed;
+
+import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Kiana Suetani
+ */
+@Import(ClientExtensionUtilSpringBootComponentScan.class)
+@SpringBootApplication
+public class SEOStudioSpringBootApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SEOStudioSpringBootApplication.class, args);
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProvider.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProvider.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.nio.charset.StandardCharsets;
+
+import java.time.Duration;
+
+import java.util.Objects;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProvider {
+
+	public PageSpeedScoreProvider(
+		HttpClient httpClient, String pageSpeedAPIKey, String strategy) {
+
+		_httpClient = httpClient;
+		_pageSpeedAPIKey = pageSpeedAPIKey;
+
+		if (Objects.equals(strategy, "DESKTOP") ||
+			Objects.equals(strategy, "MOBILE")) {
+
+			_strategy = strategy;
+		}
+		else {
+			_strategy = "DESKTOP";
+		}
+	}
+
+	public PageSpeedScores getScores(String url)
+		throws PageSpeedScoreProviderException {
+
+		try {
+			return _getScores(url);
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			throw new PageSpeedScoreProviderException(
+				"Unable to get PageSpeed scores for " + url,
+				interruptedException);
+		}
+		catch (PageSpeedScoreProviderException
+					pageSpeedScoreProviderException) {
+
+			throw pageSpeedScoreProviderException;
+		}
+		catch (Exception exception) {
+			throw new PageSpeedScoreProviderException(
+				"Unable to get PageSpeed scores for " + url, exception);
+		}
+	}
+
+	public static class PageSpeedScoreProviderException extends Exception {
+
+		public PageSpeedScoreProviderException(String message) {
+			super(message);
+		}
+
+		public PageSpeedScoreProviderException(
+			String message, Throwable throwable) {
+
+			super(message, throwable);
+		}
+
+	}
+
+	private String _buildGooglePageSpeedURL(String url) {
+		StringBundler sb = new StringBundler(11);
+
+		sb.append("https://content-pagespeedonline.googleapis.com");
+		sb.append("/pagespeedonline/v5/runPagespeed");
+		sb.append("?category=ACCESSIBILITY&category=BEST_PRACTICES");
+		sb.append("&category=PERFORMANCE&category=SEO&fields=");
+		sb.append(
+			URLEncoder.encode(
+				"lighthouseResult/categories/*/score", StandardCharsets.UTF_8));
+		sb.append("&key=");
+		sb.append(URLEncoder.encode(_pageSpeedAPIKey, StandardCharsets.UTF_8));
+		sb.append("&strategy=");
+		sb.append(URLEncoder.encode(_strategy, StandardCharsets.UTF_8));
+		sb.append("&url=");
+		sb.append(URLEncoder.encode(url, StandardCharsets.UTF_8));
+
+		return sb.toString();
+	}
+
+	private int _getScore(JSONObject categoriesJSONObject, String category) {
+		JSONObject categoryJSONObject = categoriesJSONObject.optJSONObject(
+			category);
+
+		if (categoryJSONObject == null) {
+			return 0;
+		}
+
+		double score = categoryJSONObject.optDouble("score", 0);
+
+		return (int)Math.round(score * 100);
+	}
+
+	private PageSpeedScores _getScores(String url)
+		throws InterruptedException, PageSpeedScoreProviderException {
+
+		if (_pageSpeedAPIKey == null) {
+			throw new PageSpeedScoreProviderException("Invalid Connection");
+		}
+
+		HttpResponse<String> httpResponse;
+
+		try {
+			HttpRequest httpRequest = HttpRequest.newBuilder(
+			).GET(
+			).timeout(
+				Duration.ofSeconds(120)
+			).uri(
+				URI.create(_buildGooglePageSpeedURL(url))
+			).build();
+
+			httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+		}
+		catch (IOException ioException) {
+			throw new PageSpeedScoreProviderException(
+				"Unable to reach Google PageSpeed API for " + url, ioException);
+		}
+
+		int statusCode = httpResponse.statusCode();
+
+		if (statusCode != HttpURLConnection.HTTP_OK) {
+			throw new PageSpeedScoreProviderException(
+				"Response code " + statusCode);
+		}
+
+		return _parseScores(httpResponse.body());
+	}
+
+	private PageSpeedScores _parseScores(String responseJSON)
+		throws PageSpeedScoreProviderException {
+
+		JSONObject responseJSONObject = new JSONObject(responseJSON);
+
+		JSONObject lighthouseResultJSONObject =
+			responseJSONObject.optJSONObject("lighthouseResult");
+
+		if (lighthouseResultJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"lighthouseResult\" in response");
+		}
+
+		JSONObject categoriesJSONObject =
+			lighthouseResultJSONObject.optJSONObject("categories");
+
+		if (categoriesJSONObject == null) {
+			throw new PageSpeedScoreProviderException(
+				"Missing \"categories\" in \"lighthouseResult\"");
+		}
+
+		return new PageSpeedScores(
+			_getScore(categoriesJSONObject, "accessibility"),
+			_getScore(categoriesJSONObject, "best-practices"),
+			_getScore(categoriesJSONObject, "performance"),
+			_getScore(categoriesJSONObject, "seo"));
+	}
+
+	private final HttpClient _httpClient;
+	private final String _pageSpeedAPIKey;
+	private final String _strategy;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScores.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScores.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScores {
+
+	public PageSpeedScores(
+		int accessibility, int bestPractices, int performance, int seo) {
+
+		_accessibility = accessibility;
+		_bestPractices = bestPractices;
+		_performance = performance;
+		_seo = seo;
+	}
+
+	public int getAccessibility() {
+		return _accessibility;
+	}
+
+	public int getBestPractices() {
+		return _bestPractices;
+	}
+
+	public int getPerformance() {
+		return _performance;
+	}
+
+	public int getSEO() {
+		return _seo;
+	}
+
+	private final int _accessibility;
+	private final int _bestPractices;
+	private final int _performance;
+	private final int _seo;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/resources/application-default.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/resources/application-default.properties
@@ -1,0 +1,25 @@
+#
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
+# OAuth
+#
+
+liferay-seostudio-etc-pagespeed-oahs.oauth2.headless.server.client.secret=${LIFERAY_SEOSTUDIO_ETC_PAGESPEED_OAHS_CLIENT_SECRET:myfancypassword}
+
+liferay.oauth.application.external.reference.codes=\
+    liferay-seostudio-etc-pagespeed-oahs,\
+    liferay-seostudio-etc-pagespeed-oaua
+
+liferay.oauth.urls.excludes=/ready
+
+#
+# Spring Boot
+#
+
+server.port=58081

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/resources/application.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.config.import=\
+    classpath:/application-default.properties,\
+    optional:configtree:${LIFERAY_ROUTES_CLIENT_EXTENSION}/,\
+    optional:configtree:${LIFERAY_ROUTES_DXP}/

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProviderTest.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/test/java/com/liferay/seo/studio/pagespeed/scanner/PageSpeedScoreProviderTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.pagespeed.scanner;
+
+import java.lang.reflect.Method;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScoreProviderTest {
+
+	@Test
+	public void testParseScores() throws Exception {
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"lighthouseResult",
+			new JSONObject(
+			).put(
+				"categories",
+				new JSONObject(
+				).put(
+					"accessibility",
+					new JSONObject(
+					).put(
+						"score", 0.92
+					)
+				).put(
+					"best-practices",
+					new JSONObject(
+					).put(
+						"score", 0.85
+					)
+				).put(
+					"performance",
+					new JSONObject(
+					).put(
+						"score", 0.78
+					)
+				).put(
+					"seo",
+					new JSONObject(
+					).put(
+						"score", 0.95
+					)
+				)
+			));
+
+		PageSpeedScores pageSpeedScores = _parseScores(jsonObject.toString());
+
+		Assertions.assertEquals(92, pageSpeedScores.getAccessibility());
+		Assertions.assertEquals(85, pageSpeedScores.getBestPractices());
+		Assertions.assertEquals(78, pageSpeedScores.getPerformance());
+		Assertions.assertEquals(95, pageSpeedScores.getSEO());
+	}
+
+	private PageSpeedScores _parseScores(String responseJSON) throws Exception {
+		Method method = PageSpeedScoreProvider.class.getDeclaredMethod(
+			"_parseScores", String.class);
+
+		method.setAccessible(true);
+
+		PageSpeedScoreProvider pageSpeedScoreProvider =
+			new PageSpeedScoreProvider(null, null, null);
+
+		return (PageSpeedScores)method.invoke(
+			pageSpeedScoreProvider, responseJSON);
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/package.json
+++ b/workspaces/liferay-seostudio-workspace/package.json
@@ -1,0 +1,14 @@
+{
+	"devDependencies": {
+		"@liferay/eslint-plugin": "1.6.0",
+		"@liferay/prettier-plugin": "1.1.5",
+		"@liferay/stylelint-plugin": "1.1.0",
+		"@typescript-eslint/eslint-plugin": "^5.12.1",
+		"@typescript-eslint/parser": "^7.8.0",
+		"babel-eslint": "^10.1.0",
+		"eslint": "7.32.0",
+		"prettier": "3.2.5",
+		"typescript": "4.4.2"
+	},
+	"private": true
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

SEO Studio needs the ability to call the Google PageSpeed Insights API and retrieve accessibility, best practices, performance, and SEO scores for site pages. No PageSpeed integration existed previously.

## How It Is Being Fixed

A new Spring Boot client extension is scaffolded at `liferay-seostudio-etc-pagespeed` under the SEO Studio workspace, following the `etc` naming convention for multi-type CXs. The scaffold includes OAuth configuration (OAHS + OAUA), an object action endpoint, and a health check controller. A `PageSpeedScoreProvider` class calls the Google PageSpeed Insights API v5, parses the Lighthouse category scores from the JSON response, and returns them as a `PageSpeedScores` object. The provider supports both DESKTOP and MOBILE strategies and defaults to DESKTOP for unrecognized values. A unit test validates the JSON parsing logic via reflection on the private `_parseScores` method.

## PR Check

**pr-check: SKIPPED** — Same changes as previous pr-check run; only pre-existing Structural Smoke baseline drift in Log4jConfigUtilTest

<!-- pr-check {"reason": "Same changes as previous pr-check run; only pre-existing Structural Smoke baseline drift in Log4jConfigUtilTest", "result": "skipped", "sha": "e3a5b95795463c52ee7fdb3c63f095de54de15aa"} -->