### PR TITLE
LPD-60917 Only confirm discard when collaborator changes exist

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
@@ -639,8 +639,9 @@ const ManageCollaborators = ({
 									displayType="secondary"
 									onClick={() => {
 										if (
-											Object.keys(selectedItems) === 0 &&
-											Object.keys(updatedRoles) === 0
+											!Object.keys(selectedItems)
+												.length &&
+											!Object.keys(updatedRoles).length
 										) {
 											onClose();
 											resetForm();

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
@@ -80,6 +80,28 @@ const ManageCollaborators = ({
 		},
 	});
 
+	const handleClose = () => {
+		if (
+			!Object.keys(selectedItems).length &&
+			!Object.keys(updatedRoles).length
+		) {
+			onClose();
+			resetForm();
+
+			return;
+		}
+
+		openConfirmModal({
+			message: Liferay.Language.get('discard-unsaved-changes'),
+			onConfirm: (isConfirmed) => {
+				if (isConfirmed) {
+					onClose();
+					resetForm();
+				}
+			},
+		});
+	};
+
 	const {refetch: collaboratorsRefetch, resource: collaboratorsResource} =
 		useResource({
 			fetchOptions: {
@@ -637,29 +659,7 @@ const ManageCollaborators = ({
 								<ClayButton
 									aria-label={Liferay.Language.get('cancel')}
 									displayType="secondary"
-									onClick={() => {
-										if (
-											!Object.keys(selectedItems)
-												.length &&
-											!Object.keys(updatedRoles).length
-										) {
-											onClose();
-											resetForm();
-										}
-										else {
-											openConfirmModal({
-												message: Liferay.Language.get(
-													'discard-unsaved-changes'
-												),
-												onConfirm: (isConfirmed) => {
-													if (isConfirmed) {
-														onClose();
-														resetForm();
-													}
-												},
-											});
-										}
-									}}
+									onClick={handleClose}
 								>
 									{Liferay.Language.get('cancel')}
 								</ClayButton>
@@ -709,14 +709,24 @@ const ManageCollaborators = ({
 		return (
 			<ClayModal
 				className="publications-invite-users-modal"
+				disableAutoClose
 				observer={observer}
 				size="lg"
 				spritemap={spritemap}
 			>
-				<ClayModal.Header
-					closeButtonAriaLabel={Liferay.Language.get('close')}
-				>
-					<div className="autofit-row">{headers}</div>
+				<ClayModal.Header withTitle={false}>
+					<ClayModal.Title>
+						<div className="autofit-row">{headers}</div>
+					</ClayModal.Title>
+
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('close')}
+						className="close"
+						displayType="unstyled"
+						onClick={handleClose}
+						spritemap={spritemap}
+						symbol="times"
+					/>
 				</ClayModal.Header>
 
 				{showShareLinkTab ? renderTabs() : ''}

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
+import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi, performLogout} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -30,88 +31,98 @@ test('LPD-30098 Invite user as admin', async ({
 	page,
 	site,
 }) => {
-	const user1 = await changeTrackingPage.addUserWithPublicationsUserRole();
+	try {
+		const user1 =
+			await changeTrackingPage.addUserWithPublicationsUserRole();
 
-	const user2 = await changeTrackingPage.addUserWithPublicationsUserRole();
+		const user2 =
+			await changeTrackingPage.addUserWithPublicationsUserRole();
 
-	await changeTrackingPage.workOnPublication(ctCollection);
+		await changeTrackingPage.workOnPublication(ctCollection);
 
-	await changeTrackingPage.addUserToPublication(
-		ctCollection.body.name,
-		'Admin',
-		user1
-	);
+		await changeTrackingPage.addUserToPublication(
+			ctCollection.body.name,
+			'Admin',
+			user1
+		);
 
-	await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-	const title = getRandomString();
+		const title = getRandomString();
 
-	await journalEditArticlePage.fillTitle(title);
+		await journalEditArticlePage.fillTitle(title);
 
-	await journalEditArticlePage.publishArticle();
+		await journalEditArticlePage.publishArticle();
 
-	await waitForAlert(page, `Success:${title} was created successfully.`);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
-	await performLogout(page);
+		await performLogout(page);
 
-	await performLoginViaApi({page, screenName: user1.alternateName});
+		await performLoginViaApi({page, screenName: user1.alternateName});
 
-	await page.getByTestId('userPersonalMenu').click();
+		await page.getByTestId('userPersonalMenu').click();
 
-	await page.getByRole('menuitem', {name: 'Notifications'}).click();
+		await page.getByRole('menuitem', {name: 'Notifications'}).click();
 
-	await expect(
-		page.getByText(
-			`has invited you to work on ${ctCollection.body.name} as a Admin.`
-		)
-	).toBeVisible();
+		await expect(
+			page.getByText(
+				`has invited you to work on ${ctCollection.body.name} as a Admin.`
+			)
+		).toBeVisible();
 
-	await changeTrackingPage.goto();
+		await changeTrackingPage.goto();
 
-	await page.waitForLoadState('load');
+		await page.waitForLoadState('load');
 
-	await page.getByRole('button', {name: 'Actions'}).click();
+		await page.getByRole('button', {name: 'Actions'}).click();
 
-	await page.getByRole('menuitem', {name: 'Edit'}).click();
+		await page.getByRole('menuitem', {name: 'Edit'}).click();
 
-	await page.getByPlaceholder('Enter the name of the').fill(title);
+		await page.getByPlaceholder('Enter the name of the').fill(title);
 
-	await page.getByRole('button', {name: 'Save'}).click();
+		await page.getByRole('button', {name: 'Save'}).click();
 
-	await waitForAlert(page, 'Success:Successfully updated');
+		await waitForAlert(page, 'Success:Successfully updated');
 
-	await page.getByRole('button', {name: 'Actions'}).click();
+		await page.getByRole('button', {name: 'Actions'}).click();
 
-	await expect(page.getByRole('menuitem', {name: 'Delete'})).toBeVisible();
+		await expect(
+			page.getByRole('menuitem', {name: 'Delete'})
+		).toBeVisible();
 
-	await changeTrackingPage.addUserToPublication(title, 'Admin', user2);
+		await changeTrackingPage.addUserToPublication(title, 'Admin', user2);
 
-	await changeTrackingPage.assertPublicationCommentsCRUDPermissions();
+		await changeTrackingPage.assertPublicationCommentsCRUDPermissions();
 
-	await page.reload();
+		await page.reload();
 
-	await page.getByRole('link', {name: 'Publish'}).click();
+		await page.getByRole('link', {name: 'Publish'}).click();
 
-	await page.getByRole('button', {name: 'Publish'}).click();
+		await page.getByRole('button', {name: 'Publish'}).click();
 
-	await expect(page.getByRole('link', {name: 'History'})).toBeVisible();
+		await expect(page.getByRole('link', {name: 'History'})).toBeVisible();
 
-	await expect(
-		page.locator('div').filter({hasText: title}).first()
-	).toBeVisible();
+		await expect(
+			page.locator('div').filter({hasText: title}).first()
+		).toBeVisible();
 
-	await waitForAlert(page, 'Success:Your request completed successfully.');
+		await waitForAlert(
+			page,
+			'Success:Your request completed successfully.'
+		);
 
-	await performLogout(page);
+		await performLogout(page);
 
-	await performLoginViaApi({page, screenName: 'test'});
+		await performLoginViaApi({page, screenName: 'test'});
 
-	await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user1.id));
-	await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user2.id));
-
-	await apiHelpers.headlessChangeTracking.deleteCTCollection(
-		ctCollection.body.id
-	);
+		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user1.id));
+		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user2.id));
+	}
+	finally {
+		await apiHelpers.headlessChangeTracking.deleteCTCollection(
+			ctCollection.body.id
+		);
+	}
 });
 
 test('LPD-89418 Paste email address to automatically add user in Invite Users modal', async ({
@@ -120,39 +131,45 @@ test('LPD-89418 Paste email address to automatically add user in Invite Users mo
 	ctCollection,
 	page,
 }) => {
-	const user = await changeTrackingPage.addUserWithPublicationsUserRole();
+	try {
+		const user = await changeTrackingPage.addUserWithPublicationsUserRole();
 
-	await changeTrackingPage.workOnPublication(ctCollection);
+		await changeTrackingPage.workOnPublication(ctCollection);
 
-	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+		await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
 
-	await page.getByLabel('View Collaborators').click();
+		await page.getByLabel('View Collaborators').click();
 
-	const input = page.getByPlaceholder('Enter name or email address.');
+		const input = page.getByPlaceholder('Enter name or email address.');
 
-	await input.click();
+		await input.click();
 
-	await input.evaluate((element: HTMLInputElement, emailAddress: string) => {
-		const dt = new DataTransfer();
+		await input.evaluate(
+			(element: HTMLInputElement, emailAddress: string) => {
+				const dt = new DataTransfer();
 
-		dt.setData('text/plain', emailAddress);
+				dt.setData('text/plain', emailAddress);
 
-		element.dispatchEvent(
-			new ClipboardEvent('paste', {
-				bubbles: true,
-				cancelable: true,
-				clipboardData: dt,
-			})
+				element.dispatchEvent(
+					new ClipboardEvent('paste', {
+						bubbles: true,
+						cancelable: true,
+						clipboardData: dt,
+					})
+				);
+			},
+			user.emailAddress
 		);
-	}, user.emailAddress);
 
-	await expect(page.getByText(user.emailAddress)).toBeVisible();
+		await expect(page.getByText(user.emailAddress)).toBeVisible();
 
-	await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
-
-	await apiHelpers.headlessChangeTracking.deleteCTCollection(
-		ctCollection.body.id
-	);
+		await apiHelpers.headlessAdminUser.deleteUserAccount(Number(user.id));
+	}
+	finally {
+		await apiHelpers.headlessChangeTracking.deleteCTCollection(
+			ctCollection.body.id
+		);
+	}
 });
 
 test('LPD-65173 Assert that the Share Link tab is hidden for Publication Templates', async ({
@@ -167,3 +184,91 @@ test('LPD-65173 Assert that the Share Link tab is hidden for Publication Templat
 
 	await expect(page.getByRole('button', {name: 'Share Link'})).toBeHidden();
 });
+
+test(
+	'LPD-60917 Cancel closes the collaborators modal without a discard prompt when nothing changed',
+	{tag: '@LPD-60917'},
+	async ({apiHelpers, changeTrackingPage, ctCollection, page}) => {
+		try {
+			let discardPrompted = false;
+
+			page.on('dialog', (dialog) => {
+				discardPrompted = true;
+
+				dialog.dismiss();
+			});
+
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+			await page.getByLabel('View Collaborators').click();
+
+			await expect(page.getByText('Invite Users')).toBeVisible();
+
+			await clickAndExpectToBeHidden({
+				target: page.getByText('Invite Users'),
+				trigger: page.getByLabel('Cancel', {exact: true}),
+			});
+
+			expect(discardPrompted).toBe(false);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.deleteCTCollection(
+				ctCollection.body.id
+			);
+		}
+	}
+);
+
+test(
+	'LPD-60917 Close button confirms discard when collaborator changes exist',
+	{tag: '@LPD-60917'},
+	async ({apiHelpers, changeTrackingPage, ctCollection, page}) => {
+		try {
+			let discardMessage = '';
+
+			page.on('dialog', (dialog) => {
+				discardMessage = dialog.message();
+
+				dialog.dismiss();
+			});
+
+			const user =
+				await changeTrackingPage.addUserWithPublicationsUserRole();
+
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+			await page.getByLabel('View Collaborators').click();
+
+			await expect(page.getByText('Invite Users')).toBeVisible();
+
+			await page.getByLabel('can view').click();
+
+			await page.getByRole('menuitem', {name: 'Admin'}).click();
+
+			await page
+				.getByPlaceholder('Enter name or email address.')
+				.fill(user.emailAddress);
+
+			await page.getByRole('option', {name: user.name}).click();
+
+			await expect(page.getByText('Add (Admin)')).toBeVisible();
+
+			await page.getByLabel('Close', {exact: true}).click();
+
+			expect(discardMessage).toBe('Discard unsaved changes?');
+
+			await apiHelpers.headlessAdminUser.deleteUserAccount(
+				Number(user.id)
+			);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.deleteCTCollection(
+				ctCollection.body.id
+			);
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60917

## What Is Being Fixed

In the Publications Share Access / Manage Collaborators pop-up, clicking Cancel raised a "Discard unsaved changes?" confirmation even when nothing had changed. The Cancel handler tested for "no changes" with `Object.keys(selectedItems) === 0`, comparing an array to a number, which is always false — so the confirmation fired on every Cancel. Separately, the modal's close (X) button bypassed the confirmation entirely, so a user with real unsaved changes could discard them silently.

## How It Is Being Fixed

The broken comparison is replaced with `!Object.keys(selectedItems).length && !Object.keys(updatedRoles).length`, matching the idiom already used for the submit button's disabled state, so Cancel closes immediately when nothing changed and prompts only when there are pending collaborator or role changes. The dirty-check is extracted into a shared `handleClose` function wired to both Cancel and a custom modal close button, and `disableAutoClose` is set so Esc and backdrop clicks cannot bypass the guard either. The confirmation now applies consistently to every way of dismissing the modal.

## PR Check

**pr-check: PASS** — tested on `7052414ceb9085646d9699d999fc59954f76637f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7052414ceb9085646d9699d999fc59954f76637f"} -->
