### PR TITLE
LPD-94343 Fix failing change-tracking-web Playwright tests

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/ctContextChange.spec.ts
@@ -183,13 +183,19 @@ test('LPD-29693, LPD-29294 Assert silence context change popover behavior', asyn
 		page.getByRole('button', {name: 'Save'}).click(),
 	]);
 
-	await journalPage.goto(site1.friendlyUrlPath);
+	await page
+		.goto(
+			`/group${site1.friendlyUrlPath}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet`
+		)
+		.catch(() => {});
 
 	await expect(popoverCheckbox).toBeVisible();
 
 	await popoverCheckbox.check();
 
-	await page.getByTestId('applicationsMenu').click();
+	await page
+		.getByRole('button', {name: 'Stay in Current Publication'})
+		.click();
 
 	await journalPage.goto(site2.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
@@ -123,6 +123,15 @@ test('Can publish a Publication containing an edited KBArticle', async ({
 
 	await page.goto(knowledgeBaseUrls.getEditKBArticleUrl(kbArticle.id));
 
+	const stayButton = page.getByRole('button', {
+		name: 'Stay in Current Publication',
+	});
+
+	await stayButton
+		.waitFor({state: 'visible', timeout: 3000})
+		.then(() => stayButton.click())
+		.catch(() => {});
+
 	await knowledgeBaseEditArticlePage.titlePlaceholder.waitFor();
 
 	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -251,7 +251,7 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 		)
 	).toBeVisible();
 	await expect(
-		page.getByText(site2.name + ' (3):  Blogs Entry (3)')
+		page.getByText(site2.name + ' (2):  Blogs Entry (2)')
 	).toBeVisible();
 
 	await apiHelpers.headlessChangeTracking.publishCTCollection(
@@ -268,7 +268,7 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 		)
 	).toBeVisible();
 	await expect(
-		page.getByText(site2.name + ' (3):   Blogs Entry (3)')
+		page.getByText(site2.name + ' (2):   Blogs Entry (2)')
 	).toBeVisible();
 });
 

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewDisplayPageTemplateChanges.spec.ts
@@ -144,7 +144,11 @@ test(
 
 		await changeTrackingPage.reviewChange(blogTitle);
 
-		await expect(page.getByText(blogBody)).toBeVisible();
+		await expect(
+			page.locator('td.publications-render-view-content', {
+				hasText: blogBody,
+			})
+		).toBeVisible();
 
 		const journalArticleTitle = getRandomString();
 		const journalContent = getRandomString();
@@ -171,6 +175,10 @@ test(
 
 		await changeTrackingPage.reviewChange(journalArticleTitle);
 
-		await expect(page.getByText(journalContent)).toBeVisible();
+		await expect(
+			page.locator('td.publications-render-view-content', {
+				hasText: journalContent,
+			})
+		).toBeVisible();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94343

## What Is Being Fixed

Several Playwright tests in the change-tracking-web module were consistently failing. The Blogs Entry count in the publication overview changed from 3 to 2 due to LPD-87228. The display page template test could not find text rendered inside a ShadowDomContainer introduced in LPD-84032. The context change popover was interrupting navigation in the ctContextChange and publicationsKBArticle tests.

## How It Is Being Fixed

The Blogs Entry count assertion is updated to match the current count. The display page template assertions use a locator with hasText that pierces shadow DOM instead of getByText which does not. The ctContextChange test catches the interrupted navigation and dismisses the popover before continuing. The KB article test dismisses the context change popover if it appears after navigating to the edit page.

## PR Check

**pr-check: SKIPPED** — Test-only changes to Playwright specs; Structural Smoke has a pre-existing Log4jConfigUtilTest failure on master unrelated to these changes.

<!-- pr-check {"reason": "Test-only changes; pre-existing Structural Smoke failure on master", "result": "skipped", "sha": "c44742f106ba5f4c1c23a32f868da05e281b2f5e"} -->