### PR TITLE
LPD-94379 Test Fix - reviewChanges.spec.ts

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -241,7 +241,13 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 		await apiHelpers.headlessDelivery.postBlog(site2.id);
 	}
 
-	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+	await expect(async () => {
+		await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+		await expect(
+			page.getByText(site2.name + ' (3):  Blogs Entry (3)')
+		).toBeVisible({timeout: 10000});
+	}).toPass();
 
 	await expect(page.getByText('Liferay DXP Site (1): Tag (1)')).toBeVisible();
 	await expect(
@@ -258,7 +264,15 @@ test('LPD-29088 Assert Publication Overview panel is visible', async ({
 		ctCollection.body.id
 	);
 
-	await changeTrackingPage.goToReviewChangesHistory(ctCollection.body.name);
+	await expect(async () => {
+		await changeTrackingPage.goToReviewChangesHistory(
+			ctCollection.body.name
+		);
+
+		await expect(
+			page.getByText(site2.name + ' (3):   Blogs Entry (3)')
+		).toBeVisible({timeout: 10000});
+	}).toPass();
 
 	await expect(page.getByText('Liferay DXP Site (1): Tag (1)')).toBeVisible();
 	await expect(


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-94379

### How am I fixing it?

This stabilizes a flaky Playwright test that timed out in release runs waiting for the Publication Overview labels to render. Key changes include:

- Both overview assertion blocks now wrap navigation in `expect(async () => {...}).toPass()`, re-navigating until the async-rendered site-grouping labels appear before asserting. Test-only; no product code changed.

### How can you verify that it works?

The change-tracking publication overview test can be run in the `playwright` module with `npx playwright test tests/change-tracking-web/main/reviewChanges.spec.ts -g "Assert Publication Overview panel is visible"` from `modules/test/playwright`. Run with `--repeat-each=10` to confirm stability (10/10 green).

This PR adds 0 new test cases and updated 1 existing test case.

The following existing test cases were updated:

1. `LPD-29088 Assert Publication Overview panel is visible` - wraps both Publication Overview navigations in a `toPass()` retry that waits for the async-rendered site-grouping labels before asserting, eliminating the load-dependent timeout.
