### PR TITLE
LPD-91213 Scaffold the SEO Studio crawler client extension

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/Dockerfile
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/jar-runner:latest
+
+COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/LCP.json
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/LCP.json
@@ -1,0 +1,31 @@
+{
+	"cpu": 1,
+	"env": {
+		"LIFERAY_ROUTES_CLIENT_EXTENSION": "/etc/liferay/lxc/ext-init-metadata",
+		"LIFERAY_ROUTES_DXP": "/etc/liferay/lxc/dxp-metadata"
+	},
+	"environments": {
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "__PROJECT_ID__",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"loadBalancer": {
+		"targetPort": 58081
+	},
+	"memory": 512,
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"scale": 1
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
@@ -1,0 +1,42 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.18"
+	}
+
+	repositories {
+		maven {
+			url new File(rootProject.projectDir, "../../.m2-tmp")
+		}
+
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.source.formatter"
+apply plugin: "java-library"
+apply plugin: "org.springframework.boot"
+
+dependencies {
+	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
+	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
+	implementation group: "io.fabric8", name: "kubernetes-client", version: "6.13.4"
+	implementation group: "org.json", name: "json", version: "20231013"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
+}
+
+repositories {
+	maven {
+		url new File(rootProject.projectDir, "../../.m2-tmp")
+	}
+
+	maven {
+		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+	}
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/client-extension.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/client-extension.yaml
@@ -1,0 +1,24 @@
+assemble:
+    -   fromTask: bootJar
+liferay-seostudio-etc-crawler-oahs:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio Etc Crawler OAuth Application Headless Server
+    scopes:
+        -   Liferay.SEO.Studio.REST.everything.read
+        -   seostudiodomain.everything
+        -   seostudioinsighttype.everything
+        -   seostudiopage.everything
+        -   seostudioscan.everything
+        -   seostudioscaninsight.everything
+    type: oAuthApplicationHeadlessServer
+liferay-seostudio-etc-crawler-oaua:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio Etc Crawler OAuth Application User Agent
+    type: oAuthApplicationUserAgent
+liferay-seostudio-etc-crawler-object-action-crawler:
+    name: Liferay SEO Studio Etc Crawler Object Action Crawler
+    oAuth2ApplicationExternalReferenceCode: liferay-seostudio-etc-crawler-oaua
+    resourcePath: /crawler
+    type: objectAction

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio;
+
+import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * @author Brooke Dalton
+ */
+@EnableScheduling
+@Import(ClientExtensionUtilSpringBootComponentScan.class)
+@SpringBootApplication
+public class SEOStudioSpringBootApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SEOStudioSpringBootApplication.class, args);
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import org.json.JSONObject;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Brooke Dalton
+ */
+@RequestMapping("/crawler")
+@RestController
+public class CrawlerRestController extends BaseRestController {
+
+	@PostMapping
+	public ResponseEntity<String> post(@RequestBody String json) {
+		return ResponseEntity.ok(
+			new JSONObject(
+			).toString());
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/ReadyRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/ReadyRestController.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Brooke Dalton
+ */
+@RequestMapping("/ready")
+@RestController
+public class ReadyRestController extends BaseRestController {
+
+	@GetMapping
+	public String get() {
+		return "READY";
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/KubernetesJobService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/KubernetesJobService.java
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import io.fabric8.kubernetes.client.utils.Serialization;
+
+import jakarta.annotation.PreDestroy;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class KubernetesJobService {
+
+	public KubernetesJobService(
+		@Value("${liferay.seo.studio.crawler.elasticsearch.host}") String
+			elasticsearchHost,
+		@Value("${liferay.seo.studio.crawler.elasticsearch.port}") int
+			elasticsearchPort,
+		@Value("${liferay.seo.studio.crawler.k8s.image.name}") String imageName,
+		@Value("${liferay.seo.studio.crawler.local.network.allowed}") boolean
+			localNetworkAllowed,
+		@Value("${liferay.seo.studio.crawler.k8s.namespace}") String
+			namespace) {
+
+		_elasticsearchHost = elasticsearchHost;
+		_elasticsearchPort = elasticsearchPort;
+		_imageName = imageName;
+		_localNetworkAllowed = localNetworkAllowed;
+		_namespace = namespace;
+
+		_jobTemplate = _loadJobTemplate();
+	}
+
+	@PreDestroy
+	public void close() {
+		_kubernetesClient.close();
+	}
+
+	public Job createJob(
+		long accountEntryId, String domainURL, int maxCrawlDepth,
+		int maxDuration, String outputIndex, String sitemapURL) {
+
+		Job job = _kubernetesClient.batch(
+		).v1(
+		).jobs(
+		).inNamespace(
+			_namespace
+		).resource(
+			new JobBuilder(
+				_jobTemplate
+			).editMetadata(
+			).addToLabels(
+				"account-entry-id", String.valueOf(accountEntryId)
+			).endMetadata(
+			).editSpec(
+			).editTemplate(
+			).editMetadata(
+			).addToLabels(
+				"account-entry-id", String.valueOf(accountEntryId)
+			).endMetadata(
+			).editSpec(
+			).editFirstContainer(
+			).withImage(
+				_imageName
+			).withEnv(
+				_createEnvVar(
+					"ACCOUNT_ENTRY_ID", String.valueOf(accountEntryId)),
+				_createEnvVar("CRAWLER_DOMAIN_URL", domainURL),
+				_createEnvVar(
+					"CRAWLER_LOOPBACK_ALLOWED",
+					String.valueOf(_localNetworkAllowed)),
+				_createEnvVar(
+					"CRAWLER_MAX_CRAWL_DEPTH", String.valueOf(maxCrawlDepth)),
+				_createEnvVar(
+					"CRAWLER_MAX_DURATION", String.valueOf(maxDuration)),
+				_createEnvVar("CRAWLER_OUTPUT_INDEX", outputIndex),
+				_createEnvVar(
+					"CRAWLER_PRIVATE_NETWORKS_ALLOWED",
+					String.valueOf(_localNetworkAllowed)),
+				_createEnvVar("CRAWLER_SEED_URL", domainURL),
+				_createEnvVar("CRAWLER_SITEMAP_URL", sitemapURL),
+				_createEnvVar("ELASTICSEARCH_HOST", _elasticsearchHost),
+				_createEnvVar(
+					"ELASTICSEARCH_PORT", String.valueOf(_elasticsearchPort))
+			).endContainer(
+			).endSpec(
+			).endTemplate(
+			).endSpec(
+			).build()
+		).create();
+
+		if (_log.isInfoEnabled()) {
+			ObjectMeta objectMeta = job.getMetadata();
+
+			_log.info("Kubernetes job dispatched: " + objectMeta.getName());
+		}
+
+		return job;
+	}
+
+	public Job getJob(String name) {
+		ScalableResource<Job> scalableResource = _getJobScalableResource(name);
+
+		return scalableResource.get();
+	}
+
+	private EnvVar _createEnvVar(String name, String value) {
+		return new EnvVarBuilder(
+		).withName(
+			name
+		).withValue(
+			value
+		).build();
+	}
+
+	private ScalableResource<Job> _getJobScalableResource(String name) {
+		return _kubernetesClient.batch(
+		).v1(
+		).jobs(
+		).inNamespace(
+			_namespace
+		).withName(
+			name
+		);
+	}
+
+	private Job _loadJobTemplate() {
+		try (InputStream inputStream = getClass().getResourceAsStream(
+				"/crawler-job-template.yaml")) {
+
+			return Serialization.unmarshal(inputStream, Job.class);
+		}
+		catch (IOException ioException) {
+			throw new IllegalStateException(
+				"Unable to load \"/crawler-job-template.yaml\"", ioException);
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		KubernetesJobService.class);
+
+	private final String _elasticsearchHost;
+	private final int _elasticsearchPort;
+	private final String _imageName;
+	private final Job _jobTemplate;
+	private final KubernetesClient _kubernetesClient =
+		new KubernetesClientBuilder(
+		).build();
+	private final boolean _localNetworkAllowed;
+	private final String _namespace;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/application-default.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/application-default.properties
@@ -1,0 +1,35 @@
+#
+# Application
+#
+
+liferay.seo.studio.crawler.elasticsearch.host=${LIFERAY_SEO_STUDIO_CRAWLER_ELASTICSEARCH_HOST}
+liferay.seo.studio.crawler.elasticsearch.port=${LIFERAY_SEO_STUDIO_CRAWLER_ELASTICSEARCH_PORT}
+liferay.seo.studio.crawler.k8s.image.name=${LIFERAY_SEO_STUDIO_CRAWLER_K8S_IMAGE_NAME}
+liferay.seo.studio.crawler.k8s.namespace=${LIFERAY_SEO_STUDIO_CRAWLER_K8S_NAMESPACE}
+liferay.seo.studio.crawler.local.network.allowed=false
+
+#
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
+# OAuth
+#
+
+liferay-seostudio-etc-crawler-oahs.oauth2.headless.server.client.secret=${LIFERAY_SEOSTUDIO_ETC_CRAWLER_OAHS_CLIENT_SECRET:myfancypassword}
+
+liferay.oauth.application.external.reference.codes=\
+    liferay-seostudio-etc-crawler-oahs,\
+    liferay-seostudio-etc-crawler-oaua
+
+liferay.oauth.urls.excludes=/crawler,/ready
+
+#
+# Spring Boot
+#
+
+server.port=58081

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/application.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.config.import=\
+    classpath:/application-default.properties,\
+    optional:configtree:${LIFERAY_ROUTES_CLIENT_EXTENSION}/,\
+    optional:configtree:${LIFERAY_ROUTES_DXP}/

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/crawler-job-template.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/resources/crawler-job-template.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    generateName: seostudio-crawler-
+    labels:
+        app: seostudio-crawler
+spec:
+    backoffLimit: 1
+    template:
+        metadata:
+            labels:
+                app: seostudio-crawler
+        spec:
+            containers:
+                -   image: placeholder
+                    name: crawler
+                    resources:
+                        limits:
+                            cpu: "2"
+                            memory: 4Gi
+                        requests:
+                            cpu: "1"
+                            memory: 2Gi
+                    securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                            drop:
+                                -   ALL
+            restartPolicy: Never
+            securityContext:
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+                seccompProfile:
+                    type: RuntimeDefault
+    ttlSecondsAfterFinished: 86400


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213

## What Is Being Fixed

SEO Studio's crawler needs a deployable runtime to dispatch and monitor crawl jobs. No client extension yet packages the crawler service, its REST endpoints, and the Kubernetes job wiring.

## How It Is Being Fixed

This is the first part of the work: it scaffolds the `liferay-seostudio-etc-crawler` Spring Boot client extension. It adds the application entry point, the `/ready` health endpoint and the `/crawler` object-action endpoint, and the `KubernetesJobService` that creates and reads Kubernetes batch jobs from a job template. It also wires the build (`build.gradle`, `LCP.json`, `Dockerfile`), the OAuth headless-server scopes in `client-extension.yaml`, and the crawler job template plus application properties. The endpoint handlers are stubs at this stage; the crawl behavior lands in a later part.

## PR Check

**pr-check: PASS** — tested on `f02c5113a9de072ff5fb201b0964eef91412ad7d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "f02c5113a9de072ff5fb201b0964eef91412ad7d"} -->
