### PR TITLE
LPD-91209 Add SEO Studio scan object fields and dispatch object actions

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-insight-type-names-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-insight-type-names-list-type-definition.json
@@ -1,0 +1,13 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_INSIGHT_TYPE_NAMES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "ORPHAN_PAGES",
+			"key": "orphanPages",
+			"name": "Orphan Pages",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Insight Type Names",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-categories-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-categories-list-type-definition.json
@@ -14,15 +14,15 @@
 			"system": true
 		},
 		{
-			"externalReferenceCode": "CRAWLABILITY",
-			"key": "crawlability",
-			"name": "Crawlability",
-			"system": true
-		},
-		{
 			"externalReferenceCode": "IMAGES",
 			"key": "images",
 			"name": "Images",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "LINKS_AND_URLS",
+			"key": "linksAndURLs",
+			"name": "Links and URLs",
 			"system": true
 		},
 		{
@@ -41,12 +41,6 @@
 			"externalReferenceCode": "STRUCTURED_DATA",
 			"key": "structuredData",
 			"name": "Structured Data",
-			"system": true
-		},
-		{
-			"externalReferenceCode": "URLS",
-			"key": "urls",
-			"name": "URLs",
 			"system": true
 		}
 	],

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/object-actions.json
@@ -2,6 +2,23 @@
 	"object-actions": [
 		{
 			"active": true,
+			"conditionExpression": "scanType == 'crawler'",
+			"errorMessage": {
+				"en_US": "Crawler scan failed. Please try again later or contact support."
+			},
+			"externalReferenceCode": "L_SEO_STUDIO_SCAN_CRAWLER",
+			"label": {
+				"en_US": "Crawler"
+			},
+			"name": "crawler",
+			"objectActionExecutorKey": "function#liferay-seostudio-etc-crawler-object-action-crawler",
+			"objectActionTriggerKey": "onAfterAdd",
+			"parameters": {
+			}
+		},
+		{
+			"active": true,
+			"conditionExpression": "scanType == 'pageSpeed'",
 			"errorMessage": {
 				"en_US": "PageSpeed scan failed. Please try again later or contact support."
 			},

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
@@ -11,6 +11,30 @@
 	},
 	"modifiable": true,
 	"name": "SEOStudioScan",
+	"objectActions": [
+		{
+			"active": true,
+			"description": "",
+			"errorMessage": {
+				"en_US": "Crawl failed. Please try again later or contact support."
+			},
+			"label": {
+				"en_US": "Trigger SEO Crawl"
+			},
+			"name": "triggerCrawlSource",
+			"objectActionExecutorKey": "function#liferay-seostudio-crawler-trigger",
+			"objectActionTriggerKey": "standalone",
+			"parameters": {
+				"objectDefinitionExternalReferenceCode": "SEO_CRAWL_SOURCE_TRIGGER"
+			},
+			"status": {
+				"code": 1,
+				"label": "success",
+				"label_i18n": "Success"
+			},
+			"system": false
+		}
+	],
 	"objectFields": [
 		{
 			"DBType": "Clob",
@@ -35,6 +59,19 @@
 			"name": "errorMessage",
 			"system": true,
 			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "EXECUTION_ID",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Execution ID"
+			},
+			"name": "executionId",
+			"system": true,
+			"type": "String"
 		},
 		{
 			"DBType": "String",

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
@@ -11,30 +11,6 @@
 	},
 	"modifiable": true,
 	"name": "SEOStudioScan",
-	"objectActions": [
-		{
-			"active": true,
-			"description": "",
-			"errorMessage": {
-				"en_US": "Crawl failed. Please try again later or contact support."
-			},
-			"label": {
-				"en_US": "Trigger SEO Crawl"
-			},
-			"name": "triggerCrawlSource",
-			"objectActionExecutorKey": "function#liferay-seostudio-crawler-trigger",
-			"objectActionTriggerKey": "standalone",
-			"parameters": {
-				"objectDefinitionExternalReferenceCode": "SEO_CRAWL_SOURCE_TRIGGER"
-			},
-			"status": {
-				"code": 1,
-				"label": "success",
-				"label_i18n": "Success"
-			},
-			"system": false
-		}
-	],
 	"objectFields": [
 		{
 			"DBType": "Clob",

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/05-seo-studio-insight-type-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/05-seo-studio-insight-type-object-definition.json
@@ -54,13 +54,14 @@
 		},
 		{
 			"DBType": "String",
-			"businessType": "Text",
+			"businessType": "Picklist",
 			"externalReferenceCode": "NAME",
 			"indexed": true,
 			"indexedAsKeyword": true,
 			"label": {
 				"en_US": "Name"
 			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_INSIGHT_TYPE_NAMES",
 			"name": "name",
 			"required": true,
 			"system": true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91209

The SEO Studio object/site-initializer changes for LPD-91209, split onto their own branch. No REST modules, Java, or tests — just the site-initializer object definitions, object actions, and list types.

This adds the scan crawl-settings `executionId` object field (the field the crawler CX records the dispatched Kubernetes Job name into and the scheduled poller reconciles against), the insight-type object fields and the SEO Studio Insight Type Names list, and the scan-insight-categories list. It also wires the Scan object actions to dispatch by `scanType` (`scanType == 'crawler'` / `scanType == 'pageSpeed'`), leaving the `name` field as free text.

**pr-check: PASS** — tested on `be0d587deee38412c09f8a76c531a912cefe80dd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "be0d587deee38412c09f8a76c531a912cefe80dd"} -->
