### PR TITLE
LPD-94510 Enable change tracking for Headless Admin Taxonomy

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.taxonomy.resource.v1_0;
 
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -42,6 +43,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @author Javier Gamarra
  * @generated
  */
+@CTAware
 @Generated("")
 @ProviderType
 public interface KeywordResource {
@@ -261,4 +263,4 @@ public interface KeywordResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1131872106
+// LIFERAY-REST-BUILDER-HASH:-523158614

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.taxonomy.resource.v1_0;
 
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -42,6 +43,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @author Javier Gamarra
  * @generated
  */
+@CTAware
 @Generated("")
 @ProviderType
 public interface TaxonomyCategoryResource {
@@ -302,4 +304,4 @@ public interface TaxonomyCategoryResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1324297453
+// LIFERAY-REST-BUILDER-HASH:-461924647

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.taxonomy.resource.v1_0;
 
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -42,6 +43,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @author Javier Gamarra
  * @generated
  */
+@CTAware
 @Generated("")
 @ProviderType
 public interface TaxonomyVocabularyResource {
@@ -271,4 +273,4 @@ public interface TaxonomyVocabularyResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1816027928
+// LIFERAY-REST-BUILDER-HASH:1173439188

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.1.1

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -5,6 +5,7 @@ application:
     className: HeadlessAdminTaxonomyApplication
     name: Liferay.Headless.Admin.Taxonomy
 author: Javier Gamarra
+changeTrackingEnabled: true
 clientDir: ../headless-admin-taxonomy-client/src/main/java
 compatibilityVersion: 15
 forcePredictableOperationId: true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94510

## What Is Being Fixed

After LPD-88409 migrated the Asset Taglib category selector to the headless taxonomy endpoints, a category or vocabulary created inside a publication could no longer be selected when editing web content within that publication. The selector's "Select" modal called `/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{id}/taxonomy-categories` and got a 404, because the headless taxonomy resources were not change tracking aware and `CTContainerRequestFilter` forced them to production mode — where the publication-scoped vocabulary and category do not exist.

## How It Is Being Fixed

Change tracking is enabled for the Headless Admin Taxonomy REST APIs by setting `changeTrackingEnabled: true` in `rest-config.yaml`. REST Builder then generates the `@CTAware` annotation onto the `*Resource` API interfaces, which the generated `Base*ResourceImpl` classes implement. `CTContainerRequestFilter` resolves the annotation through the interface hierarchy and no longer forces production mode, so the resources honor the user's active publication. The generated interface change requires a package version bump for the `com.liferay.headless.admin.taxonomy.resource.v1_0` package, captured in the baseline commit.

## Why Are There No Tests?

The flow is covered by the existing functional test `PublicationsWebContent#PublishWebContentWithCategory`.

## PR Check

**pr-check: PASS** — tested on `11fead39f9b13`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "11fead39f9b130f0846ba57faca655ab8d0de0a1"} -->