### PR TITLE
LPD-90949 Paginate asset-type sitemaps exceeding 50k URLs

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
@@ -61,7 +61,7 @@ public class AssetCategorySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		Company company = _companyLocalService.getCompany(companyId);

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
@@ -54,7 +54,7 @@ public class CPDefinitionSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		long commerceChannelGroupId =

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -24,10 +24,12 @@ import com.liferay.layout.page.template.util.LayoutPageTemplateEntryUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -37,6 +39,10 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -144,23 +150,25 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			Element element, LayoutSet layoutSet, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		int start = QueryUtil.ALL_POS;
-		int end = QueryUtil.ALL_POS;
+		ActionableDynamicQuery actionableDynamicQuery =
+			_journalArticleLocalService.getActionableDynamicQuery();
 
-		int count = _journalArticleService.getLayoutArticlesCount(
-			layoutSet.getGroupId(), 0);
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("classNameId", 0L)));
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
 
-		if (count > SitemapManager.MAXIMUM_ENTRIES) {
-			start = count - SitemapManager.MAXIMUM_ENTRIES;
-			end = count;
-		}
+		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
+		Set<String> processedArticleIds = new HashSet<>();
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
 
-		List<JournalArticle> journalArticles =
-			_journalArticleService.getLayoutArticles(
-				layoutSet.getGroupId(), 0, start, end);
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle journalArticle) -> _visitArticle(
+				element, true, journalArticle, null, layoutSet, portalURL,
+				processedArticleIds, siteAvailableLocales, themeDisplay));
 
-		visitArticles(
-			element, null, layoutSet, themeDisplay, journalArticles, true);
+		actionableDynamicQuery.performActions();
 	}
 
 	protected List<JournalArticle> getDisplayPageTemplateArticles(Layout layout)
@@ -305,72 +313,10 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			themeDisplay.getScopeGroupId());
 
 		for (JournalArticle journalArticle : journalArticles) {
-			if (processedArticleIds.contains(journalArticle.getArticleId()) ||
-				(journalArticle.getStatus() !=
-					WorkflowConstants.STATUS_APPROVED) ||
-				(headCheck && !JournalUtil.isHead(journalArticle))) {
-
-				continue;
-			}
-
-			Layout articleLayout = layout;
-
-			if ((articleLayout == null) &&
-				Validator.isNotNull(journalArticle.getLayoutUuid())) {
-
-				articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-					journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout());
-			}
-			else if (articleLayout == null) {
-				articleLayout = getDisplayPageTemplateLayout(
-					layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
-					journalArticle.getDDMStructure());
-			}
-
-			if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
-					articleLayout)) {
-
-				continue;
-			}
-
-			String groupFriendlyURL = _portal.getGroupFriendlyURL(
-				_layoutSetLocalService.getLayoutSet(
-					journalArticle.getGroupId(), false),
-				themeDisplay, false, false);
-
-			StringBundler sb = new StringBundler(4);
-
-			if (!groupFriendlyURL.startsWith(portalURL)) {
-				sb.append(portalURL);
-			}
-
-			sb.append(groupFriendlyURL);
-
-			if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
-				sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
-			}
-			else {
-				sb.append(_getFriendlyURLSeparator());
-			}
-
-			sb.append(journalArticle.getUrlTitle());
-
-			String articleURL = _portal.getCanonicalURL(
-				sb.toString(), themeDisplay, articleLayout);
-
-			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-				articleURL, themeDisplay, articleLayout,
-				_getAvailableLocales(journalArticle, siteAvailableLocales));
-
-			for (String alternateURL : alternateURLs.values()) {
-				_sitemapManager.addURLElement(
-					element, alternateURL, null,
-					journalArticle.getModifiedDate(), articleURL, alternateURLs,
-					articleLayout.getGroupId());
-			}
-
-			processedArticleIds.add(journalArticle.getArticleId());
+			_visitArticle(
+				element, headCheck, journalArticle, layout, layoutSet,
+				portalURL, processedArticleIds, siteAvailableLocales,
+				themeDisplay);
 		}
 	}
 
@@ -427,6 +373,89 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
 	}
 
+	private void _visitArticle(
+			Element element, boolean headCheck, JournalArticle journalArticle,
+			Layout layout, LayoutSet layoutSet, String portalURL,
+			Set<String> processedArticleIds, Set<Locale> siteAvailableLocales,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (processedArticleIds.contains(journalArticle.getArticleId()) ||
+			(journalArticle.getStatus() != WorkflowConstants.STATUS_APPROVED) ||
+			(headCheck && !JournalUtil.isHead(journalArticle))) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_journalArticleModelResourcePermission.contains(
+				permissionChecker, journalArticle, ActionKeys.VIEW)) {
+
+			return;
+		}
+
+			Layout articleLayout = layout;
+
+			if ((articleLayout == null) &&
+			Validator.isNotNull(journalArticle.getLayoutUuid())) {
+
+				articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
+				journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
+				layoutSet.isPrivateLayout());
+		}
+			else if (articleLayout == null) {
+				articleLayout = getDisplayPageTemplateLayout(
+				layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
+				journalArticle.getDDMStructure());
+		}
+
+		if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
+					articleLayout)) {
+
+			return;
+		}
+
+		String groupFriendlyURL = _portal.getGroupFriendlyURL(
+			_layoutSetLocalService.getLayoutSet(
+				journalArticle.getGroupId(), false),
+			themeDisplay, false, false);
+
+		StringBundler sb = new StringBundler(4);
+
+		if (!groupFriendlyURL.startsWith(portalURL)) {
+			sb.append(portalURL);
+		}
+
+		sb.append(groupFriendlyURL);
+
+		if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
+			sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
+		}
+		else {
+			sb.append(_getFriendlyURLSeparator());
+		}
+
+		sb.append(journalArticle.getUrlTitle());
+
+			String articleURL = _portal.getCanonicalURL(
+				sb.toString(), themeDisplay, articleLayout);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+				articleURL, themeDisplay, articleLayout,
+			_getAvailableLocales(journalArticle, siteAvailableLocales));
+
+		for (String alternateURL : alternateURLs.values()) {
+			_sitemapManager.addURLElement(
+				element, alternateURL, null, journalArticle.getModifiedDate(),
+				articleURL, alternateURLs, articleLayout.getGroupId());
+		}
+
+		processedArticleIds.add(journalArticle.getArticleId());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleSitemapURLProvider.class);
 
@@ -436,6 +465,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.journal.model.JournalArticle)"
+	)
+	private ModelResourcePermission<JournalArticle>
+		_journalArticleModelResourcePermission;
 
 	@Reference
 	private JournalArticleResourceLocalService

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -80,7 +80,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		List<Date> modifiedDates = _journalArticleLocalService.dslQuery(
@@ -133,12 +133,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		}
 
 		if (layout.isTypeAssetDisplay()) {
-			visitArticles(
+			_visitArticles(
 				element, layout, layoutSet, themeDisplay,
-				getDisplayPageTemplateArticles(layout), false);
+				_getDisplayPageTemplateArticles(layout), false);
 		}
 		else {
-			visitArticles(
+			_visitArticles(
 				element, null, layoutSet, themeDisplay,
 				_getDisplayPageArticles(layoutSet.getGroupId(), layoutUuid),
 				true);
@@ -171,7 +171,47 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		actionableDynamicQuery.performActions();
 	}
 
-	protected List<JournalArticle> getDisplayPageTemplateArticles(Layout layout)
+	private Set<Locale> _getAvailableLocales(
+		JournalArticle journalArticle, Set<Locale> siteAvailableLocales) {
+
+		Set<Locale> availableLocales = new HashSet<>();
+
+		if (SetUtil.isEmpty(siteAvailableLocales)) {
+			return availableLocales;
+		}
+
+		for (String availableLanguageId :
+				journalArticle.getAvailableLanguageIds()) {
+
+			Locale locale = LocaleUtil.fromLanguageId(availableLanguageId);
+
+			if (siteAvailableLocales.contains(locale)) {
+				availableLocales.add(locale);
+			}
+		}
+
+		return availableLocales;
+	}
+
+	private List<JournalArticle> _getDisplayPageArticles(
+		long groupId, String layoutUuid) {
+
+		int start = QueryUtil.ALL_POS;
+		int end = QueryUtil.ALL_POS;
+
+		int count = _journalArticleService.getArticlesByLayoutUuidCount(
+			groupId, layoutUuid);
+
+		if (count > SitemapManager.MAXIMUM_ENTRIES) {
+			start = count - SitemapManager.MAXIMUM_ENTRIES;
+			end = count;
+		}
+
+		return _journalArticleService.getArticlesByLayoutUuid(
+			groupId, layoutUuid, start, end);
+	}
+
+	private List<JournalArticle> _getDisplayPageTemplateArticles(Layout layout)
 		throws PortalException {
 
 		List<JournalArticle> journalArticles = new ArrayList<>();
@@ -183,14 +223,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		DynamicQuery assetDisplayPageEntryDynamicQuery =
 			_assetDisplayPageEntryLocalService.dynamicQuery();
 
-		long classNameId = _portal.getClassNameId(
-			JournalArticle.class.getName());
-
 		Property classNameIdProperty = PropertyFactoryUtil.forName(
 			"classNameId");
 
 		assetDisplayPageEntryDynamicQuery.add(
-			classNameIdProperty.eq(classNameId));
+			classNameIdProperty.eq(
+				_portal.getClassNameId(JournalArticle.class.getName())));
 
 		Property layoutPageTemplateEntryIdProperty =
 			PropertyFactoryUtil.forName("layoutPageTemplateEntryId");
@@ -261,7 +299,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		return journalArticles;
 	}
 
-	protected Layout getDisplayPageTemplateLayout(
+	private Layout _getDisplayPageTemplateLayout(
 		long groupId, long journalArticleResourcePrimKey,
 		DDMStructure ddmStructure) {
 
@@ -292,72 +330,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			return null;
 		}
 
-		long assetDisplayPageEntryPlid = assetDisplayPageEntry.getPlid();
-
-		return _layoutLocalService.fetchLayout(assetDisplayPageEntryPlid);
-	}
-
-	protected void visitArticles(
-			Element element, Layout layout, LayoutSet layoutSet,
-			ThemeDisplay themeDisplay, List<JournalArticle> journalArticles,
-			boolean headCheck)
-		throws PortalException {
-
-		if (journalArticles.isEmpty()) {
-			return;
-		}
-
-		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
-		Set<String> processedArticleIds = new HashSet<>();
-		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
-			themeDisplay.getScopeGroupId());
-
-		for (JournalArticle journalArticle : journalArticles) {
-			_visitArticle(
-				element, headCheck, journalArticle, layout, layoutSet,
-				portalURL, processedArticleIds, siteAvailableLocales,
-				themeDisplay);
-		}
-	}
-
-	private Set<Locale> _getAvailableLocales(
-		JournalArticle journalArticle, Set<Locale> siteAvailableLocales) {
-
-		Set<Locale> availableLocales = new HashSet<>();
-
-		if (SetUtil.isEmpty(siteAvailableLocales)) {
-			return availableLocales;
-		}
-
-		for (String availableLanguageId :
-				journalArticle.getAvailableLanguageIds()) {
-
-			Locale locale = LocaleUtil.fromLanguageId(availableLanguageId);
-
-			if (siteAvailableLocales.contains(locale)) {
-				availableLocales.add(locale);
-			}
-		}
-
-		return availableLocales;
-	}
-
-	private List<JournalArticle> _getDisplayPageArticles(
-		long groupId, String layoutUuid) {
-
-		int start = QueryUtil.ALL_POS;
-		int end = QueryUtil.ALL_POS;
-
-		int count = _journalArticleService.getArticlesByLayoutUuidCount(
-			groupId, layoutUuid);
-
-		if (count > SitemapManager.MAXIMUM_ENTRIES) {
-			start = count - SitemapManager.MAXIMUM_ENTRIES;
-			end = count;
-		}
-
-		return _journalArticleService.getArticlesByLayoutUuid(
-			groupId, layoutUuid, start, end);
+		return _layoutLocalService.fetchLayout(assetDisplayPageEntry.getPlid());
 	}
 
 	private String _getFriendlyURLSeparator() {
@@ -397,23 +370,24 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			return;
 		}
 
-			Layout articleLayout = layout;
+		Layout journalArticleLayout = layout;
 
-			if ((articleLayout == null) &&
+		if ((journalArticleLayout == null) &&
 			Validator.isNotNull(journalArticle.getLayoutUuid())) {
 
-				articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-				journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
-				layoutSet.isPrivateLayout());
+			journalArticleLayout =
+				_layoutLocalService.fetchLayoutByUuidAndGroupId(
+					journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
+					layoutSet.isPrivateLayout());
 		}
-			else if (articleLayout == null) {
-				articleLayout = getDisplayPageTemplateLayout(
+		else if (journalArticleLayout == null) {
+			journalArticleLayout = _getDisplayPageTemplateLayout(
 				layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
 				journalArticle.getDDMStructure());
 		}
 
 		if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
-					articleLayout)) {
+				journalArticleLayout)) {
 
 			return;
 		}
@@ -440,20 +414,43 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 		sb.append(journalArticle.getUrlTitle());
 
-			String articleURL = _portal.getCanonicalURL(
-				sb.toString(), themeDisplay, articleLayout);
+		String canonicalURL = _portal.getCanonicalURL(
+			sb.toString(), themeDisplay, journalArticleLayout);
 
 		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-				articleURL, themeDisplay, articleLayout,
+			canonicalURL, themeDisplay, journalArticleLayout,
 			_getAvailableLocales(journalArticle, siteAvailableLocales));
 
 		for (String alternateURL : alternateURLs.values()) {
 			_sitemapManager.addURLElement(
 				element, alternateURL, null, journalArticle.getModifiedDate(),
-				articleURL, alternateURLs, articleLayout.getGroupId());
+				canonicalURL, alternateURLs, journalArticleLayout.getGroupId());
 		}
 
 		processedArticleIds.add(journalArticle.getArticleId());
+	}
+
+	private void _visitArticles(
+			Element element, Layout layout, LayoutSet layoutSet,
+			ThemeDisplay themeDisplay, List<JournalArticle> journalArticles,
+			boolean headCheck)
+		throws PortalException {
+
+		if (journalArticles.isEmpty()) {
+			return;
+		}
+
+		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
+		Set<String> processedArticleIds = new HashSet<>();
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
+
+		for (JournalArticle journalArticle : journalArticles) {
+			_visitArticle(
+				element, headCheck, journalArticle, layout, layoutSet,
+				portalURL, processedArticleIds, siteAvailableLocales,
+				themeDisplay);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -6,16 +6,22 @@
 package com.liferay.layout.internal.site.provider;
 
 import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -135,35 +141,40 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		Map<String, LayoutTypeController> layoutTypeControllers =
 			LayoutTypeControllerTracker.getLayoutTypeControllers();
 
-		for (Map.Entry<String, LayoutTypeController> entry :
-				layoutTypeControllers.entrySet()) {
+		List<String> sitemapableTypes = TransformUtil.transform(
+			layoutTypeControllers.entrySet(),
+			entry -> {
+				LayoutTypeController layoutTypeController = entry.getValue();
 
-			LayoutTypeController layoutTypeController = entry.getValue();
+				return layoutTypeController.isSitemapable() ? entry.getKey() :
+					null;
+			});
 
-			if (!layoutTypeController.isSitemapable()) {
-				continue;
-			}
-
-			int start = QueryUtil.ALL_POS;
-			int end = QueryUtil.ALL_POS;
-
-			int count = _layoutService.getLayoutsCount(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey());
-
-			if (count > SitemapManager.MAXIMUM_ENTRIES) {
-				start = count - SitemapManager.MAXIMUM_ENTRIES;
-				end = count;
-			}
-
-			List<Layout> layouts = _layoutService.getLayouts(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey(), start, end);
-
-			for (Layout layout : layouts) {
-				visitLayout(element, layout, themeDisplay);
-			}
+		if (sitemapableTypes.isEmpty()) {
+			return;
 		}
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_layoutLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property privateLayoutProperty = PropertyFactoryUtil.forName(
+					"privateLayout");
+
+				dynamicQuery.add(
+					privateLayoutProperty.eq(layoutSet.isPrivateLayout()));
+
+				Property typeProperty = PropertyFactoryUtil.forName("type");
+
+				dynamicQuery.add(
+					typeProperty.in(sitemapableTypes.toArray(new String[0])));
+			});
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
+		actionableDynamicQuery.setPerformActionMethod(
+			(Layout layout) -> visitLayout(element, layout, themeDisplay));
+
+		actionableDynamicQuery.performActions();
 	}
 
 	protected void visitLayout(
@@ -172,6 +183,16 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 
 		if (layout.isSystem() ||
 			_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(layout)) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW)) {
 
 			return;
 		}
@@ -234,8 +255,10 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	@Reference
 	private LayoutLocalService _layoutLocalService;
 
-	@Reference
-	private LayoutService _layoutService;
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -35,7 +35,6 @@ import com.liferay.site.provider.SitemapURLProvider;
 import com.liferay.site.provider.helper.SitemapURLProviderHelper;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -58,25 +57,25 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
-
-		List<String> sitemapableLayoutTypes = new ArrayList<>();
 
 		Map<String, LayoutTypeController> layoutTypeControllers =
 			LayoutTypeControllerTracker.getLayoutTypeControllers();
 
-		for (Map.Entry<String, LayoutTypeController> entry :
-				layoutTypeControllers.entrySet()) {
+		List<String> layoutTypes = TransformUtil.transform(
+			layoutTypeControllers.entrySet(),
+			entry -> {
+				LayoutTypeController layoutTypeController = entry.getValue();
 
-			LayoutTypeController layoutTypeController = entry.getValue();
+				if (layoutTypeController.isSitemapable()) {
+					return entry.getKey();
+				}
 
-			if (layoutTypeController.isSitemapable()) {
-				sitemapableLayoutTypes.add(entry.getKey());
-			}
-		}
+				return null;
+			});
 
-		if (sitemapableLayoutTypes.isEmpty()) {
+		if (layoutTypes.isEmpty()) {
 			return null;
 		}
 
@@ -92,7 +91,7 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 					LayoutTable.INSTANCE.privateLayout.eq(false)
 				).and(
 					LayoutTable.INSTANCE.type.in(
-						sitemapableLayoutTypes.toArray(new String[0]))
+						layoutTypes.toArray(new String[0]))
 				).and(
 					LayoutTable.INSTANCE.modifiedDate.isNotNull()
 				)
@@ -141,16 +140,19 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		Map<String, LayoutTypeController> layoutTypeControllers =
 			LayoutTypeControllerTracker.getLayoutTypeControllers();
 
-		List<String> sitemapableTypes = TransformUtil.transform(
+		List<String> layoutTypes = TransformUtil.transform(
 			layoutTypeControllers.entrySet(),
 			entry -> {
 				LayoutTypeController layoutTypeController = entry.getValue();
 
-				return layoutTypeController.isSitemapable() ? entry.getKey() :
-					null;
+				if (layoutTypeController.isSitemapable()) {
+					return entry.getKey();
+				}
+
+				return null;
 			});
 
-		if (sitemapableTypes.isEmpty()) {
+		if (layoutTypes.isEmpty()) {
 			return;
 		}
 
@@ -168,7 +170,7 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 				Property typeProperty = PropertyFactoryUtil.forName("type");
 
 				dynamicQuery.add(
-					typeProperty.in(sitemapableTypes.toArray(new String[0])));
+					typeProperty.in(layoutTypes.toArray(new String[0])));
 			});
 		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
 		actionableDynamicQuery.setPerformActionMethod(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -62,10 +62,10 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
-		Date lastModifiedDate = null;
+		Date modifiedDate = null;
 
 		List<Long> companyObjectDefinitionIds = new ArrayList<>();
 		List<Long> siteObjectDefinitionIds = new ArrayList<>();
@@ -97,7 +97,7 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		}
 
 		if (!siteObjectDefinitionIds.isEmpty()) {
-			lastModifiedDate = _getLatestModifiedDate(
+			modifiedDate = _getLatestModifiedDate(
 				groupId, siteObjectDefinitionIds.toArray(new Long[0]));
 		}
 
@@ -107,14 +107,13 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 				companyObjectDefinitionIds.toArray(new Long[0]));
 
 			if ((companyDate != null) &&
-				((lastModifiedDate == null) ||
-				 companyDate.after(lastModifiedDate))) {
+				((modifiedDate == null) || companyDate.after(modifiedDate))) {
 
-				lastModifiedDate = companyDate;
+				modifiedDate = companyDate;
 			}
 		}
 
-		return lastModifiedDate;
+		return modifiedDate;
 	}
 
 	@Override

--- a/modules/apps/site/site-api/bnd.bnd
+++ b/modules/apps/site/site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site API
 Bundle-SymbolicName: com.liferay.site.api
-Bundle-Version: 28.1.1
+Bundle-Version: 29.0.0
 Export-Package:\
 	com.liferay.site.configuration,\
 	com.liferay.site.configuration.manager,\

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -62,13 +62,13 @@ public interface SitemapManager {
 		throws PortalException;
 
 	public String getSitemap(
-			String assetType, String layoutUuid, long groupId,
+			String assetTypeClassName, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	public String getSitemap(
-			String assetType, String layoutUuid, long groupId, int page,
-			boolean privateLayout, ThemeDisplay themeDisplay)
+			String assetTypeClassName, String layoutUuid, long groupId,
+			int page, boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	public InputStream getSitemapInputStream(

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -66,9 +66,14 @@ public interface SitemapManager {
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
+	public String getSitemap(
+			String assetType, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
 	public InputStream getSitemapInputStream(
-			String assetTypeKey, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+			String assetTypeKey, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 }

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/SitemapURLProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/SitemapURLProvider.java
@@ -22,7 +22,7 @@ public interface SitemapURLProvider {
 
 	public String getClassName();
 
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException;
 
 	public default boolean isInclude(long companyId, long groupId)

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/manager/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/manager/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -122,11 +122,11 @@ public class SitemapManagerImpl implements SitemapManager {
 		locElement.addText(encodeXML(url));
 
 		if (modifiedDate != null) {
-			Element modifiedDateElement = urlElement.addElement("lastmod");
+			Element lastmodElement = urlElement.addElement("lastmod");
 
 			DateFormat iso8601DateFormat = DateUtil.getISO8601Format();
 
-			modifiedDateElement.addText(iso8601DateFormat.format(modifiedDate));
+			lastmodElement.addText(iso8601DateFormat.format(modifiedDate));
 		}
 
 		if (typeSettingsUnicodeProperties == null) {
@@ -206,7 +206,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			alternateURLElement.addAttribute("href", canonicalURL);
 		}
 
-		if (element.attributeValue(_ATTRIBUTE_PAGINATION_PAGE) == null) {
+		if (element.attributeValue(_ATTRIBUTE_CURRENT_PAGE) == null) {
 			_removeOldestElement(element, urlElement);
 
 			return;
@@ -260,25 +260,26 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Override
 	public String getSitemap(
-			String assetType, String layoutUuid, long groupId,
+			String assetTypeClassName, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		return getSitemap(
-			assetType, layoutUuid, groupId, 1, privateLayout, themeDisplay);
+			assetTypeClassName, layoutUuid, groupId, 1, privateLayout,
+			themeDisplay);
 	}
 
 	@Override
 	public String getSitemap(
-			String assetType, String layoutUuid, long groupId, int page,
-			boolean privateLayout, ThemeDisplay themeDisplay)
+			String assetTypeClassName, String layoutUuid, long groupId,
+			int page, boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		if (Validator.isNotNull(assetType)) {
+		if (Validator.isNotNull(assetTypeClassName)) {
 			long companyId = themeDisplay.getCompanyId();
 
 			SitemapURLProvider sitemapURLProvider =
-				_serviceTrackerMap.getService(assetType);
+				_serviceTrackerMap.getService(assetTypeClassName);
 
 			if ((sitemapURLProvider == null) ||
 				!_sitemapConfigurationManager.xmlSitemapIndexCompanyEnabled(
@@ -292,7 +293,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 
 			return _getAssetTypeSitemap(
-				assetType, groupId, page, privateLayout, themeDisplay);
+				assetTypeClassName, groupId, page, privateLayout, themeDisplay);
 		}
 
 		if (Validator.isNull(layoutUuid) &&
@@ -392,11 +393,11 @@ public class SitemapManagerImpl implements SitemapManager {
 		locElement.addText(sb.toString());
 
 		if (modifiedDate != null) {
-			Element modifiedDateElement = sitemapElement.addElement("lastmod");
+			Element lastmodElement = sitemapElement.addElement("lastmod");
 
 			DateFormat iso8601DateFormat = DateUtil.getISO8601Format();
 
-			modifiedDateElement.addText(iso8601DateFormat.format(modifiedDate));
+			lastmodElement.addText(iso8601DateFormat.format(modifiedDate));
 		}
 	}
 
@@ -421,7 +422,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		return document;
 	}
 
-	private Date _getAssetTypeGroupLastModifiedDate(
+	private Date _getAssetTypeModifiedDate(
 			String className, long companyId, long groupId)
 		throws PortalException {
 
@@ -432,7 +433,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			return null;
 		}
 
-		return sitemapURLProvider.getLastModifiedDate(companyId, groupId);
+		return sitemapURLProvider.getModifiedDate(companyId, groupId);
 	}
 
 	private int _getAssetTypePageCount(
@@ -573,22 +574,23 @@ public class SitemapManagerImpl implements SitemapManager {
 						className, groupId, privateLayout, themeDisplay);
 				}
 
-				Date lastModifiedDate = _getAssetTypeGroupLastModifiedDate(
+				Date assetTypeModifiedDate = _getAssetTypeModifiedDate(
 					className, companyId, groupId);
 
-				int pageCount = _getAssetTypePageCount(
+				int assetTypePageCount = _getAssetTypePageCount(
 					companyId, groupId, assetTypeKey);
 
-				if (pageCount <= 1) {
+				if (assetTypePageCount <= 1) {
 					_addSitemapElement(
-						rootElement, assetTypeKey, portalURL, lastModifiedDate,
-						groupId, 0, privateLayout);
+						rootElement, assetTypeKey, portalURL,
+						assetTypeModifiedDate, groupId, 0, privateLayout);
 				}
 				else {
-					for (int page = 1; page <= pageCount; page++) {
+					for (int page = 1; page <= assetTypePageCount; page++) {
 						_addSitemapElement(
 							rootElement, assetTypeKey, portalURL,
-							lastModifiedDate, groupId, page, privateLayout);
+							assetTypeModifiedDate, groupId, page,
+							privateLayout);
 					}
 				}
 			}
@@ -754,14 +756,14 @@ public class SitemapManagerImpl implements SitemapManager {
 		rootElement.remove(newElement);
 
 		String assetTypeKey = rootElement.attributeValue(
-			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY);
+			_ATTRIBUTE_ASSET_TYPE_KEY);
 
 		long companyId = GetterUtil.getLong(
-			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_COMPANY_ID));
+			rootElement.attributeValue(_ATTRIBUTE_COMPANY_ID));
 		int currentPage = GetterUtil.getInteger(
-			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE));
+			rootElement.attributeValue(_ATTRIBUTE_CURRENT_PAGE));
 		long groupId = GetterUtil.getLong(
-			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_GROUP_ID));
+			rootElement.attributeValue(_ATTRIBUTE_GROUP_ID));
 
 		_storeCurrentPage(
 			rootElement, companyId, groupId, assetTypeKey, currentPage);
@@ -769,11 +771,10 @@ public class SitemapManagerImpl implements SitemapManager {
 		rootElement.clearContent();
 
 		_initEntriesAndSize(rootElement);
-		_initPaginationAttributes(
-			rootElement, companyId, groupId, assetTypeKey);
+		_initPagination(rootElement, companyId, groupId, assetTypeKey);
 
 		rootElement.addAttribute(
-			_ATTRIBUTE_PAGINATION_PAGE, String.valueOf(currentPage + 1));
+			_ATTRIBUTE_CURRENT_PAGE, String.valueOf(currentPage + 1));
 
 		rootElement.add(newElement);
 
@@ -793,17 +794,15 @@ public class SitemapManagerImpl implements SitemapManager {
 		rootElement.addAttribute("size", String.valueOf(size));
 	}
 
-	private void _initPaginationAttributes(
+	private void _initPagination(
 		Element rootElement, long companyId, long groupId,
 		String assetTypeKey) {
 
+		rootElement.addAttribute(_ATTRIBUTE_ASSET_TYPE_KEY, assetTypeKey);
 		rootElement.addAttribute(
-			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY, assetTypeKey);
-		rootElement.addAttribute(
-			_ATTRIBUTE_PAGINATION_COMPANY_ID, String.valueOf(companyId));
-		rootElement.addAttribute(
-			_ATTRIBUTE_PAGINATION_GROUP_ID, String.valueOf(groupId));
-		rootElement.addAttribute(_ATTRIBUTE_PAGINATION_PAGE, "1");
+			_ATTRIBUTE_COMPANY_ID, String.valueOf(companyId));
+		rootElement.addAttribute(_ATTRIBUTE_GROUP_ID, String.valueOf(groupId));
+		rootElement.addAttribute(_ATTRIBUTE_CURRENT_PAGE, "1");
 	}
 
 	private boolean _isCompanyVirtualHostname(ThemeDisplay themeDisplay) {
@@ -844,8 +843,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 		}
 
-		_initPaginationAttributes(
-			rootElement, companyId, groupId, assetTypeKey);
+		_initPagination(rootElement, companyId, groupId, assetTypeKey);
 
 		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
 			assetType);
@@ -860,7 +858,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		_storeCurrentPage(
 			rootElement, companyId, groupId, assetTypeKey,
 			GetterUtil.getInteger(
-				rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE)));
+				rootElement.attributeValue(_ATTRIBUTE_CURRENT_PAGE)));
 	}
 
 	private void _removeAttribute(Element rootElement, String name) {
@@ -930,10 +928,10 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	private void _removePaginationAttributes(Element rootElement) {
-		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY);
-		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_COMPANY_ID);
-		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_GROUP_ID);
-		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_PAGE);
+		_removeAttribute(rootElement, _ATTRIBUTE_ASSET_TYPE_KEY);
+		_removeAttribute(rootElement, _ATTRIBUTE_COMPANY_ID);
+		_removeAttribute(rootElement, _ATTRIBUTE_GROUP_ID);
+		_removeAttribute(rootElement, _ATTRIBUTE_CURRENT_PAGE);
 	}
 
 	private void _storeCurrentPage(
@@ -1049,16 +1047,13 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 	}
 
-	private static final String _ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY =
-		"_paginationAssetTypeKey";
+	private static final String _ATTRIBUTE_ASSET_TYPE_KEY = "_assetTypeKey";
 
-	private static final String _ATTRIBUTE_PAGINATION_COMPANY_ID =
-		"_paginationCompanyId";
+	private static final String _ATTRIBUTE_COMPANY_ID = "_companyId";
 
-	private static final String _ATTRIBUTE_PAGINATION_GROUP_ID =
-		"_paginationGroupId";
+	private static final String _ATTRIBUTE_CURRENT_PAGE = "_currentPage";
 
-	private static final String _ATTRIBUTE_PAGINATION_PAGE = "_paginationPage";
+	private static final String _ATTRIBUTE_GROUP_ID = "_groupId";
 
 	private static final byte[] _ATTRIBUTE_XHTML =
 		" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"".getBytes();

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -206,7 +206,13 @@ public class SitemapManagerImpl implements SitemapManager {
 			alternateURLElement.addAttribute("href", canonicalURL);
 		}
 
-		_removeOldestElement(element, urlElement);
+		if (element.attributeValue(_ATTRIBUTE_PAGINATION_PAGE) == null) {
+			_removeOldestElement(element, urlElement);
+
+			return;
+		}
+
+		_handlePagination(element, urlElement);
 	}
 
 	@Override
@@ -258,6 +264,16 @@ public class SitemapManagerImpl implements SitemapManager {
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		return getSitemap(
+			assetType, layoutUuid, groupId, 1, privateLayout, themeDisplay);
+	}
+
+	@Override
+	public String getSitemap(
+			String assetType, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException {
+
 		if (Validator.isNotNull(assetType)) {
 			long companyId = themeDisplay.getCompanyId();
 
@@ -276,7 +292,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 
 			return _getAssetTypeSitemap(
-				groupId, privateLayout, themeDisplay, assetType);
+				assetType, groupId, page, privateLayout, themeDisplay);
 		}
 
 		if (Validator.isNull(layoutUuid) &&
@@ -291,8 +307,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Override
 	public InputStream getSitemapInputStream(
-			String assetTypeKey, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+			String assetTypeKey, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		long companyId = themeDisplay.getCompanyId();
@@ -320,7 +336,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 
 		String xml = getSitemap(
-			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId, page,
 			privateLayout, themeDisplay);
 
 		if (xml == null) {
@@ -332,6 +348,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_maximumEntries = MAXIMUM_ENTRIES;
+
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			_bundleContext, SitemapURLProvider.class, null,
 			(serviceReference, emitter) -> {
@@ -345,6 +363,41 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private void _addSitemapElement(
+		Element rootElement, String assetTypeKey, String portalURL,
+		Date modifiedDate, long groupId, int page, boolean privateLayout) {
+
+		Element sitemapElement = rootElement.addElement("sitemap");
+
+		Element locElement = sitemapElement.addElement("loc");
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(portalURL);
+		sb.append(_portal.getPathContext());
+		sb.append("/sitemap-");
+		sb.append(assetTypeKey);
+		sb.append(".xml?groupId=");
+		sb.append(groupId);
+		sb.append("&privateLayout=");
+		sb.append(privateLayout);
+
+		if (page > 0) {
+			sb.append("&page=");
+			sb.append(page);
+		}
+
+		locElement.addText(sb.toString());
+
+		if (modifiedDate != null) {
+			Element modifiedDateElement = sitemapElement.addElement("lastmod");
+
+			DateFormat iso8601DateFormat = DateUtil.getISO8601Format();
+
+			modifiedDateElement.addText(iso8601DateFormat.format(modifiedDate));
+		}
 	}
 
 	private Document _createSitemapDocument(
@@ -382,36 +435,36 @@ public class SitemapManagerImpl implements SitemapManager {
 		return sitemapURLProvider.getLastModifiedDate(companyId, groupId);
 	}
 
-	private String _getAssetTypeSitemap(
-			long groupId, boolean privateLayout, ThemeDisplay themeDisplay,
-			String assetType)
+	private int _getAssetTypePageCount(
+			long companyId, long groupId, String assetTypeKey)
 		throws PortalException {
 
-		Document document = _createSitemapDocument(
-			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+		int pageCount = 1;
 
-		Element rootElement = document.getRootElement();
+		while (_sitemapStorageHelper.hasSitemapFile(
+					companyId, groupId, assetTypeKey, pageCount + 1)) {
 
-		_initEntriesAndSize(rootElement);
-
-		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
-			assetType);
-
-		for (LayoutSet curLayoutSet :
-				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
-
-			sitemapURLProvider.visitLayoutSet(
-				rootElement, curLayoutSet, themeDisplay);
+			pageCount++;
 		}
 
-		_removeEntriesAndSize(rootElement);
+		return pageCount;
+	}
 
-		String xml = document.asXML();
+	private String _getAssetTypeSitemap(
+			String assetType, long groupId, int page, boolean privateLayout,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		_regenerateAssetTypeSitemap(
+			assetType, groupId, privateLayout, themeDisplay);
+
+		String assetTypeKey = _assetTypeKeys.get(assetType);
+		long companyId = themeDisplay.getCompanyId();
 
 		try {
-			_sitemapStorageHelper.storeSitemapFile(
-				themeDisplay.getCompanyId(), groupId,
-				_assetTypeKeys.get(assetType), 1, xml);
+			return StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page));
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -419,7 +472,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 		}
 
-		return xml;
+		return null;
 	}
 
 	private String _getFriendlyURL(String path, long groupId) {
@@ -489,9 +542,10 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		long companyId = themeDisplay.getCompanyId();
+
 		String xmlSitemapIndexMode =
-			_sitemapConfigurationManager.xmlSitemapIndexMode(
-				themeDisplay.getCompanyId());
+			_sitemapConfigurationManager.xmlSitemapIndexMode(companyId);
 
 		if (StringUtil.equals(
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
@@ -505,33 +559,37 @@ public class SitemapManagerImpl implements SitemapManager {
 					_serviceTrackerMap.getService(className);
 
 				if ((sitemapURLProvider == null) ||
-					!sitemapURLProvider.isInclude(
-						themeDisplay.getCompanyId(), groupId)) {
+					!sitemapURLProvider.isInclude(companyId, groupId)) {
 
 					continue;
 				}
 
-				Element sitemapElement = rootElement.addElement("sitemap");
+				String assetTypeKey = entry.getValue();
 
-				Element locationElement = sitemapElement.addElement("loc");
+				if (!_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, assetTypeKey, 1)) {
 
-				locationElement.addText(
-					StringBundler.concat(
-						portalURL, _portal.getPathContext(), "/sitemap-",
-						entry.getValue(), ".xml?groupId=", groupId,
-						"&privateLayout=", privateLayout));
+					_regenerateAssetTypeSitemap(
+						className, groupId, privateLayout, themeDisplay);
+				}
 
 				Date lastModifiedDate = _getAssetTypeGroupLastModifiedDate(
-					className, themeDisplay.getCompanyId(), groupId);
+					className, companyId, groupId);
 
-				if (lastModifiedDate != null) {
-					Element lastModifiedElement = sitemapElement.addElement(
-						"lastmod");
+				int pageCount = _getAssetTypePageCount(
+					companyId, groupId, assetTypeKey);
 
-					DateFormat w3cDateFormat = DateUtil.getISO8601Format();
-
-					lastModifiedElement.addText(
-						w3cDateFormat.format(lastModifiedDate));
+				if (pageCount <= 1) {
+					_addSitemapElement(
+						rootElement, assetTypeKey, portalURL, lastModifiedDate,
+						groupId, 0, privateLayout);
+				}
+				else {
+					for (int page = 1; page <= pageCount; page++) {
+						_addSitemapElement(
+							rootElement, assetTypeKey, portalURL,
+							lastModifiedDate, groupId, page, privateLayout);
+					}
 				}
 			}
 		}
@@ -552,8 +610,7 @@ public class SitemapManagerImpl implements SitemapManager {
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			try {
-				_sitemapStorageHelper.storeSitemapFile(
-					themeDisplay.getCompanyId(), groupId, xml);
+				_sitemapStorageHelper.storeSitemapFile(companyId, groupId, xml);
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
@@ -677,12 +734,76 @@ public class SitemapManagerImpl implements SitemapManager {
 		return bytes.length - offset;
 	}
 
+	private void _handlePagination(Element rootElement, Element newElement) {
+		int entries =
+			GetterUtil.getInteger(rootElement.attributeValue("entries")) + 1;
+
+		int newElementSize = _getSize(newElement);
+
+		int size =
+			GetterUtil.getInteger(rootElement.attributeValue("size")) +
+				newElementSize;
+
+		if ((entries <= _maximumEntries) && (size < _MAXIMUM_SIZE)) {
+			rootElement.addAttribute("entries", String.valueOf(entries));
+			rootElement.addAttribute("size", String.valueOf(size));
+
+			return;
+		}
+
+		rootElement.remove(newElement);
+
+		String assetTypeKey = rootElement.attributeValue(
+			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY);
+
+		long companyId = GetterUtil.getLong(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_COMPANY_ID));
+		int currentPage = GetterUtil.getInteger(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE));
+		long groupId = GetterUtil.getLong(
+			rootElement.attributeValue(_ATTRIBUTE_PAGINATION_GROUP_ID));
+
+		_storeCurrentPage(
+			rootElement, companyId, groupId, assetTypeKey, currentPage);
+
+		rootElement.clearContent();
+
+		_initEntriesAndSize(rootElement);
+		_initPaginationAttributes(
+			rootElement, companyId, groupId, assetTypeKey);
+
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_PAGE, String.valueOf(currentPage + 1));
+
+		rootElement.add(newElement);
+
+		rootElement.addAttribute("entries", "1");
+		rootElement.addAttribute(
+			"size",
+			String.valueOf(
+				GetterUtil.getInteger(rootElement.attributeValue("size")) +
+					newElementSize));
+	}
+
 	private void _initEntriesAndSize(Element rootElement) {
 		rootElement.addAttribute("entries", "0");
 
 		int size = _getSize(rootElement);
 
 		rootElement.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _initPaginationAttributes(
+		Element rootElement, long companyId, long groupId,
+		String assetTypeKey) {
+
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY, assetTypeKey);
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_COMPANY_ID, String.valueOf(companyId));
+		rootElement.addAttribute(
+			_ATTRIBUTE_PAGINATION_GROUP_ID, String.valueOf(groupId));
+		rootElement.addAttribute(_ATTRIBUTE_PAGINATION_PAGE, "1");
 	}
 
 	private boolean _isCompanyVirtualHostname(ThemeDisplay themeDisplay) {
@@ -695,6 +816,59 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 
 		return Objects.equals(virtualHostname, themeDisplay.getServerName());
+	}
+
+	private void _regenerateAssetTypeSitemap(
+			String assetType, long groupId, boolean privateLayout,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		Document document = _createSitemapDocument(
+			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+		Element rootElement = document.getRootElement();
+
+		_initEntriesAndSize(rootElement);
+
+		String assetTypeKey = _assetTypeKeys.get(assetType);
+
+		long companyId = themeDisplay.getCompanyId();
+
+		try {
+			_sitemapStorageHelper.deleteSitemaps(
+				companyId, groupId, assetTypeKey);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		_initPaginationAttributes(
+			rootElement, companyId, groupId, assetTypeKey);
+
+		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
+			assetType);
+
+		for (LayoutSet curLayoutSet :
+				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
+
+			sitemapURLProvider.visitLayoutSet(
+				rootElement, curLayoutSet, themeDisplay);
+		}
+
+		_storeCurrentPage(
+			rootElement, companyId, groupId, assetTypeKey,
+			GetterUtil.getInteger(
+				rootElement.attributeValue(_ATTRIBUTE_PAGINATION_PAGE)));
+	}
+
+	private void _removeAttribute(Element rootElement, String name) {
+		Attribute attribute = rootElement.attribute(name);
+
+		if (attribute != null) {
+			rootElement.remove(attribute);
+		}
 	}
 
 	private void _removeEntriesAndSize(Element rootElement) {
@@ -729,13 +903,8 @@ public class SitemapManagerImpl implements SitemapManager {
 			_log.debug(sb.toString());
 		}
 
-		if (entriesAttribute != null) {
-			rootElement.remove(entriesAttribute);
-		}
-
-		if (sizeAttribute != null) {
-			rootElement.remove(sizeAttribute);
-		}
+		_removeAttribute(rootElement, "entries");
+		_removeAttribute(rootElement, "size");
 	}
 
 	private void _removeOldestElement(Element rootElement, Element newElement) {
@@ -746,7 +915,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		entries++;
 		size += _getSize(newElement);
 
-		while ((entries > MAXIMUM_ENTRIES) || (size >= _MAXIMUM_SIZE)) {
+		while ((entries > _maximumEntries) || (size >= _MAXIMUM_SIZE)) {
 			Element oldestUrlElement = rootElement.element(
 				newElement.getName());
 
@@ -758,6 +927,34 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		rootElement.addAttribute("entries", String.valueOf(entries));
 		rootElement.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _removePaginationAttributes(Element rootElement) {
+		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY);
+		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_COMPANY_ID);
+		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_GROUP_ID);
+		_removeAttribute(rootElement, _ATTRIBUTE_PAGINATION_PAGE);
+	}
+
+	private void _storeCurrentPage(
+		Element rootElement, long companyId, long groupId, String assetTypeKey,
+		int currentPage) {
+
+		_removeEntriesAndSize(rootElement);
+		_removePaginationAttributes(rootElement);
+
+		Document document = rootElement.getDocument();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				companyId, groupId, assetTypeKey, currentPage,
+				document.asXML());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
 	}
 
 	private void _visitLayoutSet(
@@ -805,9 +1002,9 @@ public class SitemapManagerImpl implements SitemapManager {
 
 				Element sitemapElement = element.addElement("sitemap");
 
-				Element locationElement = sitemapElement.addElement("loc");
+				Element locElement = sitemapElement.addElement("loc");
 
-				locationElement.addText(
+				locElement.addText(
 					StringBundler.concat(
 						portalURL, _portal.getPathContext(),
 						"/sitemap.xml?p_l_id=", layout.getPlid(),
@@ -852,6 +1049,17 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 	}
 
+	private static final String _ATTRIBUTE_PAGINATION_ASSET_TYPE_KEY =
+		"_paginationAssetTypeKey";
+
+	private static final String _ATTRIBUTE_PAGINATION_COMPANY_ID =
+		"_paginationCompanyId";
+
+	private static final String _ATTRIBUTE_PAGINATION_GROUP_ID =
+		"_paginationGroupId";
+
+	private static final String _ATTRIBUTE_PAGINATION_PAGE = "_paginationPage";
+
 	private static final byte[] _ATTRIBUTE_XHTML =
 		" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"".getBytes();
 
@@ -892,6 +1100,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	private int _maximumEntries;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
@@ -120,9 +120,9 @@ public class SitemapStrutsAction implements StrutsAction {
 			InputStream inputStream = _sitemapManager.getSitemapInputStream(
 				ParamUtil.getString(httpServletRequest, "assetTypeKey"),
 				ParamUtil.getString(httpServletRequest, "layoutUuid"),
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				themeDisplay,
-				ParamUtil.getInteger(httpServletRequest, "page", 1));
+				layoutSet.getGroupId(),
+				ParamUtil.getInteger(httpServletRequest, "page", 1),
+				layoutSet.isPrivateLayout(), themeDisplay);
 
 			if (inputStream == null) {
 				httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -57,6 +57,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -389,6 +390,94 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapByAssetTypePaginationAttributesAreAbsent()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			_sitemapManager.getSitemap(
+				_CLASS_NAME_JOURNAL_ARTICLE, null, _group.getGroupId(), false,
+				_themeDisplay);
+
+			String xml = StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					_WEB_CONTENT, 1));
+
+			Assert.assertFalse(xml.contains("_assetTypeKey"));
+			Assert.assertFalse(xml.contains("_companyId"));
+			Assert.assertFalse(xml.contains("_groupId"));
+			Assert.assertFalse(xml.contains("_currentPage"));
+			Assert.assertFalse(xml.contains("entries="));
+		}
+	}
+
+	@Test
+	public void testSitemapByAssetTypePaginationStoresMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				_sitemapManager.getSitemap(
+					_CLASS_NAME_JOURNAL_ARTICLE, null, _group.getGroupId(), 1,
+					false, _themeDisplay);
+
+				long companyId = TestPropsValues.getCompanyId();
+				long groupId = _group.getGroupId();
+
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 1));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 2));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 3));
+				Assert.assertFalse(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 4));
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
+		}
+	}
+
+	@Test
 	public void testSitemapByAssetTypeRespectsIncludeFlag() throws Exception {
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -661,8 +750,8 @@ public class SitemapManagerTest {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 					_group.getGroupId(),
-					_portal.getClassNameId(JournalArticle.class.getName()),
-					null, true, WorkflowConstants.STATUS_APPROVED);
+					_portal.getClassNameId(_CLASS_NAME_JOURNAL_ARTICLE), null,
+					true, WorkflowConstants.STATUS_APPROVED);
 
 			Layout layout = _layoutLocalService.getLayout(
 				layoutPageTemplateEntry.getPlid());
@@ -1251,6 +1340,93 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIndexByAssetTypePageParamWithMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				Document document = _saxReader.read(
+					_sitemapManager.getSitemap(
+						null, _group.getGroupId(), false, _themeDisplay));
+
+				Element rootElement = document.getRootElement();
+
+				List<String> locs = TransformUtil.transform(
+					rootElement.elements("sitemap"),
+					sitemapElement -> {
+						String loc = sitemapElement.elementText("loc");
+
+						return loc.contains(_WEB_CONTENT) ? loc : null;
+					});
+
+				Assert.assertEquals(locs.toString(), 3, locs.size());
+
+				for (int i = 0; i < locs.size(); i++) {
+					String loc = locs.get(i);
+
+					Assert.assertTrue(loc.contains("&page=" + (i + 1)));
+				}
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
+		}
+	}
+
+	@Test
+	public void testSitemapIndexByAssetTypePageParamWithSinglePage()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Document document = _saxReader.read(
+				_sitemapManager.getSitemap(
+					null, _group.getGroupId(), false, _themeDisplay));
+
+			Element rootElement = document.getRootElement();
+
+			for (Element sitemapElement : rootElement.elements("sitemap")) {
+				String loc = sitemapElement.elementText("loc");
+
+				Assert.assertFalse(loc.contains("&page="));
+			}
+		}
+	}
+
+	@Test
 	public void testSitemapIndexByAssetTypeRespectsPerTypeFlagsCompany()
 		throws Exception {
 
@@ -1341,6 +1517,29 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIndexByAssetTypeStoresInDLStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_sitemapManager.getSitemap(
+				null, _group.getGroupId(), false, _themeDisplay);
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
 	public void testSitemapURLsWithLayoutFriendlyURLPublicServletMappingDisabled()
 		throws Exception {
 
@@ -1371,7 +1570,7 @@ public class SitemapManagerTest {
 
 	private void _addAssetCategoryAssetDisplayPageEntry() throws Exception {
 		_addAssetDisplayPageEntry(
-			_portal.getClassNameId(AssetCategory.class.getName()), 0, null,
+			_portal.getClassNameId(_CLASS_NAME_ASSET_CATEGORY), 0, null,
 			AssetDisplayPageConstants.TYPE_DEFAULT);
 	}
 
@@ -1408,7 +1607,7 @@ public class SitemapManagerTest {
 		throws Exception {
 
 		return _addAssetDisplayPageEntry(
-			_portal.getClassNameId(JournalArticle.class.getName()),
+			_portal.getClassNameId(_CLASS_NAME_JOURNAL_ARTICLE),
 			journalArticle.getResourcePrimKey(),
 			journalArticle.getDDMStructureKey(),
 			AssetDisplayPageConstants.TYPE_SPECIFIC);
@@ -1517,7 +1716,7 @@ public class SitemapManagerTest {
 
 		InfoItemLanguagesProvider<Layout> infoItemLanguagesProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemLanguagesProvider.class, Layout.class.getName());
+				InfoItemLanguagesProvider.class, _CLASS_NAME_LAYOUT);
 
 		for (String availableLanguageId :
 				infoItemLanguagesProvider.getAvailableLanguageIds(layout)) {
@@ -1878,6 +2077,8 @@ public class SitemapManagerTest {
 
 	private static final String _PID_SITEMAP_GROUP_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapGroupConfiguration";
+
+	private static final String _WEB_CONTENT = "web-content";
 
 	private static CompanyConfigurationTemporarySwapper
 		_companyConfigurationTemporarySwapper;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90949

## What Is Being Fixed

Asset-type sitemaps (web content, layouts, commerce products and categories, object entries) were truncated to MAXIMUM_ENTRIES (50,000). Any URLs beyond that cap were silently dropped, so large sites published incomplete sitemaps. The sitemap protocol limits a single file to 50,000 URLs / 50MB, which the previous implementation handled by discarding the overflow rather than paginating it.

## How It Is Being Fixed

Asset-type sitemaps are now paginated instead of truncated. When a dataset exceeds the per-file limits, the manager splits it across multiple stored sitemap files and exposes each through the sitemap index with a page parameter. SitemapManager gains a paginated getSitemap overload, and getSitemapInputStream takes a page argument; the index emits one entry per page. The URL providers stream every entry through an ActionableDynamicQuery rather than capping the result set, and now filter entries by VIEW permission. The MAXIMUM_ENTRIES truncation was removed from the providers, getLastModifiedDate was renamed to getModifiedDate across the SitemapURLProvider contract and its implementations, and internal pagination bookkeeping attributes are stripped from the stored output. Integration tests cover multi-page storage, the page request parameter, single-page output, and the absence of internal attributes.

## PR Check

**pr-check: PASS** — tested on `a9a6421411cad0323a3825ba5b5dc18c403a6894`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "a9a6421411cad0323a3825ba5b5dc18c403a6894"} -->