### PR TITLE
LPD-94380 Fix flaky publicationsKBArticle edit test via view page

### DIFF
--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsKBArticle.spec.ts
@@ -12,7 +12,6 @@ import {knowledgeBasePages} from '../../../fixtures/knowledgeBasePagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
-import {KnowledgeBaseUrls} from '../../knowledge-base-web/main/utils/knowledgeBaseUrls';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -104,35 +103,28 @@ test('Can publish a Publication containing an edited KBArticle', async ({
 	ctCollection,
 	knowledgeBaseEditArticlePage,
 	knowledgeBasePage,
+	knowledgeBaseViewArticlePage,
 	page,
 	site,
 }) => {
 	const content = getRandomString();
 	const title = getRandomString();
 
-	const kbArticle =
-		await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
-			articleBody: content,
-			siteId: site.id,
-			title,
-		});
+	await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+		articleBody: content,
+		siteId: site.id,
+		title,
+	});
 
 	await changeTrackingPage.workOnPublication(ctCollection);
 
-	const knowledgeBaseUrls = new KnowledgeBaseUrls(site.friendlyUrlPath);
+	await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
 
-	await page.goto(knowledgeBaseUrls.getEditKBArticleUrl(kbArticle.id));
+	await page.getByLabel('Edit').click();
 
-	await knowledgeBaseEditArticlePage.titlePlaceholder.waitFor();
-
-	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
-		`${content} edit`,
-		`${title} edit`
-	);
-
-	await waitForAlert(
-		page,
-		`Success:${title} edit was successfully published.`
+	await knowledgeBaseEditArticlePage.editKBArticle(
+		`${title} edit`,
+		`${content} edit`
 	);
 
 	await apiHelpers.headlessChangeTracking.publishCTCollection(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94380

## What Is Being Fixed

The Playwright test "Can publish a Publication containing an edited KBArticle" (publicationsKBArticle.spec.ts) failed with a 90s timeout, and on CI that timeout cascaded into a 500 on the isolated-site teardown DELETE reported in the ticket. The test reached the KB article edit form via a direct `page.goto()` to the edit URL and reused `publishNewKnowledgeBaseArticle`, a helper written for creating new (empty) articles. On that direct-goto path `fill()` did not clear the already populated title and content, so the article published under its original title; the test then waited forever for a success alert referencing the edited title.

## How It Is Being Fixed

Reworked the test to follow the same flow as the already-passing edit test in knowledge-base-web.spec.ts (LPD-71884): navigate to the article through the view page, click Edit, and call `editKBArticle()`, which clears and refills the fields and waits for the publish alert. Removed the direct edit-URL navigation and the now-unused `KnowledgeBaseUrls` import. Verified locally — the full spec file passes (5 of 5) and the edited-article test drops from a 90s timeout to ~47s.

## PR Check

**pr-check: PASS** — tested on `9770064cc6d21179c54928e4a1854a51534610c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "9770064cc6d21179c54928e4a1854a51534610c5"} -->
