### PR TITLE
LPD-94818 Flush CTScore update before caching to avoid stale version

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
@@ -199,6 +199,8 @@ public class CTScoreLocalServiceImpl extends CTScoreLocalServiceBaseImpl {
 				ctScore.setScore(score);
 
 				session.saveOrUpdate(ctScore);
+
+				session.flush();
 			}
 
 			_entityCache.putResult(CTScoreImpl.class, ctScore, false, true);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94818

## What Is Being Fixed

`CTScoreLocalServiceImpl._updateScore` populated the entity cache before the Hibernate session was flushed when updating an existing CTScore, so the cached snapshot carried the pre-increment `mvccVersion`. Because `incrementScore` / `decrementScore` run asynchronously through `@BufferedIncrement`, a concurrent reader could pull the stale version from the cache and then fail a later optimistic-lock delete with `jakarta.persistence.OptimisticLockException: ... delete from CTScore where ctScoreId=? and ...; actual row count: 0; expected: 1`. It surfaced intermittently as a failure in `UpgradeVirtualHostTest.testMissingCtCollectionId`.

## How It Is Being Fixed

The update branch of `_updateScore` now calls `session.flush()` after `saveOrUpdate`, mirroring what the insert branch already does. Flushing executes the UPDATE immediately, so the in-memory CTScore holds the incremented `mvccVersion` before `_entityCache.putResult` snapshots it. The cache write then reflects the committed version and the later optimistic-lock delete matches the row.

## Why Are There No Tests?

The defect is a concurrency race between the asynchronous `@BufferedIncrement` processing and a concurrent CTScore delete. The staleness window exists only mid-transaction, before the deferred flush; any read that would observe it through the service API instead triggers Hibernate's auto-flush-before-query plus `MVCCSynchronizerPostUpdateEventListener`, which heal the cache before an assertion can run. A candidate integration test (increment twice, then delete) was written and verified against a running server to pass both with and without the fix, confirming it cannot distinguish the two. A concurrency-stress reproduction would be inherently flaky. The existing `UpgradeVirtualHostTest` exercises the real runtime path that originally surfaced the bug.

## PR Check

**pr-check: PASS** — tested on `040ca2c34ab6d4024edb83a7509eae74142fcfa3`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "040ca2c34ab6d4024edb83a7509eae74142fcfa3"} -->
