### PR TITLE
LPD-94459 Keep language selector when editing Global web content

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -32,12 +32,18 @@ import com.liferay.taglib.util.IncludeTag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.PageContext;
 
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Adolfo Pérez
  */
 public class InputTag extends IncludeTag {
+
+	public Set<Locale> getAvailableLocales() {
+		return _availableLocales;
+	}
 
 	public String getClassName() {
 		return _className;
@@ -81,6 +87,10 @@ public class InputTag extends IncludeTag {
 
 	public boolean isShowLabel() {
 		return _showLabel;
+	}
+
+	public void setAvailableLocales(Set<Locale> availableLocales) {
+		_availableLocales = availableLocales;
 	}
 
 	public void setClassName(String className) {
@@ -138,6 +148,7 @@ public class InputTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_availableLocales = null;
 		_className = null;
 		_classPK = 0;
 		_defaultLanguageId = null;
@@ -160,6 +171,9 @@ public class InputTag extends IncludeTag {
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
 		super.setAttributes(httpServletRequest);
 
+		httpServletRequest.setAttribute(
+			"liferay-friendly-url:input:availableLocales",
+			getAvailableLocales());
 		httpServletRequest.setAttribute(
 			"liferay-friendly-url:input:className", getClassName());
 		httpServletRequest.setAttribute(
@@ -322,6 +336,7 @@ public class InputTag extends IncludeTag {
 
 	private static final Log _log = LogFactoryUtil.getLog(InputTag.class);
 
+	private Set<Locale> _availableLocales;
 	private String _className;
 	private long _classPK;
 	private String _defaultLanguageId;

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
@@ -45,6 +45,11 @@
 		<tag-class>com.liferay.friendly.url.taglib.servlet.taglib.InputTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>availableLocales</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>className</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/init.jsp
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/init.jsp
@@ -18,3 +18,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.HttpComponentsUtil" %><%@
 page import="com.liferay.portal.kernel.util.LocaleUtil" %>
+
+<%@ page import="java.util.Locale" %><%@
+page import="java.util.Set" %>

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/input/init.jsp" %>
 
 <%
+Set<Locale> availableLocales = (Set<Locale>)request.getAttribute("liferay-friendly-url:input:availableLocales");
 String defaultLanguageId = (String)request.getAttribute("liferay-friendly-url:input:defaultLanguageId");
 boolean disabled = (boolean)request.getAttribute("liferay-friendly-url:input:disabled");
 int friendlyURLMaxLength = (int)request.getAttribute("liferay-friendly-url:input:friendlyURLMaxLength");
@@ -43,6 +44,7 @@ if (defaultLanguageId == null) {
 	<c:choose>
 		<c:when test="<%= localizable %>">
 			<liferay-ui:input-localized
+				availableLocales="<%= availableLocales %>"
 				defaultLanguageId="<%= defaultLanguageId %>"
 				disabled="<%= disabled %>"
 				helpMessage='<%= (String)request.getAttribute("liferay-friendly-url:input:helpMessage") %>'

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/taglib/servlet/taglib/test/InputTagTest.java
@@ -37,8 +37,11 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.portlet.PortletPreferences;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -93,6 +96,34 @@ public class InputTagTest {
 	@Test
 	public void testInputTag() throws Exception {
 		_assertInputTag(_layout.getFriendlyURLMap());
+	}
+
+	@Test
+	public void testInputTagAvailableLocales() throws Exception {
+		Set<Locale> availableLocales = new HashSet<>(
+			Arrays.asList(LocaleUtil.SPAIN, LocaleUtil.US));
+
+		InputTag inputTag = new InputTag();
+
+		inputTag.setAvailableLocales(availableLocales);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(inputTag);
+
+		Assert.assertEquals(
+			availableLocales,
+			mockHttpServletRequest.getAttribute(
+				"liferay-friendly-url:input:availableLocales"));
+	}
+
+	@Test
+	public void testInputTagAvailableLocalesIsNullByDefault() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(new InputTag());
+
+		Assert.assertNull(
+			mockHttpServletRequest.getAttribute(
+				"liferay-friendly-url:input:availableLocales"));
 	}
 
 	@Test
@@ -205,17 +236,8 @@ public class InputTagTest {
 	private void _assertInputTag(Map<Locale, String> expectedFriendlyURLMap)
 		throws Exception {
 
-		InputTag inputTag = new InputTag();
-
-		inputTag.setClassName(Layout.class.getName());
-		inputTag.setClassPK(_layout.getPlid());
-
 		MockHttpServletRequest mockHttpServletRequest =
-			ContentLayoutTestUtil.getMockHttpServletRequest(
-				_companyLocalService.getCompany(_layout.getCompanyId()), _group,
-				_layout);
-
-		inputTag.doTag(mockHttpServletRequest, new MockHttpServletResponse());
+			_getMockHttpServletRequest(new InputTag());
 
 		Map<Locale, String> friendlyURLMap = _localization.getLocalizationMap(
 			(String)mockHttpServletRequest.getAttribute(
@@ -233,6 +255,22 @@ public class InputTagTest {
 			Assert.assertEquals(
 				entry.getValue(), friendlyURLMap.get(entry.getKey()));
 		}
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(InputTag inputTag)
+		throws Exception {
+
+		inputTag.setClassName(Layout.class.getName());
+		inputTag.setClassPK(_layout.getPlid());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			ContentLayoutTestUtil.getMockHttpServletRequest(
+				_companyLocalService.getCompany(_layout.getCompanyId()), _group,
+				_layout);
+
+		inputTag.doTag(mockHttpServletRequest, new MockHttpServletResponse());
+
+		return mockHttpServletRequest;
 	}
 
 	@Inject

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -377,6 +377,10 @@ AUI.add(
 				_onLocaleChanged(event) {
 					const instance = this;
 
+					if (!event.item) {
+						return;
+					}
+
 					const languageId = event.item.getAttribute('data-value');
 
 					instance.selectFlag(languageId, event.source === instance);
@@ -673,27 +677,24 @@ AUI.add(
 					);
 
 					let translationAriaLabel =
-						languagesTranslationsAriaLabels[languageId][
-							'notTranslatedStatus'
-						];
+						languagesTranslationsAriaLabels?.[languageId]
+							?.notTranslatedStatus || STR_BLANK;
 					let translationStatus =
 						Liferay.Language.get('not-translated');
 					let translationStatusCssClass = 'warning';
 
 					if (translatedLanguages.has(languageId)) {
 						translationAriaLabel =
-							languagesTranslationsAriaLabels[languageId][
-								'translatedStatus'
-							];
+							languagesTranslationsAriaLabels?.[languageId]
+								?.translatedStatus || STR_BLANK;
 						translationStatus = Liferay.Language.get('translated');
 						translationStatusCssClass = 'success';
 					}
 
 					if (languageId === instance.get('defaultLanguageId')) {
 						translationAriaLabel =
-							languagesTranslationsAriaLabels[languageId][
-								'defaultStatus'
-							];
+							languagesTranslationsAriaLabels?.[languageId]
+								?.defaultStatus || STR_BLANK;
 						translationStatus = Liferay.Language.get('default');
 						translationStatusCssClass = 'info';
 					}
@@ -724,9 +725,8 @@ AUI.add(
 					);
 
 					const updatedTriggerAriaLabel =
-						languagesTranslationsAriaLabels[languageId][
-							'currentlySelected'
-						];
+						languagesTranslationsAriaLabels?.[languageId]
+							?.currentlySelected || STR_BLANK;
 
 					languageId = languageId.replaceAll('_', '-');
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
@@ -26,6 +26,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = (JournalEdit
 <p class="text-secondary"><liferay-ui:message key="the-friendly-url-may-be-modified-to-ensure-uniqueness" /></p>
 
 <liferay-friendly-url:input
+	availableLocales="<%= journalEditArticleDisplayContext.getAvailableLocales() %>"
 	className="<%= JournalArticle.class.getName() %>"
 	classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
 	defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -463,8 +463,10 @@ journalEditArticleDisplayContext.setViewAttributes();
 									</span>
 
 									<liferay-friendly-url:input
+										availableLocales="<%= journalEditArticleDisplayContext.getAvailableLocales() %>"
 										className="<%= JournalArticle.class.getName() %>"
 										classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
+										defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
 										inputAddon="<%= journalEditArticleDisplayContext.getFriendlyURLBase() %>"
 										languagesDropdownVisible="<%= false %>"
 										name="friendlyURL"

--- a/modules/test/playwright/tests/journal-web/main/translation.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/translation.spec.ts
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getGlobalSiteId from '../../../utils/getGlobalSiteId';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -19,7 +21,8 @@ const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	journalPagesTest,
-	loginTest()
+	loginTest(),
+	siteSettingsPagesTest
 );
 
 test(
@@ -76,6 +79,61 @@ test(
 		}
 		finally {
 			watcher.dispose();
+		}
+	}
+);
+
+test(
+	'Language selector remains when editing Global web content from a site with limited languages',
+	{
+		tag: '@LPD-94459',
+	},
+	async ({
+		apiHelpers,
+		journalEditArticlePage,
+		page,
+		site,
+		siteSettingsLocalizationPage,
+	}) => {
+		const globalSiteId = await getGlobalSiteId(apiHelpers);
+
+		const webContent =
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: await getBasicWebContentStructureId(apiHelpers),
+				groupId: globalSiteId,
+			});
+
+		try {
+			await siteSettingsLocalizationPage.setCustomDefaultLanguage(
+				'Spanish (Spain)',
+				site.friendlyUrlPath
+			);
+
+			await siteSettingsLocalizationPage.disableAllLanguagesExceptSp(
+				site.friendlyUrlPath
+			);
+
+			await page.goto(
+				`/group${site.friendlyUrlPath}${PORTLET_URLS.journal}&_com_liferay_journal_web_portlet_JournalPortlet_mvcRenderCommandName=%2Fjournal%2Fedit_article&_com_liferay_journal_web_portlet_JournalPortlet_groupId=${globalSiteId}&_com_liferay_journal_web_portlet_JournalPortlet_articleId=${webContent.articleId}`
+			);
+
+			const languageSelector = page.getByRole('combobox', {
+				name: 'Select a language',
+			});
+
+			await expect(languageSelector).toBeVisible();
+
+			await journalEditArticlePage.changeLanguage('de_DE');
+
+			await expect(languageSelector).toBeVisible();
+
+			await expect(languageSelector).toContainText('de-DE');
+		}
+		finally {
+			await apiHelpers.jsonWebServicesJournal.deleteArticle(
+				globalSiteId,
+				webContent.articleId
+			);
 		}
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94459

## What is this trying to solve?

When a web content article that lives in the Global site is edited from a child site whose languages are restricted to a custom set, selecting a language outside the site's set makes the editor's language selector disappear, so translations can no longer be managed.

The friendly URL field is the culprit: `liferay-friendly-url:input` renders a `liferay-ui:input-localized` without `availableLocales`, which defaults to the scope site's locale set instead of the article's. When the translation manager broadcasts a locale the friendly URL input does not know, `_updateTrigger` in `input_localized.js` dereferences a missing entry in its aria label map, and the resulting TypeError propagates back into the React effect that fired the event, unmounting the whole TranslationManager component. The site-limited locale set also meant friendly URL localizations outside the site's languages were dropped from the submitted form.

## How am I fixing it?

`liferay-friendly-url:input` gains an `availableLocales` attribute that is passed through to the inner `liferay-ui:input-localized`; when the attribute is not set, the previous site-default behavior is unchanged for all other callers. The web content editor passes the article's available locales and default language at both call sites (`edit_article.jsp` and `article/friendly_url.jsp`), so the friendly URL field now agrees with the translation manager, the title, and the description fields. Finally, `input_localized.js` guards the trigger and translation status updates against unknown language IDs and a null event item, so a stray locale can degrade to a blank aria label instead of crashing the editor's translation manager.

## How can you verify that it works?

Run the included automated tests.

## PR Check

**pr-check: PASS** — tested on `ab3f7f3bfdec74528b4018a03ca743dde93e27c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ab3f7f3bfdec74528b4018a03ca743dde93e27c5"} -->
