### PR TITLE
LPD-93365 Store and persist the Health Scan configuration

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-days-of-week-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-days-of-week-list-type-definition.json
@@ -1,0 +1,49 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_DAYS_OF_WEEK",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "FRIDAY",
+			"key": "FR",
+			"name": "Friday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "MONDAY",
+			"key": "MO",
+			"name": "Monday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SATURDAY",
+			"key": "SA",
+			"name": "Saturday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SUNDAY",
+			"key": "SU",
+			"name": "Sunday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "THURSDAY",
+			"key": "TH",
+			"name": "Thursday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "TUESDAY",
+			"key": "TU",
+			"name": "Tuesday",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "WEDNESDAY",
+			"key": "WE",
+			"name": "Wednesday",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Days of Week",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-ranking-methods-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-ranking-methods-list-type-definition.json
@@ -1,0 +1,19 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_ENGINE_RANKING_METHODS",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "MOST_RECENT_BY_CREATION",
+			"key": "mostRecentByCreation",
+			"name": "Most Recent by Creation Date",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "TOP_BY_PAGE_VISIT",
+			"key": "topByPageVisit",
+			"name": "Top by Page Visit",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Engine Ranking Methods",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-scopes-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-scopes-list-type-definition.json
@@ -20,8 +20,8 @@
 			"system": true
 		},
 		{
-			"externalReferenceCode": "SITEMAP_ONLY",
-			"key": "sitemapOnly",
+			"externalReferenceCode": "PUBLIC_SITEMAP_PAGES",
+			"key": "publicSitemapPages",
 			"name": "Public Sitemap Pages",
 			"system": true
 		}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-scopes-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-engine-scopes-list-type-definition.json
@@ -1,0 +1,31 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_ENGINE_SCOPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "ALL_PUBLISHED_PAGES",
+			"key": "allPublishedPages",
+			"name": "All Published Pages",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "EXCLUDED_PATHS_ONLY",
+			"key": "excludedPathsOnly",
+			"name": "Excluded Paths Only",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "INCLUDED_PATHS_ONLY",
+			"key": "includedPathsOnly",
+			"name": "Included Paths Only",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "SITEMAP_ONLY",
+			"key": "sitemapOnly",
+			"name": "Public Sitemap Pages",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Engine Scopes",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-frequencies-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-frequencies-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_SCAN_FREQUENCIES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "DAILY",
+			"key": "daily",
+			"name": "Daily",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "MONTHLY",
+			"key": "monthly",
+			"name": "Monthly",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "WEEKLY",
+			"key": "weekly",
+			"name": "Weekly",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Scan Frequencies",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/02-seo-studio-domain-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/02-seo-studio-domain-object-definition.json
@@ -13,19 +13,17 @@
 	"name": "SEOStudioDomain",
 	"objectFields": [
 		{
-			"DBType": "String",
-			"businessType": "Picklist",
-			"externalReferenceCode": "DEFAULT_SCAN_SCOPE",
+			"DBType": "Boolean",
+			"businessType": "Boolean",
+			"defaultValue": false,
+			"externalReferenceCode": "AUTO_SCAN_ENABLED",
 			"indexed": true,
-			"indexedAsKeyword": true,
 			"label": {
-				"en_US": "Default Scan Scope"
+				"en_US": "Auto Scan Enabled"
 			},
-			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_SCOPES",
-			"name": "defaultScanScope",
-			"required": true,
+			"name": "autoScanEnabled",
 			"system": true,
-			"type": "String"
+			"type": "Boolean"
 		},
 		{
 			"DBType": "String",
@@ -69,6 +67,24 @@
 			"required": true,
 			"system": true,
 			"type": "String"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "NEXT_SCAN_DATE",
+			"indexed": true,
+			"label": {
+				"en_US": "Next Scan Date"
+			},
+			"name": "nextScanDate",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"system": true,
+			"type": "DateTime"
 		},
 		{
 			"DBType": "Long",
@@ -123,6 +139,82 @@
 			"required": true,
 			"system": true,
 			"type": "Long"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "SCAN_CONFIG",
+			"indexed": false,
+			"label": {
+				"en_US": "Scan Config"
+			},
+			"name": "scanConfig",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Integer",
+			"externalReferenceCode": "SCAN_DAY_OF_MONTH",
+			"indexed": false,
+			"label": {
+				"en_US": "Scan Day of Month"
+			},
+			"name": "scanDayOfMonth",
+			"system": true,
+			"type": "Integer"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SCAN_DAY_OF_WEEK",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Scan Day of Week"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_DAYS_OF_WEEK",
+			"name": "scanDayOfWeek",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SCAN_FREQUENCY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Scan Frequency"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_SCAN_FREQUENCIES",
+			"name": "scanFrequency",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SCAN_TIME",
+			"indexed": false,
+			"label": {
+				"en_US": "Scan Time"
+			},
+			"name": "scanTime",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SCAN_TIME_ZONE",
+			"indexed": false,
+			"label": {
+				"en_US": "Scan Time Zone"
+			},
+			"name": "scanTimeZone",
+			"system": true,
+			"type": "String"
 		}
 	],
 	"objectFolderExternalReferenceCode": "default",

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/display/context/HealthScanConfigurationDisplayContext.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/display/context/HealthScanConfigurationDisplayContext.java
@@ -5,10 +5,13 @@
 
 package com.liferay.seo.studio.web.internal.display.context;
 
+import com.liferay.object.rest.dto.v1_0.ListEntry;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -36,7 +39,10 @@ import java.util.TreeSet;
 public class HealthScanConfigurationDisplayContext {
 
 	public HealthScanConfigurationDisplayContext(
-		HttpServletRequest httpServletRequest) {
+		HttpServletRequest httpServletRequest,
+		ObjectEntry seoStudioDomainObjectEntry) {
+
+		_seoStudioDomainObjectEntry = seoStudioDomainObjectEntry;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -45,6 +51,12 @@ public class HealthScanConfigurationDisplayContext {
 	public Map<String, Object> getViewProps() {
 		return HashMapBuilder.<String, Object>put(
 			"defaultTimeZoneId", _getDefaultTimeZoneId()
+		).put(
+			"domainId", _getDomainId()
+		).put(
+			"scanConfig", _getScanConfig()
+		).put(
+			"schedule", _getScheduleJSONObject()
 		).put(
 			"timeZones", _getTimeZonesJSONArray()
 		).build();
@@ -58,6 +70,60 @@ public class HealthScanConfigurationDisplayContext {
 		}
 
 		return timeZone.getID();
+	}
+
+	private Long _getDomainId() {
+		if (_seoStudioDomainObjectEntry == null) {
+			return null;
+		}
+
+		return _seoStudioDomainObjectEntry.getId();
+	}
+
+	private String _getListTypeEntryKey(Object value) {
+		ListEntry listEntry = (ListEntry)value;
+
+		if (listEntry == null) {
+			return null;
+		}
+
+		return listEntry.getKey();
+	}
+
+	private String _getScanConfig() {
+		if (_seoStudioDomainObjectEntry == null) {
+			return null;
+		}
+
+		Map<String, Object> properties =
+			_seoStudioDomainObjectEntry.getProperties();
+
+		return (String)properties.get("scanConfig");
+	}
+
+	private JSONObject _getScheduleJSONObject() {
+		if (_seoStudioDomainObjectEntry == null) {
+			return null;
+		}
+
+		Map<String, Object> properties =
+			_seoStudioDomainObjectEntry.getProperties();
+
+		return JSONUtil.put(
+			"autoScanEnabled", properties.get("autoScanEnabled")
+		).put(
+			"scanDayOfMonth", properties.get("scanDayOfMonth")
+		).put(
+			"scanDayOfWeek",
+			_getListTypeEntryKey(properties.get("scanDayOfWeek"))
+		).put(
+			"scanFrequency",
+			_getListTypeEntryKey(properties.get("scanFrequency"))
+		).put(
+			"scanTime", properties.get("scanTime")
+		).put(
+			"scanTimeZone", properties.get("scanTimeZone")
+		);
 	}
 
 	private JSONArray _getTimeZonesJSONArray() {
@@ -124,6 +190,7 @@ public class HealthScanConfigurationDisplayContext {
 		return timeZonesJSONArray;
 	}
 
+	private final ObjectEntry _seoStudioDomainObjectEntry;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/fragment/renderer/HealthScanConfigurationFragmentRenderer.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/fragment/renderer/HealthScanConfigurationFragmentRenderer.java
@@ -6,6 +6,12 @@
 package com.liferay.seo.studio.web.internal.fragment.renderer;
 
 import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.seo.studio.web.internal.display.context.HealthScanConfigurationDisplayContext;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,12 +41,54 @@ public class HealthScanConfigurationFragmentRenderer
 	protected HealthScanConfigurationDisplayContext getDisplayContext(
 		HttpServletRequest httpServletRequest) {
 
-		return new HealthScanConfigurationDisplayContext(httpServletRequest);
+		return new HealthScanConfigurationDisplayContext(
+			httpServletRequest,
+			_fetchSEOStudioDomainObjectEntry(httpServletRequest));
 	}
 
 	@Override
 	protected String getJSPPath() {
 		return "/health_scan_configuration.jsp";
 	}
+
+	private ObjectEntry _fetchSEOStudioDomainObjectEntry(
+		HttpServletRequest httpServletRequest) {
+
+		try {
+			long companyId = portal.getCompanyId(httpServletRequest);
+
+			ObjectDefinition objectDefinition =
+				objectDefinitionLocalService.
+					fetchObjectDefinitionByExternalReferenceCode(
+						"L_SEO_STUDIO_DOMAIN", companyId);
+
+			if (objectDefinition == null) {
+				return null;
+			}
+
+			Page<ObjectEntry> page = objectEntryManager.getObjectEntries(
+				companyId, objectDefinition, null, null,
+				getDTOConverterContext(objectDefinition), null,
+				Pagination.of(1, 1), null, null);
+
+			if (page != null) {
+				for (ObjectEntry objectEntry : page.getItems()) {
+					return objectEntry;
+				}
+			}
+
+			return null;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			return null;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		HealthScanConfigurationFragmentRenderer.class);
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/components/HealthScanConfiguration.tsx
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/components/HealthScanConfiguration.tsx
@@ -4,9 +4,10 @@
  */
 
 import ClayButton from '@clayui/button';
+import {openToast} from 'frontend-js-components-web';
 import React, {useMemo, useState} from 'react';
 
-import {getDefaultConfig} from '../constants';
+import {buildInitialConfig} from '../constants';
 import {
 	EngineConfig,
 	EngineKey,
@@ -38,19 +39,24 @@ function isConfigValid(config: HealthScanConfig): boolean {
 
 interface Props {
 	defaultTimeZoneId: string;
+	domainId: number | null;
+	scanConfig: string | null;
+	schedule: Partial<ScheduleConfig> | null;
 	timeZones: TimeZoneOption[];
 }
 
 export default function HealthScanConfiguration({
 	defaultTimeZoneId,
+	domainId,
+	scanConfig,
+	schedule,
 	timeZones,
 }: Props) {
-	const [savedConfig] = useState<HealthScanConfig>(() =>
-		getDefaultConfig(defaultTimeZoneId)
+	const [savedConfig, setSavedConfig] = useState<HealthScanConfig>(() =>
+		buildInitialConfig(defaultTimeZoneId, scanConfig, schedule)
 	);
-	const [config, setConfig] = useState<HealthScanConfig>(() =>
-		getDefaultConfig(defaultTimeZoneId)
-	);
+	const [config, setConfig] = useState<HealthScanConfig>(savedConfig);
+	const [saving, setSaving] = useState(false);
 
 	const valid = useMemo(() => isConfigValid(config), [config]);
 
@@ -61,12 +67,66 @@ export default function HealthScanConfiguration({
 		}));
 	}
 
-	function handleScheduleChange(schedule: ScheduleConfig) {
-		setConfig((current) => ({...current, schedule}));
+	function handleScheduleChange(nextSchedule: ScheduleConfig) {
+		setConfig((current) => ({...current, schedule: nextSchedule}));
 	}
 
 	function handleCancel() {
 		setConfig(savedConfig);
+	}
+
+	async function handleSave() {
+		if (!domainId) {
+			return;
+		}
+
+		setSaving(true);
+
+		try {
+			const response = await Liferay.Util.fetch(
+				`/o/seo-studio/domains/${domainId}`,
+				{
+					body: JSON.stringify({
+						autoScanEnabled: config.schedule.autoScanEnabled,
+						scanConfig: JSON.stringify({engines: config.engines}),
+						scanDayOfMonth: config.schedule.scanDayOfMonth,
+						scanDayOfWeek: config.schedule.scanDayOfWeek,
+						scanFrequency: config.schedule.scanFrequency,
+						scanTime: config.schedule.scanTime || '00:00',
+						scanTimeZone: config.schedule.scanTimeZone,
+					}),
+					headers: {'Content-Type': 'application/json'},
+					method: 'PATCH',
+				}
+			);
+
+			if (response.ok) {
+				setSavedConfig(config);
+
+				openToast({
+					message: Liferay.Language.get(
+						'your-request-completed-successfully'
+					),
+					type: 'success',
+				});
+			}
+			else {
+				openToast({
+					message: Liferay.Language.get(
+						'an-unexpected-error-occurred'
+					),
+					type: 'danger',
+				});
+			}
+		}
+		catch {
+			openToast({
+				message: Liferay.Language.get('an-unexpected-error-occurred'),
+				type: 'danger',
+			});
+		}
+
+		setSaving(false);
 	}
 
 	return (
@@ -91,11 +151,16 @@ export default function HealthScanConfiguration({
 
 				<div className="sheet-footer">
 					<ClayButton.Group spaced>
-						<ClayButton disabled={!valid} displayType="primary">
+						<ClayButton
+							disabled={!valid || !domainId || saving}
+							displayType="primary"
+							onClick={handleSave}
+						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 
 						<ClayButton
+							disabled={saving}
 							displayType="secondary"
 							onClick={handleCancel}
 						>

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {EngineKey, HealthScanConfig} from './types';
+import {EngineKey, HealthScanConfig, ScheduleConfig} from './types';
 
 interface EngineDescriptor {
 	key: EngineKey;
@@ -109,4 +109,46 @@ export function getDefaultConfig(defaultTimeZoneId: string): HealthScanConfig {
 			scanTimeZone: defaultTimeZoneId,
 		},
 	};
+}
+
+export function buildInitialConfig(
+	defaultTimeZoneId: string,
+	scanConfig: string | null,
+	schedule: Partial<ScheduleConfig> | null
+): HealthScanConfig {
+	const config = getDefaultConfig(defaultTimeZoneId);
+
+	if (scanConfig) {
+		const parsedConfig = JSON.parse(
+			scanConfig
+		) as Partial<HealthScanConfig>;
+
+		if (parsedConfig.engines) {
+			for (const key of Object.keys(config.engines) as EngineKey[]) {
+				if (parsedConfig.engines[key]) {
+					config.engines[key] = {
+						...config.engines[key],
+						...parsedConfig.engines[key],
+					};
+				}
+			}
+		}
+	}
+
+	if (schedule) {
+		config.schedule = {
+			autoScanEnabled:
+				schedule.autoScanEnabled ?? config.schedule.autoScanEnabled,
+			scanDayOfMonth:
+				schedule.scanDayOfMonth || config.schedule.scanDayOfMonth,
+			scanDayOfWeek:
+				schedule.scanDayOfWeek || config.schedule.scanDayOfWeek,
+			scanFrequency:
+				schedule.scanFrequency || config.schedule.scanFrequency,
+			scanTime: schedule.scanTime || config.schedule.scanTime,
+			scanTimeZone: schedule.scanTimeZone || config.schedule.scanTimeZone,
+		};
+	}
+
+	return config;
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
@@ -62,7 +62,7 @@ export const SCOPE_OPTIONS: SelectOption[] = [
 	},
 	{
 		label: Liferay.Language.get('public-sitemap-pages'),
-		value: 'sitemapOnly',
+		value: 'publicSitemapPages',
 	},
 	{
 		label: Liferay.Language.get('included-path-only'),

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/constants.ts
@@ -89,7 +89,7 @@ export function getDefaultConfig(defaultTimeZoneId: string): HealthScanConfig {
 
 	for (const {key} of ENGINE_DESCRIPTORS) {
 		engines[key] = {
-			enabled: true,
+			enabled: false,
 			excludedPaths: '',
 			includedPaths: '',
 			maxPagesPerScan: 100,
@@ -101,7 +101,7 @@ export function getDefaultConfig(defaultTimeZoneId: string): HealthScanConfig {
 	return {
 		engines,
 		schedule: {
-			autoScanEnabled: true,
+			autoScanEnabled: false,
 			scanDayOfMonth: 1,
 			scanDayOfWeek: 'MO',
 			scanFrequency: 'daily',

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/types.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/health_scan/types.ts
@@ -15,7 +15,7 @@ export type ScanScope =
 	| 'allPublishedPages'
 	| 'excludedPathsOnly'
 	| 'includedPathsOnly'
-	| 'sitemapOnly';
+	| 'publicSitemapPages';
 
 export interface EngineConfig {
 	enabled: boolean;

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
@@ -167,7 +167,7 @@ describe('HealthScanConfiguration', () => {
 			toggleCrawler();
 
 			fireEvent.change(screen.getAllByLabelText('scope')[0], {
-				target: {value: 'sitemapOnly'},
+				target: {value: 'publicSitemapPages'},
 			});
 
 			expect(

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
@@ -4,10 +4,15 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {openToast} from 'frontend-js-components-web';
 import React from 'react';
 
 import HealthScanConfiguration from '../../../js/health_scan/components/HealthScanConfiguration';
+
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
 
 function getSaveButton() {
 	return screen.getByRole('button', {name: 'save'});
@@ -26,16 +31,30 @@ const TIME_ZONES = [
 	{label: '(UTC -05:00) Eastern Standard Time', value: 'America/New_York'},
 ];
 
-function renderConfiguration() {
+type ConfigurationProps = React.ComponentProps<typeof HealthScanConfiguration>;
+
+function renderConfiguration(props: Partial<ConfigurationProps> = {}) {
 	return render(
 		<HealthScanConfiguration
 			defaultTimeZoneId="UTC"
+			domainId={1}
+			scanConfig={null}
+			schedule={null}
 			timeZones={TIME_ZONES}
+			{...props}
 		/>
 	);
 }
 
 describe('HealthScanConfiguration', () => {
+	beforeEach(() => {
+		(openToast as jest.Mock).mockClear();
+
+		(Liferay.Util as unknown) = {
+			fetch: jest.fn().mockResolvedValue({ok: true}),
+		};
+	});
+
 	describe('schedule section', () => {
 		it('shows the schedule fields when Auto Scan is on', () => {
 			renderConfiguration();
@@ -233,6 +252,141 @@ describe('HealthScanConfiguration', () => {
 			expect(screen.getAllByLabelText('scope')).toHaveLength(4);
 			expect(getSaveButton()).toBeEnabled();
 			expect(getCancelButton()).toBeEnabled();
+		});
+	});
+
+	describe('persistence', () => {
+		it('disables Save when no domain is available', () => {
+			renderConfiguration({domainId: null});
+
+			expect(getSaveButton()).toBeDisabled();
+		});
+
+		it('persists the configuration to the domain on Save', async () => {
+			const fetchMock = Liferay.Util.fetch as jest.Mock;
+
+			renderConfiguration({domainId: 42});
+
+			fireEvent.click(getSaveButton());
+
+			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+			const [url, init] = fetchMock.mock.calls[0];
+
+			expect(url).toBe('/o/seo-studio/domains/42');
+			expect(init.method).toBe('PATCH');
+
+			const body = JSON.parse(init.body);
+
+			expect(body.autoScanEnabled).toBe(true);
+			expect(body.scanFrequency).toBe('daily');
+			expect(body.scanTimeZone).toBe('UTC');
+
+			const scanConfig = JSON.parse(body.scanConfig);
+
+			expect(scanConfig.engines.crawler.enabled).toBe(true);
+
+			await waitFor(() =>
+				expect(openToast).toHaveBeenCalledWith(
+					expect.objectContaining({type: 'success'})
+				)
+			);
+		});
+
+		it('shows an error toast when the save request fails', async () => {
+			(Liferay.Util.fetch as jest.Mock).mockResolvedValue({ok: false});
+
+			renderConfiguration();
+
+			fireEvent.click(getSaveButton());
+
+			await waitFor(() =>
+				expect(openToast).toHaveBeenCalledWith(
+					expect.objectContaining({type: 'danger'})
+				)
+			);
+		});
+
+		it('seeds the form from the persisted configuration', () => {
+			renderConfiguration({
+				scanConfig: JSON.stringify({
+					engines: {
+						crawler: {
+							enabled: false,
+							excludedPaths: '',
+							includedPaths: '',
+							maxPagesPerScan: 100,
+							rankingMethod: 'topByPageVisit',
+							scope: 'allPublishedPages',
+						},
+					},
+				}),
+				schedule: {
+					autoScanEnabled: true,
+					scanDayOfWeek: 'WE',
+					scanFrequency: 'weekly',
+				},
+			});
+
+			expect(screen.getByLabelText('frequency')).toHaveValue('weekly');
+			expect(screen.getByLabelText('day-of-week')).toHaveValue('WE');
+			expect(
+				screen.queryByLabelText('crawler-insights')
+			).not.toBeChecked();
+		});
+
+		it('keeps the schedule defaults when persisted fields are empty', () => {
+			renderConfiguration({
+				schedule: {
+					autoScanEnabled: true,
+					scanDayOfMonth: 0,
+					scanDayOfWeek: '',
+					scanFrequency: '',
+					scanTime: '',
+					scanTimeZone: '',
+				} as unknown as ConfigurationProps['schedule'],
+			});
+
+			expect(screen.getByLabelText('frequency')).toHaveValue('daily');
+			expect(screen.getByLabelText('time')).toHaveValue('00:00');
+			expect(screen.getByLabelText('time-zone')).toHaveValue('UTC');
+		});
+
+		it('persists midnight when Time is cleared', async () => {
+			const fetchMock = Liferay.Util.fetch as jest.Mock;
+
+			renderConfiguration({domainId: 42});
+
+			enableAutoScan();
+
+			fireEvent.change(screen.getByLabelText('time'), {
+				target: {value: ''},
+			});
+			fireEvent.click(getSaveButton());
+
+			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+			const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+			expect(body.scanTime).toBe('00:00');
+		});
+
+		it('merges a partial persisted engine over its defaults', () => {
+			renderConfiguration({
+				scanConfig: JSON.stringify({
+					engines: {
+						crawler: {
+							scope: 'sitemapOnly',
+						},
+					},
+				}),
+			});
+
+			expect(screen.getByLabelText('crawler-insights')).toBeChecked();
+			expect(screen.getAllByLabelText('scope')).toHaveLength(4);
+			expect(screen.getAllByLabelText('scope')[0]).toHaveValue(
+				'sitemapOnly'
+			);
 		});
 	});
 

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/health_scan/HealthScanConfiguration.spec.tsx
@@ -22,8 +22,12 @@ function getCancelButton() {
 	return screen.getByRole('button', {name: 'cancel'});
 }
 
-function toggleContentTechnical() {
+function toggleCrawler() {
 	fireEvent.click(screen.getByLabelText('crawler-insights'));
+}
+
+function enableAutoScan() {
+	fireEvent.click(screen.getByLabelText(/auto-scan/, {selector: 'input'}));
 }
 
 const TIME_ZONES = [
@@ -56,8 +60,22 @@ describe('HealthScanConfiguration', () => {
 	});
 
 	describe('schedule section', () => {
-		it('shows the schedule fields when Auto Scan is on', () => {
+		it('hides the schedule fields when Auto Scan is off by default', () => {
 			renderConfiguration();
+
+			expect(
+				screen.queryByLabelText('frequency')
+			).not.toBeInTheDocument();
+			expect(screen.queryByLabelText('time')).not.toBeInTheDocument();
+			expect(
+				screen.queryByLabelText('time-zone')
+			).not.toBeInTheDocument();
+		});
+
+		it('shows the schedule fields when Auto Scan is turned on', () => {
+			renderConfiguration();
+
+			enableAutoScan();
 
 			expect(screen.getByLabelText('frequency')).toBeInTheDocument();
 			expect(screen.getByLabelText('time')).toHaveValue('00:00');
@@ -67,6 +85,8 @@ describe('HealthScanConfiguration', () => {
 		it('populates the time zone select with the provided time zones', () => {
 			renderConfiguration();
 
+			enableAutoScan();
+
 			expect(
 				screen.getByText('(UTC -05:00) Eastern Standard Time')
 			).toBeInTheDocument();
@@ -74,6 +94,8 @@ describe('HealthScanConfiguration', () => {
 
 		it('reveals the day-of-week selector only for Weekly', () => {
 			renderConfiguration();
+
+			enableAutoScan();
 
 			expect(
 				screen.queryByLabelText('day-of-week')
@@ -92,6 +114,8 @@ describe('HealthScanConfiguration', () => {
 		it('reveals the day-of-month selector only for Monthly', () => {
 			renderConfiguration();
 
+			enableAutoScan();
+
 			fireEvent.change(screen.getByLabelText('frequency'), {
 				target: {value: 'monthly'},
 			});
@@ -101,41 +125,28 @@ describe('HealthScanConfiguration', () => {
 				screen.queryByLabelText('day-of-week')
 			).not.toBeInTheDocument();
 		});
-
-		it('hides the schedule fields when Auto Scan is off', () => {
-			renderConfiguration();
-
-			fireEvent.click(
-				screen.getByLabelText(/auto-scan/, {selector: 'input'})
-			);
-
-			expect(
-				screen.queryByLabelText('frequency')
-			).not.toBeInTheDocument();
-			expect(screen.queryByLabelText('time')).not.toBeInTheDocument();
-			expect(
-				screen.queryByLabelText('time-zone')
-			).not.toBeInTheDocument();
-		});
 	});
 
 	describe('scope section', () => {
-		it('renders a block for every engine, enabled by default', () => {
+		it('renders a toggle for every engine, disabled by default', () => {
 			renderConfiguration();
 
-			expect(screen.getAllByLabelText('scope')).toHaveLength(4);
+			expect(screen.getByLabelText('crawler-insights')).not.toBeChecked();
+			expect(screen.queryAllByLabelText('scope')).toHaveLength(0);
 		});
 
-		it("hides an engine's fields when its toggle is off", () => {
+		it("shows an engine's fields when its toggle is on", () => {
 			renderConfiguration();
 
-			toggleContentTechnical();
+			toggleCrawler();
 
-			expect(screen.getAllByLabelText('scope')).toHaveLength(3);
+			expect(screen.getAllByLabelText('scope')).toHaveLength(1);
 		});
 
 		it('reveals the Included Path input only for "Included Paths Only"', () => {
 			renderConfiguration();
+
+			toggleCrawler();
 
 			expect(
 				screen.queryByLabelText(/included-path/, {selector: 'input'})
@@ -152,6 +163,8 @@ describe('HealthScanConfiguration', () => {
 
 		it('shows no path input for "Public Sitemap Pages"', () => {
 			renderConfiguration();
+
+			toggleCrawler();
 
 			fireEvent.change(screen.getAllByLabelText('scope')[0], {
 				target: {value: 'sitemapOnly'},
@@ -170,6 +183,8 @@ describe('HealthScanConfiguration', () => {
 	describe('path validation', () => {
 		function selectIncludedPathsOnly() {
 			renderConfiguration();
+
+			toggleCrawler();
 
 			fireEvent.change(screen.getAllByLabelText('scope')[0], {
 				target: {value: 'includedPathsOnly'},
@@ -215,6 +230,8 @@ describe('HealthScanConfiguration', () => {
 		it('requires an Excluded Path and disables Save while it is empty', () => {
 			renderConfiguration();
 
+			toggleCrawler();
+
 			fireEvent.change(screen.getAllByLabelText('scope')[0], {
 				target: {value: 'excludedPathsOnly'},
 			});
@@ -243,13 +260,13 @@ describe('HealthScanConfiguration', () => {
 		it('reverts unsaved changes on Cancel', () => {
 			renderConfiguration();
 
-			toggleContentTechnical();
+			toggleCrawler();
 
-			expect(screen.getAllByLabelText('scope')).toHaveLength(3);
+			expect(screen.getAllByLabelText('scope')).toHaveLength(1);
 
 			fireEvent.click(getCancelButton());
 
-			expect(screen.getAllByLabelText('scope')).toHaveLength(4);
+			expect(screen.queryAllByLabelText('scope')).toHaveLength(0);
 			expect(getSaveButton()).toBeEnabled();
 			expect(getCancelButton()).toBeEnabled();
 		});
@@ -278,13 +295,13 @@ describe('HealthScanConfiguration', () => {
 
 			const body = JSON.parse(init.body);
 
-			expect(body.autoScanEnabled).toBe(true);
+			expect(body.autoScanEnabled).toBe(false);
 			expect(body.scanFrequency).toBe('daily');
 			expect(body.scanTimeZone).toBe('UTC');
 
 			const scanConfig = JSON.parse(body.scanConfig);
 
-			expect(scanConfig.engines.crawler.enabled).toBe(true);
+			expect(scanConfig.engines.crawler.enabled).toBe(false);
 
 			await waitFor(() =>
 				expect(openToast).toHaveBeenCalledWith(
@@ -376,16 +393,19 @@ describe('HealthScanConfiguration', () => {
 				scanConfig: JSON.stringify({
 					engines: {
 						crawler: {
-							scope: 'sitemapOnly',
+							enabled: true,
 						},
 					},
 				}),
 			});
 
 			expect(screen.getByLabelText('crawler-insights')).toBeChecked();
-			expect(screen.getAllByLabelText('scope')).toHaveLength(4);
+			expect(
+				screen.getByLabelText('ai-generated-insights')
+			).not.toBeChecked();
+			expect(screen.getAllByLabelText('scope')).toHaveLength(1);
 			expect(screen.getAllByLabelText('scope')[0]).toHaveValue(
-				'sitemapOnly'
+				'allPublishedPages'
 			);
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93365

## What Is Being Fixed

The Health Scan configuration UI had nowhere to persist to: `SEOStudioDomain` carried no scan-schedule or per-engine fields, and the form's Save button did nothing, so a user's frequency, time, time zone, and engine settings were discarded on reload.

## How It Is Being Fixed

`SEOStudioDomain` gains typed, queryable schedule fields (`autoScanEnabled`, `scanFrequency`, `scanDayOfWeek`, `scanDayOfMonth`, `scanTime`, `scanTimeZone`, and an indexed `nextScanDate`) plus a `scanConfig` Clob that holds the per-engine tree, backed by new canonical list-type definitions for frequencies, days of week, engine scopes, and ranking methods. The configuration form now persists on Save by PATCHing the domain through its Objects REST endpoint, and the fragment renderer's display context seeds the form from the stored values so a saved configuration round-trips. The schedule and every engine default to off.

Because the Objects framework returns empty-string and zero sentinels for unset columns rather than null, the form merges each persisted schedule field over its default individually instead of spreading the whole object, so an unconfigured domain shows real defaults (Daily, 00:00, UTC) rather than blanks, and a cleared time coerces to midnight on save. Finally, the sitemap scan scope key is renamed to `publicSitemapPages` so every engine-scope key is the camelCase of its label.

## PR Check

**pr-check: PASS** — tested on `9c8133d0868cd435418af71ef5872378992f5ff0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9c8133d0868cd435418af71ef5872378992f5ff0"} -->