### PR TITLE
LPD-94391 Fix status filter for ongoing publications

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/frontend/data/set/filter/OngoingStatusSelectionFDSFilter.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/frontend/data/set/filter/OngoingStatusSelectionFDSFilter.java
@@ -6,6 +6,7 @@
 package com.liferay.change.tracking.web.internal.frontend.data.set.filter;
 
 import com.liferay.change.tracking.web.internal.constants.PublicationsFDSNames;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -25,6 +26,11 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class OngoingStatusSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
+	}
 
 	@Override
 	public String getId() {

--- a/modules/test/playwright/tests/change-tracking-web/main/viewPublications.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/viewPublications.spec.ts
@@ -135,7 +135,7 @@ test('LPD-71138 Add status filter for ongoing publications', async ({
 	await inProgressCheckbox.check();
 	await pendingApprovalCheckbox.uncheck();
 
-	await addFilterButton.click();
+	await page.getByRole('button', {name: 'Show Results'}).click();
 
 	await expect(
 		page.getByRole('link', {name: inProgressCTCollection.body.name})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94391

## What Is Being Fixed

The status filter on the Ongoing publications page does not filter results. Selecting "Pending Approval" still shows all publications including "In Progress" ones.

## How It Is Being Fixed

The OngoingStatusSelectionFDSFilter inherited the default entity field type of STRING from BaseSelectionFDSFilter. The status field in CTCollectionEntityModel is an IntegerEntityField, so the FDS selection filter generated an OData expression with a quoted string value instead of an integer, causing a silent type mismatch. Overriding getEntityFieldType to return INTEGER makes the OData filter match the entity model. The test is updated to click "Show Results" instead of "Add Filter" when modifying an active filter.

## PR Check

**pr-check: SKIPPED** — Source Format passed; Structural Smoke has pre-existing Log4jConfigUtilTest failure on master.

<!-- pr-check {"reason": "Source Format passed; pre-existing Structural Smoke failure on master", "result": "skipped", "sha": "2f558a133674740703af104d18e954ad6e823dd6"} -->