### PR TITLE
LPD-90949 Paginate asset-type sitemaps exceeding 50k URLs

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
@@ -61,7 +61,7 @@ public class AssetCategorySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		Company company = _companyLocalService.getCompany(companyId);

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
@@ -54,7 +54,7 @@ public class CPDefinitionSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		long commerceChannelGroupId =

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -24,10 +24,12 @@ import com.liferay.layout.page.template.util.LayoutPageTemplateEntryUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -37,6 +39,10 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -74,7 +80,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
 		List<Date> modifiedDates = _journalArticleLocalService.dslQuery(
@@ -127,15 +133,15 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		}
 
 		if (layout.isTypeAssetDisplay()) {
-			visitArticles(
-				element, layout, layoutSet, themeDisplay,
-				getDisplayPageTemplateArticles(layout), false);
+			_visitArticles(
+				element, false, _getDisplayPageTemplateArticles(layout), layout,
+				layoutSet, themeDisplay);
 		}
 		else {
-			visitArticles(
-				element, null, layoutSet, themeDisplay,
+			_visitArticles(
+				element, true,
 				_getDisplayPageArticles(layoutSet.getGroupId(), layoutUuid),
-				true);
+				null, layoutSet, themeDisplay);
 		}
 	}
 
@@ -144,26 +150,68 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			Element element, LayoutSet layoutSet, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		ActionableDynamicQuery actionableDynamicQuery =
+			_journalArticleLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("classNameId", 0L)));
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
+
+		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
+		Set<String> processedArticleIds = new HashSet<>();
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle journalArticle) -> _visitArticle(
+				element, true, journalArticle, null, layoutSet, portalURL,
+				processedArticleIds, siteAvailableLocales, themeDisplay));
+
+		actionableDynamicQuery.performActions();
+	}
+
+	private Set<Locale> _getAvailableLocales(
+		JournalArticle journalArticle, Set<Locale> siteAvailableLocales) {
+
+		Set<Locale> availableLocales = new HashSet<>();
+
+		if (SetUtil.isEmpty(siteAvailableLocales)) {
+			return availableLocales;
+		}
+
+		for (String availableLanguageId :
+				journalArticle.getAvailableLanguageIds()) {
+
+			Locale locale = LocaleUtil.fromLanguageId(availableLanguageId);
+
+			if (siteAvailableLocales.contains(locale)) {
+				availableLocales.add(locale);
+			}
+		}
+
+		return availableLocales;
+	}
+
+	private List<JournalArticle> _getDisplayPageArticles(
+		long groupId, String layoutUuid) {
+
 		int start = QueryUtil.ALL_POS;
 		int end = QueryUtil.ALL_POS;
 
-		int count = _journalArticleService.getLayoutArticlesCount(
-			layoutSet.getGroupId(), 0);
+		int count = _journalArticleService.getArticlesByLayoutUuidCount(
+			groupId, layoutUuid);
 
 		if (count > SitemapManager.MAXIMUM_ENTRIES) {
 			start = count - SitemapManager.MAXIMUM_ENTRIES;
 			end = count;
 		}
 
-		List<JournalArticle> journalArticles =
-			_journalArticleService.getLayoutArticles(
-				layoutSet.getGroupId(), 0, start, end);
-
-		visitArticles(
-			element, null, layoutSet, themeDisplay, journalArticles, true);
+		return _journalArticleService.getArticlesByLayoutUuid(
+			groupId, layoutUuid, start, end);
 	}
 
-	protected List<JournalArticle> getDisplayPageTemplateArticles(Layout layout)
+	private List<JournalArticle> _getDisplayPageTemplateArticles(Layout layout)
 		throws PortalException {
 
 		List<JournalArticle> journalArticles = new ArrayList<>();
@@ -175,14 +223,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		DynamicQuery assetDisplayPageEntryDynamicQuery =
 			_assetDisplayPageEntryLocalService.dynamicQuery();
 
-		long classNameId = _portal.getClassNameId(
-			JournalArticle.class.getName());
-
 		Property classNameIdProperty = PropertyFactoryUtil.forName(
 			"classNameId");
 
 		assetDisplayPageEntryDynamicQuery.add(
-			classNameIdProperty.eq(classNameId));
+			classNameIdProperty.eq(
+				_portal.getClassNameId(JournalArticle.class.getName())));
 
 		Property layoutPageTemplateEntryIdProperty =
 			PropertyFactoryUtil.forName("layoutPageTemplateEntryId");
@@ -253,7 +299,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		return journalArticles;
 	}
 
-	protected Layout getDisplayPageTemplateLayout(
+	private Layout _getDisplayPageTemplateLayout(
 		long groupId, long journalArticleResourcePrimKey,
 		DDMStructure ddmStructure) {
 
@@ -284,134 +330,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			return null;
 		}
 
-		long assetDisplayPageEntryPlid = assetDisplayPageEntry.getPlid();
-
-		return _layoutLocalService.fetchLayout(assetDisplayPageEntryPlid);
-	}
-
-	protected void visitArticles(
-			Element element, Layout layout, LayoutSet layoutSet,
-			ThemeDisplay themeDisplay, List<JournalArticle> journalArticles,
-			boolean headCheck)
-		throws PortalException {
-
-		if (journalArticles.isEmpty()) {
-			return;
-		}
-
-		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
-		Set<String> processedArticleIds = new HashSet<>();
-		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
-			themeDisplay.getScopeGroupId());
-
-		for (JournalArticle journalArticle : journalArticles) {
-			if (processedArticleIds.contains(journalArticle.getArticleId()) ||
-				(journalArticle.getStatus() !=
-					WorkflowConstants.STATUS_APPROVED) ||
-				(headCheck && !JournalUtil.isHead(journalArticle))) {
-
-				continue;
-			}
-
-			Layout articleLayout = layout;
-
-			if ((articleLayout == null) &&
-				Validator.isNotNull(journalArticle.getLayoutUuid())) {
-
-				articleLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-					journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout());
-			}
-			else if (articleLayout == null) {
-				articleLayout = getDisplayPageTemplateLayout(
-					layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
-					journalArticle.getDDMStructure());
-			}
-
-			if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
-					articleLayout)) {
-
-				continue;
-			}
-
-			String groupFriendlyURL = _portal.getGroupFriendlyURL(
-				_layoutSetLocalService.getLayoutSet(
-					journalArticle.getGroupId(), false),
-				themeDisplay, false, false);
-
-			StringBundler sb = new StringBundler(4);
-
-			if (!groupFriendlyURL.startsWith(portalURL)) {
-				sb.append(portalURL);
-			}
-
-			sb.append(groupFriendlyURL);
-
-			if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
-				sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
-			}
-			else {
-				sb.append(_getFriendlyURLSeparator());
-			}
-
-			sb.append(journalArticle.getUrlTitle());
-
-			String articleURL = _portal.getCanonicalURL(
-				sb.toString(), themeDisplay, articleLayout);
-
-			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-				articleURL, themeDisplay, articleLayout,
-				_getAvailableLocales(journalArticle, siteAvailableLocales));
-
-			for (String alternateURL : alternateURLs.values()) {
-				_sitemapManager.addURLElement(
-					element, alternateURL, null,
-					journalArticle.getModifiedDate(), articleURL, alternateURLs,
-					articleLayout.getGroupId());
-			}
-
-			processedArticleIds.add(journalArticle.getArticleId());
-		}
-	}
-
-	private Set<Locale> _getAvailableLocales(
-		JournalArticle journalArticle, Set<Locale> siteAvailableLocales) {
-
-		Set<Locale> availableLocales = new HashSet<>();
-
-		if (SetUtil.isEmpty(siteAvailableLocales)) {
-			return availableLocales;
-		}
-
-		for (String availableLanguageId :
-				journalArticle.getAvailableLanguageIds()) {
-
-			Locale locale = LocaleUtil.fromLanguageId(availableLanguageId);
-
-			if (siteAvailableLocales.contains(locale)) {
-				availableLocales.add(locale);
-			}
-		}
-
-		return availableLocales;
-	}
-
-	private List<JournalArticle> _getDisplayPageArticles(
-		long groupId, String layoutUuid) {
-
-		int start = QueryUtil.ALL_POS;
-		int end = QueryUtil.ALL_POS;
-
-		int count = _journalArticleService.getArticlesByLayoutUuidCount(
-			groupId, layoutUuid);
-
-		if (count > SitemapManager.MAXIMUM_ENTRIES) {
-			start = count - SitemapManager.MAXIMUM_ENTRIES;
-			end = count;
-		}
-
-		return _journalArticleService.getArticlesByLayoutUuid(
-			groupId, layoutUuid, start, end);
+		return _layoutLocalService.fetchLayout(assetDisplayPageEntry.getPlid());
 	}
 
 	private String _getFriendlyURLSeparator() {
@@ -427,6 +346,113 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
 	}
 
+	private void _visitArticle(
+			Element element, boolean headCheck, JournalArticle journalArticle,
+			Layout layout, LayoutSet layoutSet, String portalURL,
+			Set<String> processedArticleIds, Set<Locale> siteAvailableLocales,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (processedArticleIds.contains(journalArticle.getArticleId()) ||
+			(journalArticle.getStatus() != WorkflowConstants.STATUS_APPROVED) ||
+			(headCheck && !JournalUtil.isHead(journalArticle))) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_journalArticleModelResourcePermission.contains(
+				permissionChecker, journalArticle, ActionKeys.VIEW)) {
+
+			return;
+		}
+
+		Layout journalArticleLayout = layout;
+
+		if ((journalArticleLayout == null) &&
+			Validator.isNotNull(journalArticle.getLayoutUuid())) {
+
+			journalArticleLayout =
+				_layoutLocalService.fetchLayoutByUuidAndGroupId(
+					journalArticle.getLayoutUuid(), layoutSet.getGroupId(),
+					layoutSet.isPrivateLayout());
+		}
+		else if (journalArticleLayout == null) {
+			journalArticleLayout = _getDisplayPageTemplateLayout(
+				layoutSet.getGroupId(), journalArticle.getResourcePrimKey(),
+				journalArticle.getDDMStructure());
+		}
+
+		if (_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(
+				journalArticleLayout)) {
+
+			return;
+		}
+
+		String groupFriendlyURL = _portal.getGroupFriendlyURL(
+			_layoutSetLocalService.getLayoutSet(
+				journalArticle.getGroupId(), false),
+			themeDisplay, false, false);
+
+		StringBundler sb = new StringBundler(4);
+
+		if (!groupFriendlyURL.startsWith(portalURL)) {
+			sb.append(portalURL);
+		}
+
+		sb.append(groupFriendlyURL);
+
+		if (Validator.isNotNull(journalArticle.getLayoutUuid())) {
+			sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
+		}
+		else {
+			sb.append(_getFriendlyURLSeparator());
+		}
+
+		sb.append(journalArticle.getUrlTitle());
+
+		String canonicalURL = _portal.getCanonicalURL(
+			sb.toString(), themeDisplay, journalArticleLayout);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			canonicalURL, themeDisplay, journalArticleLayout,
+			_getAvailableLocales(journalArticle, siteAvailableLocales));
+
+		for (String alternateURL : alternateURLs.values()) {
+			_sitemapManager.addURLElement(
+				element, alternateURL, null, journalArticle.getModifiedDate(),
+				canonicalURL, alternateURLs, journalArticleLayout.getGroupId());
+		}
+
+		processedArticleIds.add(journalArticle.getArticleId());
+	}
+
+	private void _visitArticles(
+			Element element, boolean headCheck,
+			List<JournalArticle> journalArticles, Layout layout,
+			LayoutSet layoutSet, ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (journalArticles.isEmpty()) {
+			return;
+		}
+
+		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
+		Set<String> processedArticleIds = new HashSet<>();
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
+
+		for (JournalArticle journalArticle : journalArticles) {
+			_visitArticle(
+				element, headCheck, journalArticle, layout, layoutSet,
+				portalURL, processedArticleIds, siteAvailableLocales,
+				themeDisplay);
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleSitemapURLProvider.class);
 
@@ -436,6 +462,12 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.journal.model.JournalArticle)"
+	)
+	private ModelResourcePermission<JournalArticle>
+		_journalArticleModelResourcePermission;
 
 	@Reference
 	private JournalArticleResourceLocalService

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -6,16 +6,22 @@
 package com.liferay.layout.internal.site.provider;
 
 import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -29,7 +35,6 @@ import com.liferay.site.provider.SitemapURLProvider;
 import com.liferay.site.provider.helper.SitemapURLProviderHelper;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -52,25 +57,13 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
-		List<String> sitemapableLayoutTypes = new ArrayList<>();
+		List<String> layoutTypes = _getLayoutTypes(
+			LayoutTypeControllerTracker.getLayoutTypeControllers());
 
-		Map<String, LayoutTypeController> layoutTypeControllers =
-			LayoutTypeControllerTracker.getLayoutTypeControllers();
-
-		for (Map.Entry<String, LayoutTypeController> entry :
-				layoutTypeControllers.entrySet()) {
-
-			LayoutTypeController layoutTypeController = entry.getValue();
-
-			if (layoutTypeController.isSitemapable()) {
-				sitemapableLayoutTypes.add(entry.getKey());
-			}
-		}
-
-		if (sitemapableLayoutTypes.isEmpty()) {
+		if (layoutTypes.isEmpty()) {
 			return null;
 		}
 
@@ -86,7 +79,7 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 					LayoutTable.INSTANCE.privateLayout.eq(false)
 				).and(
 					LayoutTable.INSTANCE.type.in(
-						sitemapableLayoutTypes.toArray(new String[0]))
+						layoutTypes.toArray(new String[0]))
 				).and(
 					LayoutTable.INSTANCE.modifiedDate.isNotNull()
 				)
@@ -120,7 +113,7 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			layoutUuid, layoutSet.getGroupId(), layoutSet.isPrivateLayout());
 
-		visitLayout(element, layout, themeDisplay);
+		_visitLayout(element, layout, themeDisplay);
 	}
 
 	@Override
@@ -132,69 +125,34 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 			return;
 		}
 
-		Map<String, LayoutTypeController> layoutTypeControllers =
-			LayoutTypeControllerTracker.getLayoutTypeControllers();
+		List<String> layoutTypes = _getLayoutTypes(
+			LayoutTypeControllerTracker.getLayoutTypeControllers());
 
-		for (Map.Entry<String, LayoutTypeController> entry :
-				layoutTypeControllers.entrySet()) {
-
-			LayoutTypeController layoutTypeController = entry.getValue();
-
-			if (!layoutTypeController.isSitemapable()) {
-				continue;
-			}
-
-			int start = QueryUtil.ALL_POS;
-			int end = QueryUtil.ALL_POS;
-
-			int count = _layoutService.getLayoutsCount(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey());
-
-			if (count > SitemapManager.MAXIMUM_ENTRIES) {
-				start = count - SitemapManager.MAXIMUM_ENTRIES;
-				end = count;
-			}
-
-			List<Layout> layouts = _layoutService.getLayouts(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				entry.getKey(), start, end);
-
-			for (Layout layout : layouts) {
-				visitLayout(element, layout, themeDisplay);
-			}
-		}
-	}
-
-	protected void visitLayout(
-			Element element, Layout layout, ThemeDisplay themeDisplay)
-		throws PortalException {
-
-		if (layout.isSystem() ||
-			_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(layout)) {
-
+		if (layoutTypes.isEmpty()) {
 			return;
 		}
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			layout.getTypeSettingsProperties();
+		ActionableDynamicQuery actionableDynamicQuery =
+			_layoutLocalService.getActionableDynamicQuery();
 
-		String layoutFullURL = _portal.getCanonicalURL(
-			_portal.getLayoutFullURL(layout, themeDisplay), themeDisplay,
-			layout);
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property privateLayoutProperty = PropertyFactoryUtil.forName(
+					"privateLayout");
 
-		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-			layoutFullURL, themeDisplay, layout,
-			_getAvailableLocales(
-				layout,
-				_language.getAvailableLocales(themeDisplay.getScopeGroupId())));
+				dynamicQuery.add(
+					privateLayoutProperty.eq(layoutSet.isPrivateLayout()));
 
-		for (String alternateURL : alternateURLs.values()) {
-			_sitemapManager.addURLElement(
-				element, alternateURL, typeSettingsUnicodeProperties,
-				layout.getModifiedDate(), layoutFullURL, alternateURLs,
-				layout.getGroupId());
-		}
+				Property typeProperty = PropertyFactoryUtil.forName("type");
+
+				dynamicQuery.add(
+					typeProperty.in(layoutTypes.toArray(new String[0])));
+			});
+		actionableDynamicQuery.setGroupId(layoutSet.getGroupId());
+		actionableDynamicQuery.setPerformActionMethod(
+			(Layout layout) -> _visitLayout(element, layout, themeDisplay));
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private Set<Locale> _getAvailableLocales(
@@ -225,6 +183,63 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		return availableLocales;
 	}
 
+	private List<String> _getLayoutTypes(
+		Map<String, LayoutTypeController> layoutTypeControllers) {
+
+		return TransformUtil.transform(
+			layoutTypeControllers.entrySet(),
+			entry -> {
+				LayoutTypeController layoutTypeController = entry.getValue();
+
+				if (layoutTypeController.isSitemapable()) {
+					return entry.getKey();
+				}
+
+				return null;
+			});
+	}
+
+	private void _visitLayout(
+			Element element, Layout layout, ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (layout.isSystem() ||
+			_sitemapURLProviderHelper.isExcludeLayoutFromSitemap(layout)) {
+
+			return;
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((permissionChecker != null) &&
+			!_layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW)) {
+
+			return;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			layout.getTypeSettingsProperties();
+
+		String layoutFullURL = _portal.getCanonicalURL(
+			_portal.getLayoutFullURL(layout, themeDisplay), themeDisplay,
+			layout);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			layoutFullURL, themeDisplay, layout,
+			_getAvailableLocales(
+				layout,
+				_language.getAvailableLocales(themeDisplay.getScopeGroupId())));
+
+		for (String alternateURL : alternateURLs.values()) {
+			_sitemapManager.addURLElement(
+				element, alternateURL, typeSettingsUnicodeProperties,
+				layout.getModifiedDate(), layoutFullURL, alternateURLs,
+				layout.getGroupId());
+		}
+	}
+
 	@Reference
 	private InfoItemServiceRegistry _infoItemServiceRegistry;
 
@@ -234,8 +249,10 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	@Reference
 	private LayoutLocalService _layoutLocalService;
 
-	@Reference
-	private LayoutService _layoutService;
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -62,10 +62,10 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	@Override
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException {
 
-		Date lastModifiedDate = null;
+		Date modifiedDate = null;
 
 		List<Long> companyObjectDefinitionIds = new ArrayList<>();
 		List<Long> siteObjectDefinitionIds = new ArrayList<>();
@@ -97,7 +97,7 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		}
 
 		if (!siteObjectDefinitionIds.isEmpty()) {
-			lastModifiedDate = _getLatestModifiedDate(
+			modifiedDate = _getLatestModifiedDate(
 				groupId, siteObjectDefinitionIds.toArray(new Long[0]));
 		}
 
@@ -107,14 +107,13 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 				companyObjectDefinitionIds.toArray(new Long[0]));
 
 			if ((companyDate != null) &&
-				((lastModifiedDate == null) ||
-				 companyDate.after(lastModifiedDate))) {
+				((modifiedDate == null) || companyDate.after(modifiedDate))) {
 
-				lastModifiedDate = companyDate;
+				modifiedDate = companyDate;
 			}
 		}
 
-		return lastModifiedDate;
+		return modifiedDate;
 	}
 
 	@Override

--- a/modules/apps/site/site-api/bnd.bnd
+++ b/modules/apps/site/site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site API
 Bundle-SymbolicName: com.liferay.site.api
-Bundle-Version: 28.1.1
+Bundle-Version: 29.0.0
 Export-Package:\
 	com.liferay.site.configuration,\
 	com.liferay.site.configuration.manager,\

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -48,12 +48,22 @@ public interface SitemapManager {
 			String canonicalURL, ThemeDisplay themeDisplay, Layout layout)
 		throws PortalException;
 
-	public String getAssetTypeClassName(String assetTypeKey);
+	public long getAssetTypeClassNameId(String assetTypeKey);
 
-	public Map<String, String> getAssetTypeKeys();
+	public Map<Long, String> getAssetTypeKeys();
 
 	public String getSitemap(
 			long groupId, boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
+	public String getSitemap(
+			long assetTypeClassNameId, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
+	public String getSitemap(
+			long assetTypeClassNameId, String layoutUuid, long groupId,
+			int page, boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	public String getSitemap(
@@ -61,14 +71,9 @@ public interface SitemapManager {
 			ThemeDisplay themeDisplay)
 		throws PortalException;
 
-	public String getSitemap(
-			String assetType, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay)
-		throws PortalException;
-
 	public InputStream getSitemapInputStream(
-			String assetTypeKey, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+			String assetTypeKey, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 }

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/SitemapURLProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/provider/SitemapURLProvider.java
@@ -22,7 +22,7 @@ public interface SitemapURLProvider {
 
 	public String getClassName();
 
-	public Date getLastModifiedDate(long companyId, long groupId)
+	public Date getModifiedDate(long companyId, long groupId)
 		throws PortalException;
 
 	public default boolean isInclude(long companyId, long groupId)

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/manager/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/manager/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/provider/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
@@ -63,12 +64,12 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -96,7 +97,7 @@ public class SitemapManagerImpl implements SitemapManager {
 			path = path.substring(contextPath.length());
 		}
 
-		String friendlyURL = _getFriendlyURL(path, groupId);
+		String friendlyURL = _getFriendlyURL(groupId, path);
 
 		if (friendlyURL.startsWith(StringPool.SLASH)) {
 			friendlyURL = friendlyURL.substring(1);
@@ -122,11 +123,11 @@ public class SitemapManagerImpl implements SitemapManager {
 		locElement.addText(encodeXML(url));
 
 		if (modifiedDate != null) {
-			Element modifiedDateElement = urlElement.addElement("lastmod");
-
 			DateFormat iso8601DateFormat = DateUtil.getISO8601Format();
 
-			modifiedDateElement.addText(iso8601DateFormat.format(modifiedDate));
+			Element lastmodElement = urlElement.addElement("lastmod");
+
+			lastmodElement.addText(iso8601DateFormat.format(modifiedDate));
 		}
 
 		if (typeSettingsUnicodeProperties == null) {
@@ -201,12 +202,18 @@ public class SitemapManagerImpl implements SitemapManager {
 			Element alternateURLElement = urlElement.addElement(
 				"xhtml:link", "http://www.w3.org/1999/xhtml");
 
-			alternateURLElement.addAttribute("rel", "alternate");
-			alternateURLElement.addAttribute("hreflang", "x-default");
 			alternateURLElement.addAttribute("href", canonicalURL);
+			alternateURLElement.addAttribute("hreflang", "x-default");
+			alternateURLElement.addAttribute("rel", "alternate");
 		}
 
-		_removeOldestElement(element, urlElement);
+		if (element.attributeValue(_ATTRIBUTE_NAME_PAGE) == null) {
+			_removeOldestElement(element, urlElement);
+
+			return;
+		}
+
+		_addEntryAndPaginate(element, urlElement);
 	}
 
 	@Override
@@ -225,12 +232,12 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	@Override
-	public String getAssetTypeClassName(String assetTypeKey) {
-		return _assetTypeClassNames.get(assetTypeKey);
+	public long getAssetTypeClassNameId(String assetTypeKey) {
+		return GetterUtil.getLong(_assetTypeClassNameIds.get(assetTypeKey));
 	}
 
 	@Override
-	public Map<String, String> getAssetTypeKeys() {
+	public Map<Long, String> getAssetTypeKeys() {
 		return _assetTypeKeys;
 	}
 
@@ -244,25 +251,26 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Override
 	public String getSitemap(
-			String layoutUuid, long groupId, boolean privateLayout,
-			ThemeDisplay themeDisplay)
+			long assetTypeClassNameId, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		return getSitemap(
-			null, layoutUuid, groupId, privateLayout, themeDisplay);
+			assetTypeClassNameId, layoutUuid, groupId, 1, privateLayout,
+			themeDisplay);
 	}
 
 	@Override
 	public String getSitemap(
-			String assetType, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay)
+			long assetTypeClassNameId, String layoutUuid, long groupId,
+			int page, boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		if (Validator.isNotNull(assetType)) {
+		if (assetTypeClassNameId > 0) {
 			long companyId = themeDisplay.getCompanyId();
 
 			SitemapURLProvider sitemapURLProvider =
-				_serviceTrackerMap.getService(assetType);
+				_serviceTrackerMap.getService(assetTypeClassNameId);
 
 			if ((sitemapURLProvider == null) ||
 				!_sitemapConfigurationManager.xmlSitemapIndexCompanyEnabled(
@@ -276,7 +284,8 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 
 			return _getAssetTypeSitemap(
-				groupId, privateLayout, themeDisplay, assetType);
+				assetTypeClassNameId, groupId, page, privateLayout,
+				themeDisplay);
 		}
 
 		if (Validator.isNull(layoutUuid) &&
@@ -286,13 +295,22 @@ public class SitemapManagerImpl implements SitemapManager {
 			return _getIndexSitemap(groupId, privateLayout, themeDisplay);
 		}
 
-		return _getSitemap(layoutUuid, groupId, privateLayout, themeDisplay);
+		return _getSitemap(groupId, layoutUuid, privateLayout, themeDisplay);
+	}
+
+	@Override
+	public String getSitemap(
+			String layoutUuid, long groupId, boolean privateLayout,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		return getSitemap(0, layoutUuid, groupId, privateLayout, themeDisplay);
 	}
 
 	@Override
 	public InputStream getSitemapInputStream(
-			String assetTypeKey, String layoutUuid, long groupId,
-			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+			String assetTypeKey, String layoutUuid, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		long companyId = themeDisplay.getCompanyId();
@@ -320,7 +338,7 @@ public class SitemapManagerImpl implements SitemapManager {
 		}
 
 		String xml = getSitemap(
-			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			getAssetTypeClassNameId(assetTypeKey), layoutUuid, groupId, page,
 			privateLayout, themeDisplay);
 
 		if (xml == null) {
@@ -332,19 +350,123 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_maximumEntries = MAXIMUM_ENTRIES;
+
+		Map<String, Long> assetTypeClassNameIds = new HashMap<>();
+		Map<Long, String> assetTypeKeys = new HashMap<>();
+
+		for (Map.Entry<String, String> entry :
+				_assetTypeKeysByClassName.entrySet()) {
+
+			long classNameId = _classNameLocalService.getClassNameId(
+				entry.getKey());
+
+			assetTypeClassNameIds.put(entry.getValue(), classNameId);
+			assetTypeKeys.put(classNameId, entry.getValue());
+		}
+
+		_assetTypeClassNameIds = Collections.unmodifiableMap(
+			assetTypeClassNameIds);
+		_assetTypeKeys = Collections.unmodifiableMap(assetTypeKeys);
+
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			_bundleContext, SitemapURLProvider.class, null,
 			(serviceReference, emitter) -> {
 				SitemapURLProvider sitemapURLProvider =
 					_bundleContext.getService(serviceReference);
 
-				emitter.emit(sitemapURLProvider.getClassName());
+				emitter.emit(
+					_classNameLocalService.getClassNameId(
+						sitemapURLProvider.getClassName()));
 			});
 	}
 
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private void _addEntryAndPaginate(Element element, Element newElement) {
+		int entries =
+			GetterUtil.getInteger(element.attributeValue("entries")) + 1;
+
+		int newElementSize = _getSize(newElement);
+
+		int size =
+			GetterUtil.getInteger(element.attributeValue("size")) +
+				newElementSize;
+
+		if ((entries <= _maximumEntries) && (size < _MAXIMUM_SIZE)) {
+			element.addAttribute("entries", String.valueOf(entries));
+			element.addAttribute("size", String.valueOf(size));
+
+			return;
+		}
+
+		element.remove(newElement);
+
+		String assetTypeKey = element.attributeValue(
+			_ATTRIBUTE_NAME_ASSET_TYPE_KEY);
+
+		long companyId = GetterUtil.getLong(
+			element.attributeValue(_ATTRIBUTE_NAME_COMPANY_ID));
+		long groupId = GetterUtil.getLong(
+			element.attributeValue(_ATTRIBUTE_NAME_GROUP_ID));
+		int page = GetterUtil.getInteger(
+			element.attributeValue(_ATTRIBUTE_NAME_PAGE));
+
+		_storePage(assetTypeKey, companyId, element, groupId, page);
+
+		element.clearContent();
+
+		_initEntriesAndSize(element);
+		_initPagination(assetTypeKey, companyId, element, groupId);
+
+		element.addAttribute(_ATTRIBUTE_NAME_PAGE, String.valueOf(page + 1));
+
+		element.add(newElement);
+
+		element.addAttribute("entries", "1");
+		element.addAttribute(
+			"size",
+			String.valueOf(
+				GetterUtil.getInteger(element.attributeValue("size")) +
+					newElementSize));
+	}
+
+	private void _addSitemapElement(
+		String assetTypeKey, Element element, long groupId, Date modifiedDate,
+		int page, boolean privateLayout, String url) {
+
+		Element sitemapElement = element.addElement("sitemap");
+
+		Element locElement = sitemapElement.addElement("loc");
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(url);
+		sb.append(_portal.getPathContext());
+		sb.append("/sitemap-");
+		sb.append(assetTypeKey);
+		sb.append(".xml?groupId=");
+		sb.append(groupId);
+		sb.append("&privateLayout=");
+		sb.append(privateLayout);
+
+		if (page > 0) {
+			sb.append("&page=");
+			sb.append(page);
+		}
+
+		locElement.addText(sb.toString());
+
+		if (modifiedDate != null) {
+			DateFormat iso8601DateFormat = DateUtil.getISO8601Format();
+
+			Element lastmodElement = sitemapElement.addElement("lastmod");
+
+			lastmodElement.addText(iso8601DateFormat.format(modifiedDate));
+		}
 	}
 
 	private Document _createSitemapDocument(
@@ -368,50 +490,50 @@ public class SitemapManagerImpl implements SitemapManager {
 		return document;
 	}
 
-	private Date _getAssetTypeGroupLastModifiedDate(
-			String className, long companyId, long groupId)
+	private Date _getAssetTypeModifiedDate(
+			long classNameId, long companyId, long groupId)
 		throws PortalException {
 
 		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
-			className);
+			classNameId);
 
 		if (sitemapURLProvider == null) {
 			return null;
 		}
 
-		return sitemapURLProvider.getLastModifiedDate(companyId, groupId);
+		return sitemapURLProvider.getModifiedDate(companyId, groupId);
+	}
+
+	private int _getAssetTypePageCount(
+			String assetTypeKey, long companyId, long groupId)
+		throws PortalException {
+
+		int pageCount = 1;
+
+		while (_sitemapStorageHelper.hasSitemapFile(
+					companyId, groupId, assetTypeKey, pageCount + 1)) {
+
+			pageCount++;
+		}
+
+		return pageCount;
 	}
 
 	private String _getAssetTypeSitemap(
-			long groupId, boolean privateLayout, ThemeDisplay themeDisplay,
-			String assetType)
+			long assetTypeClassNameId, long groupId, int page,
+			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		Document document = _createSitemapDocument(
-			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+		_regenerateAssetTypeSitemap(
+			assetTypeClassNameId, groupId, privateLayout, themeDisplay);
 
-		Element rootElement = document.getRootElement();
-
-		_initEntriesAndSize(rootElement);
-
-		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
-			assetType);
-
-		for (LayoutSet curLayoutSet :
-				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
-
-			sitemapURLProvider.visitLayoutSet(
-				rootElement, curLayoutSet, themeDisplay);
-		}
-
-		_removeEntriesAndSize(rootElement);
-
-		String xml = document.asXML();
+		String assetTypeKey = _assetTypeKeys.get(assetTypeClassNameId);
+		long companyId = themeDisplay.getCompanyId();
 
 		try {
-			_sitemapStorageHelper.storeSitemapFile(
-				themeDisplay.getCompanyId(), groupId,
-				_assetTypeKeys.get(assetType), 1, xml);
+			return StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page));
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -419,10 +541,10 @@ public class SitemapManagerImpl implements SitemapManager {
 			}
 		}
 
-		return xml;
+		return null;
 	}
 
-	private String _getFriendlyURL(String path, long groupId) {
+	private String _getFriendlyURL(long groupId, String path) {
 		int[] groupFriendlyURLIndex = _portal.getGroupFriendlyURLIndex(path);
 
 		if (groupFriendlyURLIndex != null) {
@@ -489,49 +611,56 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		long companyId = themeDisplay.getCompanyId();
+
 		String xmlSitemapIndexMode =
-			_sitemapConfigurationManager.xmlSitemapIndexMode(
-				themeDisplay.getCompanyId());
+			_sitemapConfigurationManager.xmlSitemapIndexMode(companyId);
 
 		if (StringUtil.equals(
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			String portalURL = themeDisplay.getPortalURL();
 
-			for (Map.Entry<String, String> entry : _assetTypeKeys.entrySet()) {
-				String className = entry.getKey();
+			for (Map.Entry<Long, String> entry : _assetTypeKeys.entrySet()) {
+				long assetTypeClassNameId = entry.getKey();
 
 				SitemapURLProvider sitemapURLProvider =
-					_serviceTrackerMap.getService(className);
+					_serviceTrackerMap.getService(assetTypeClassNameId);
 
 				if ((sitemapURLProvider == null) ||
-					!sitemapURLProvider.isInclude(
-						themeDisplay.getCompanyId(), groupId)) {
+					!sitemapURLProvider.isInclude(companyId, groupId)) {
 
 					continue;
 				}
 
-				Element sitemapElement = rootElement.addElement("sitemap");
+				String assetTypeKey = entry.getValue();
 
-				Element locationElement = sitemapElement.addElement("loc");
+				if (!_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, assetTypeKey, 1)) {
 
-				locationElement.addText(
-					StringBundler.concat(
-						portalURL, _portal.getPathContext(), "/sitemap-",
-						entry.getValue(), ".xml?groupId=", groupId,
-						"&privateLayout=", privateLayout));
+					_regenerateAssetTypeSitemap(
+						assetTypeClassNameId, groupId, privateLayout,
+						themeDisplay);
+				}
 
-				Date lastModifiedDate = _getAssetTypeGroupLastModifiedDate(
-					className, themeDisplay.getCompanyId(), groupId);
+				Date assetTypeModifiedDate = _getAssetTypeModifiedDate(
+					assetTypeClassNameId, companyId, groupId);
 
-				if (lastModifiedDate != null) {
-					Element lastModifiedElement = sitemapElement.addElement(
-						"lastmod");
+				int assetTypePageCount = _getAssetTypePageCount(
+					assetTypeKey, companyId, groupId);
 
-					DateFormat w3cDateFormat = DateUtil.getISO8601Format();
-
-					lastModifiedElement.addText(
-						w3cDateFormat.format(lastModifiedDate));
+				if (assetTypePageCount <= 1) {
+					_addSitemapElement(
+						assetTypeKey, rootElement, groupId,
+						assetTypeModifiedDate, 0, privateLayout, portalURL);
+				}
+				else {
+					for (int page = 1; page <= assetTypePageCount; page++) {
+						_addSitemapElement(
+							assetTypeKey, rootElement, groupId,
+							assetTypeModifiedDate, page, privateLayout,
+							portalURL);
+					}
 				}
 			}
 		}
@@ -552,8 +681,7 @@ public class SitemapManagerImpl implements SitemapManager {
 				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			try {
-				_sitemapStorageHelper.storeSitemapFile(
-					themeDisplay.getCompanyId(), groupId, xml);
+				_sitemapStorageHelper.storeSitemapFile(companyId, groupId, xml);
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
@@ -629,7 +757,7 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	private String _getSitemap(
-			String layoutUuid, long groupId, boolean privateLayout,
+			long groupId, String layoutUuid, boolean privateLayout,
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
@@ -641,8 +769,9 @@ public class SitemapManagerImpl implements SitemapManager {
 		_initEntriesAndSize(rootElement);
 
 		_visitLayoutSets(
+			rootElement,
 			_getLayoutSets(groupId, layoutUuid, privateLayout, themeDisplay),
-			layoutUuid, rootElement, themeDisplay);
+			layoutUuid, themeDisplay);
 
 		_removeEntriesAndSize(rootElement);
 
@@ -652,7 +781,7 @@ public class SitemapManagerImpl implements SitemapManager {
 	private List<SitemapURLProvider> _getSitemapURLProviders() {
 		return TransformUtil.transform(
 			_serviceTrackerMap.keySet(),
-			className -> _serviceTrackerMap.getService(className));
+			classNameId -> _serviceTrackerMap.getService(classNameId));
 	}
 
 	private int _getSize(Element element) {
@@ -677,12 +806,22 @@ public class SitemapManagerImpl implements SitemapManager {
 		return bytes.length - offset;
 	}
 
-	private void _initEntriesAndSize(Element rootElement) {
-		rootElement.addAttribute("entries", "0");
+	private void _initEntriesAndSize(Element element) {
+		element.addAttribute("entries", "0");
 
-		int size = _getSize(rootElement);
+		int size = _getSize(element);
 
-		rootElement.addAttribute("size", String.valueOf(size));
+		element.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _initPagination(
+		String assetTypeKey, long companyId, Element element, long groupId) {
+
+		element.addAttribute(_ATTRIBUTE_NAME_ASSET_TYPE_KEY, assetTypeKey);
+		element.addAttribute(
+			_ATTRIBUTE_NAME_COMPANY_ID, String.valueOf(companyId));
+		element.addAttribute(_ATTRIBUTE_NAME_GROUP_ID, String.valueOf(groupId));
+		element.addAttribute(_ATTRIBUTE_NAME_PAGE, "1");
 	}
 
 	private boolean _isCompanyVirtualHostname(ThemeDisplay themeDisplay) {
@@ -697,9 +836,61 @@ public class SitemapManagerImpl implements SitemapManager {
 		return Objects.equals(virtualHostname, themeDisplay.getServerName());
 	}
 
-	private void _removeEntriesAndSize(Element rootElement) {
-		Attribute entriesAttribute = rootElement.attribute("entries");
-		Attribute sizeAttribute = rootElement.attribute("size");
+	private void _regenerateAssetTypeSitemap(
+			long assetTypeClassNameId, long groupId, boolean privateLayout,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		Document document = _createSitemapDocument(
+			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+		Element rootElement = document.getRootElement();
+
+		_initEntriesAndSize(rootElement);
+
+		String assetTypeKey = _assetTypeKeys.get(assetTypeClassNameId);
+
+		long companyId = themeDisplay.getCompanyId();
+
+		try {
+			_sitemapStorageHelper.deleteSitemaps(
+				companyId, groupId, assetTypeKey);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		_initPagination(assetTypeKey, companyId, rootElement, groupId);
+
+		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
+			assetTypeClassNameId);
+
+		for (LayoutSet curLayoutSet :
+				_getLayoutSets(groupId, null, privateLayout, themeDisplay)) {
+
+			sitemapURLProvider.visitLayoutSet(
+				rootElement, curLayoutSet, themeDisplay);
+		}
+
+		_storePage(
+			assetTypeKey, companyId, rootElement, groupId,
+			GetterUtil.getInteger(
+				rootElement.attributeValue(_ATTRIBUTE_NAME_PAGE)));
+	}
+
+	private void _removeAttribute(Element element, String name) {
+		Attribute attribute = element.attribute(name);
+
+		if (attribute != null) {
+			element.remove(attribute);
+		}
+	}
+
+	private void _removeEntriesAndSize(Element element) {
+		Attribute entriesAttribute = element.attribute("entries");
+		Attribute sizeAttribute = element.attribute("size");
 
 		if (_log.isDebugEnabled()) {
 			StringBundler sb = new StringBundler(4);
@@ -729,35 +920,55 @@ public class SitemapManagerImpl implements SitemapManager {
 			_log.debug(sb.toString());
 		}
 
-		if (entriesAttribute != null) {
-			rootElement.remove(entriesAttribute);
-		}
-
-		if (sizeAttribute != null) {
-			rootElement.remove(sizeAttribute);
-		}
+		_removeAttribute(element, "entries");
+		_removeAttribute(element, "size");
 	}
 
-	private void _removeOldestElement(Element rootElement, Element newElement) {
-		int entries = GetterUtil.getInteger(
-			rootElement.attributeValue("entries"));
-		int size = GetterUtil.getInteger(rootElement.attributeValue("size"));
+	private void _removeOldestElement(Element element, Element newElement) {
+		int entries = GetterUtil.getInteger(element.attributeValue("entries"));
+		int size = GetterUtil.getInteger(element.attributeValue("size"));
 
 		entries++;
 		size += _getSize(newElement);
 
-		while ((entries > MAXIMUM_ENTRIES) || (size >= _MAXIMUM_SIZE)) {
-			Element oldestUrlElement = rootElement.element(
-				newElement.getName());
+		while ((entries > _maximumEntries) || (size >= _MAXIMUM_SIZE)) {
+			Element oldestUrlElement = element.element(newElement.getName());
 
 			entries--;
 			size -= _getSize(oldestUrlElement);
 
-			rootElement.remove(oldestUrlElement);
+			element.remove(oldestUrlElement);
 		}
 
-		rootElement.addAttribute("entries", String.valueOf(entries));
-		rootElement.addAttribute("size", String.valueOf(size));
+		element.addAttribute("entries", String.valueOf(entries));
+		element.addAttribute("size", String.valueOf(size));
+	}
+
+	private void _removePaginationAttributes(Element element) {
+		_removeAttribute(element, _ATTRIBUTE_NAME_ASSET_TYPE_KEY);
+		_removeAttribute(element, _ATTRIBUTE_NAME_COMPANY_ID);
+		_removeAttribute(element, _ATTRIBUTE_NAME_GROUP_ID);
+		_removeAttribute(element, _ATTRIBUTE_NAME_PAGE);
+	}
+
+	private void _storePage(
+		String assetTypeKey, long companyId, Element element, long groupId,
+		int page) {
+
+		_removeEntriesAndSize(element);
+		_removePaginationAttributes(element);
+
+		Document document = element.getDocument();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				companyId, groupId, assetTypeKey, page, document.asXML());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
 	}
 
 	private void _visitLayoutSet(
@@ -805,9 +1016,9 @@ public class SitemapManagerImpl implements SitemapManager {
 
 				Element sitemapElement = element.addElement("sitemap");
 
-				Element locationElement = sitemapElement.addElement("loc");
+				Element locElement = sitemapElement.addElement("loc");
 
-				locationElement.addText(
+				locElement.addText(
 					StringBundler.concat(
 						portalURL, _portal.getPathContext(),
 						"/sitemap.xml?p_l_id=", layout.getPlid(),
@@ -821,7 +1032,7 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	private void _visitLayoutSets(
-			List<LayoutSet> layoutSets, String layoutUuid, Element rootElement,
+			Element element, List<LayoutSet> layoutSets, String layoutUuid,
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
@@ -842,15 +1053,24 @@ public class SitemapManagerImpl implements SitemapManager {
 			if (Validator.isNull(layoutUuid)) {
 				for (LayoutSet curLayoutSet : layoutSets) {
 					sitemapURLProvider.visitLayoutSet(
-						rootElement, curLayoutSet, themeDisplay);
+						element, curLayoutSet, themeDisplay);
 				}
 			}
 			else {
 				sitemapURLProvider.visitLayout(
-					rootElement, layoutUuid, layoutSets.get(0), themeDisplay);
+					element, layoutUuid, layoutSets.get(0), themeDisplay);
 			}
 		}
 	}
+
+	private static final String _ATTRIBUTE_NAME_ASSET_TYPE_KEY =
+		"_assetTypeKey";
+
+	private static final String _ATTRIBUTE_NAME_COMPANY_ID = "_companyId";
+
+	private static final String _ATTRIBUTE_NAME_GROUP_ID = "_groupId";
+
+	private static final String _ATTRIBUTE_NAME_PAGE = "_page";
 
 	private static final byte[] _ATTRIBUTE_XHTML =
 		" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"".getBytes();
@@ -863,23 +1083,18 @@ public class SitemapManagerImpl implements SitemapManager {
 	private static final Log _log = LogFactoryUtil.getLog(
 		SitemapManagerImpl.class.getName());
 
-	private static final Map<String, String> _assetTypeClassNames;
-	private static final Map<String, String> _assetTypeKeys = Map.of(
+	private static final Map<String, String> _assetTypeKeysByClassName = Map.of(
 		AssetCategory.class.getName(), "categories",
 		JournalArticle.class.getName(), "web-content", Layout.class.getName(),
 		"pages", ObjectEntry.class.getName(), "object-entries");
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
 
-	static {
-		Map<String, String> assetTypeClassNames = new ConcurrentHashMap<>();
+	private Map<String, Long> _assetTypeClassNameIds;
+	private Map<Long, String> _assetTypeKeys;
 
-		for (Map.Entry<String, String> entry : _assetTypeKeys.entrySet()) {
-			assetTypeClassNames.put(entry.getValue(), entry.getKey());
-		}
-
-		_assetTypeClassNames = Collections.unmodifiableMap(assetTypeClassNames);
-	}
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;
@@ -893,6 +1108,8 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
 
+	private int _maximumEntries;
+
 	@Reference
 	private Portal _portal;
 
@@ -902,7 +1119,7 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Reference
 	private SAXReader _saxReader;
 
-	private ServiceTrackerMap<String, SitemapURLProvider> _serviceTrackerMap;
+	private ServiceTrackerMap<Long, SitemapURLProvider> _serviceTrackerMap;
 
 	@Reference
 	private SitemapConfigurationManager _sitemapConfigurationManager;

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
@@ -120,9 +120,9 @@ public class SitemapStrutsAction implements StrutsAction {
 			InputStream inputStream = _sitemapManager.getSitemapInputStream(
 				ParamUtil.getString(httpServletRequest, "assetTypeKey"),
 				ParamUtil.getString(httpServletRequest, "layoutUuid"),
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
-				themeDisplay,
-				ParamUtil.getInteger(httpServletRequest, "page", 1));
+				layoutSet.getGroupId(),
+				ParamUtil.getInteger(httpServletRequest, "page", 1),
+				layoutSet.isPrivateLayout(), themeDisplay);
 
 			if (inputStream == null) {
 				httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
@@ -233,11 +233,13 @@ public class SitemapStrutsActionTest {
 
 			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
 
-			Map<String, String> assetTypeKeys =
+			Map<Long, String> assetTypeKeys =
 				_sitemapManager.getAssetTypeKeys();
 
 			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
-				assetTypeKeys.get(JournalArticle.class.getName()), null);
+				assetTypeKeys.get(
+					_portal.getClassNameId(JournalArticle.class.getName())),
+				null);
 
 			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -57,6 +57,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -136,6 +137,13 @@ public class SitemapManagerTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_assetCategoryClassNameId = PortalUtil.getClassNameId(
+			AssetCategory.class);
+		_journalArticleClassNameId = PortalUtil.getClassNameId(
+			JournalArticle.class);
+		_layoutClassNameId = PortalUtil.getClassNameId(Layout.class);
+		_objectEntryClassNameId = PortalUtil.getClassNameId(ObjectEntry.class);
+
 		_companyConfigurationTemporarySwapper =
 			new CompanyConfigurationTemporarySwapper(
 				TestPropsValues.getCompanyId(),
@@ -358,7 +366,7 @@ public class SitemapManagerTest {
 			_addObjectDefinitionDisplayPage(_includedObjectDefinition);
 
 			String xml = _sitemapManager.getSitemap(
-				_CLASS_NAME_OBJECT_ENTRY, null, _group.getGroupId(), false,
+				_objectEntryClassNameId, null, _group.getGroupId(), false,
 				_themeDisplay);
 
 			Document document = _saxReader.read(xml);
@@ -389,6 +397,94 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapByAssetTypePaginationAttributesAreAbsent()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			_sitemapManager.getSitemap(
+				_journalArticleClassNameId, null, _group.getGroupId(), false,
+				_themeDisplay);
+
+			String xml = StringUtil.read(
+				_sitemapStorageHelper.getSitemapInputStream(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					_WEB_CONTENT, 1));
+
+			Assert.assertFalse(xml.contains("_assetTypeKey"));
+			Assert.assertFalse(xml.contains("_companyId"));
+			Assert.assertFalse(xml.contains("_groupId"));
+			Assert.assertFalse(xml.contains("_page"));
+			Assert.assertFalse(xml.contains("entries="));
+		}
+	}
+
+	@Test
+	public void testSitemapByAssetTypePaginationStoresMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				_sitemapManager.getSitemap(
+					_journalArticleClassNameId, null, _group.getGroupId(), 1,
+					false, _themeDisplay);
+
+				long companyId = TestPropsValues.getCompanyId();
+				long groupId = _group.getGroupId();
+
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 1));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 2));
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 3));
+				Assert.assertFalse(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId, _WEB_CONTENT, 4));
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
+		}
+	}
+
+	@Test
 	public void testSitemapByAssetTypeRespectsIncludeFlag() throws Exception {
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -409,7 +505,7 @@ public class SitemapManagerTest {
 			_addJournalArticleAssetDisplayPageEntry(journalArticle);
 
 			String xml = _sitemapManager.getSitemap(
-				_CLASS_NAME_JOURNAL_ARTICLE, null, _group.getGroupId(), false,
+				_journalArticleClassNameId, null, _group.getGroupId(), false,
 				_themeDisplay);
 
 			Assert.assertNull(xml);
@@ -435,7 +531,7 @@ public class SitemapManagerTest {
 			_addJournalArticleAssetDisplayPageEntry(journalArticle);
 
 			String xml = _sitemapManager.getSitemap(
-				_CLASS_NAME_JOURNAL_ARTICLE, null, _group.getGroupId(), false,
+				_journalArticleClassNameId, null, _group.getGroupId(), false,
 				_themeDisplay);
 
 			Document document = _saxReader.read(xml);
@@ -660,9 +756,8 @@ public class SitemapManagerTest {
 
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				DisplayPageTemplateTestUtil.addDisplayPageTemplate(
-					_group.getGroupId(),
-					_portal.getClassNameId(JournalArticle.class.getName()),
-					null, true, WorkflowConstants.STATUS_APPROVED);
+					_group.getGroupId(), _journalArticleClassNameId, null, true,
+					WorkflowConstants.STATUS_APPROVED);
 
 			Layout layout = _layoutLocalService.getLayout(
 				layoutPageTemplateEntry.getPlid());
@@ -1185,13 +1280,11 @@ public class SitemapManagerTest {
 
 			List<String> urls = new ArrayList<>();
 
-			for (Map.Entry<String, String> entry :
+			for (Map.Entry<Long, String> entry :
 					_sitemapManager.getAssetTypeKeys(
 					).entrySet()) {
 
-				if (StringUtil.equals(
-						entry.getKey(), _CLASS_NAME_OBJECT_ENTRY)) {
-
+				if (entry.getKey() == _objectEntryClassNameId) {
 					continue;
 				}
 
@@ -1235,7 +1328,7 @@ public class SitemapManagerTest {
 
 			Element webContentLocElement = _getLocElement(
 				rootElement.elements(),
-				_buildAssetTypeSitemapURL(_CLASS_NAME_JOURNAL_ARTICLE));
+				_buildAssetTypeSitemapURL(_journalArticleClassNameId));
 
 			Assert.assertNotNull(webContentLocElement);
 
@@ -1251,12 +1344,99 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIndexByAssetTypePageParamWithMultiplePages()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_sitemapManager, "_maximumEntries", 3);
+
+			try {
+				for (int i = 0; i < 7; i++) {
+					_addJournalArticleAssetDisplayPageEntry(
+						_addJournalArticle());
+				}
+
+				Document document = _saxReader.read(
+					_sitemapManager.getSitemap(
+						null, _group.getGroupId(), false, _themeDisplay));
+
+				Element rootElement = document.getRootElement();
+
+				List<String> locs = TransformUtil.transform(
+					rootElement.elements("sitemap"),
+					sitemapElement -> {
+						String loc = sitemapElement.elementText("loc");
+
+						return loc.contains(_WEB_CONTENT) ? loc : null;
+					});
+
+				Assert.assertEquals(locs.toString(), 3, locs.size());
+
+				for (int i = 0; i < locs.size(); i++) {
+					String loc = locs.get(i);
+
+					Assert.assertTrue(loc.contains("&page=" + (i + 1)));
+				}
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+			}
+		}
+	}
+
+	@Test
+	public void testSitemapIndexByAssetTypePageParamWithSinglePage()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Document document = _saxReader.read(
+				_sitemapManager.getSitemap(
+					null, _group.getGroupId(), false, _themeDisplay));
+
+			Element rootElement = document.getRootElement();
+
+			for (Element sitemapElement : rootElement.elements("sitemap")) {
+				String loc = sitemapElement.elementText("loc");
+
+				Assert.assertFalse(loc.contains("&page="));
+			}
+		}
+	}
+
+	@Test
 	public void testSitemapIndexByAssetTypeRespectsPerTypeFlagsCompany()
 		throws Exception {
 
 		String categoriesURL = _buildAssetTypeSitemapURL(
-			_CLASS_NAME_ASSET_CATEGORY);
-		String pagesURL = _buildAssetTypeSitemapURL(_CLASS_NAME_LAYOUT);
+			_assetCategoryClassNameId);
+		String pagesURL = _buildAssetTypeSitemapURL(_layoutClassNameId);
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -1278,7 +1458,7 @@ public class SitemapManagerTest {
 		}
 
 		String webContentURL = _buildAssetTypeSitemapURL(
-			_CLASS_NAME_JOURNAL_ARTICLE);
+			_journalArticleClassNameId);
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -1341,6 +1521,29 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIndexByAssetTypeStoresInDLStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_sitemapManager.getSitemap(
+				null, _group.getGroupId(), false, _themeDisplay);
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
 	public void testSitemapURLsWithLayoutFriendlyURLPublicServletMappingDisabled()
 		throws Exception {
 
@@ -1371,7 +1574,7 @@ public class SitemapManagerTest {
 
 	private void _addAssetCategoryAssetDisplayPageEntry() throws Exception {
 		_addAssetDisplayPageEntry(
-			_portal.getClassNameId(AssetCategory.class.getName()), 0, null,
+			_assetCategoryClassNameId, 0, null,
 			AssetDisplayPageConstants.TYPE_DEFAULT);
 	}
 
@@ -1408,8 +1611,7 @@ public class SitemapManagerTest {
 		throws Exception {
 
 		return _addAssetDisplayPageEntry(
-			_portal.getClassNameId(JournalArticle.class.getName()),
-			journalArticle.getResourcePrimKey(),
+			_journalArticleClassNameId, journalArticle.getResourcePrimKey(),
 			journalArticle.getDDMStructureKey(),
 			AssetDisplayPageConstants.TYPE_SPECIFIC);
 	}
@@ -1481,7 +1683,8 @@ public class SitemapManagerTest {
 		throws Exception {
 
 		String xml = _sitemapManager.getSitemap(
-			assetType, uuid, groupId, false, _themeDisplay);
+			Validator.isNull(assetType) ? 0 : _portal.getClassNameId(assetType),
+			uuid, groupId, false, _themeDisplay);
 
 		Document document = _saxReader.read(xml);
 
@@ -1500,12 +1703,12 @@ public class SitemapManagerTest {
 		}
 	}
 
-	private String _buildAssetTypeSitemapURL(String assetTypeGroup) {
+	private String _buildAssetTypeSitemapURL(long assetTypeClassNameId) {
 		return StringBundler.concat(
 			_themeDisplay.getPortalURL(), _portal.getPathContext(), "/sitemap-",
 			_sitemapManager.getAssetTypeKeys(
 			).get(
-				assetTypeGroup
+				assetTypeClassNameId
 			),
 			".xml?groupId=", _group.getGroupId(), "&privateLayout=false");
 	}
@@ -1555,7 +1758,7 @@ public class SitemapManagerTest {
 			for (AssetCategory assetCategory : assetCategories) {
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
-						_portal.getClassNameId(AssetCategory.class),
+						_assetCategoryClassNameId,
 						assetCategory.getCategoryId());
 
 				urls.add(
@@ -1862,25 +2065,20 @@ public class SitemapManagerTest {
 			_group.getGroupId(), uuid, urls);
 	}
 
-	private static final String _CLASS_NAME_ASSET_CATEGORY =
-		AssetCategory.class.getName();
-
-	private static final String _CLASS_NAME_JOURNAL_ARTICLE =
-		JournalArticle.class.getName();
-
-	private static final String _CLASS_NAME_LAYOUT = Layout.class.getName();
-
-	private static final String _CLASS_NAME_OBJECT_ENTRY =
-		ObjectEntry.class.getName();
-
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
 	private static final String _PID_SITEMAP_GROUP_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapGroupConfiguration";
 
+	private static final String _WEB_CONTENT = "web-content";
+
+	private static long _assetCategoryClassNameId;
 	private static CompanyConfigurationTemporarySwapper
 		_companyConfigurationTemporarySwapper;
+	private static long _journalArticleClassNameId;
+	private static long _layoutClassNameId;
+	private static long _objectEntryClassNameId;
 
 	@Inject
 	private AssetCategoryService _assetCategoryService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90949

## What Is Being Fixed

Asset-type sitemaps (web content, layouts, commerce products and categories, object entries) were truncated to MAXIMUM_ENTRIES (50,000). Any URLs beyond that cap were silently dropped, so large sites published incomplete sitemaps. The sitemap protocol limits a single file to 50,000 URLs / 50MB, which the previous implementation handled by discarding the overflow rather than paginating it.

## How It Is Being Fixed

Asset-type sitemaps are now paginated instead of truncated. When a dataset exceeds the per-file limits, the manager splits it across multiple stored sitemap files and exposes each through the sitemap index with a page parameter. SitemapManager gains a paginated getSitemap overload, and getSitemapInputStream takes a page argument; the index emits one entry per page. The URL providers stream every entry through an ActionableDynamicQuery rather than capping the result set, and now filter entries by VIEW permission. The MAXIMUM_ENTRIES truncation was removed from the providers, getLastModifiedDate was renamed to getModifiedDate across the SitemapURLProvider contract and its implementations, and internal pagination bookkeeping attributes are stripped from the stored output. Integration tests cover multi-page storage, the page request parameter, single-page output, and the absence of internal attributes.

## PR Check

**pr-check: PASS** — tested on `772fb75bd8e9681d0eea2e4667d32323dc2394f8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "772fb75bd8e9681d0eea2e4667d32323dc2394f8"} -->