### PR TITLE
LPD-23181 Putting and restoring web content through trash box after publishing, unexpected error is shown on publication history.

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -309,7 +309,9 @@ public class GetEntryRenderDataMVCResourceCommand
 
 		long leftCtCollectionId = CTConstants.CT_COLLECTION_ID_PRODUCTION;
 
-		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+		if ((ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) &&
+			(ctEntry.getChangeType() != CTConstants.CT_CHANGE_TYPE_ADDITION)) {
+
 			leftCtCollectionId = ctEntry.getCtCollectionId();
 		}
 

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationHistoryEditedOnProduction.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationHistoryEditedOnProduction.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
+import getRandomString from '../../../utils/getRandomString';
+import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+
+const test = mergeTests(apiHelpersTest, changeTrackingPagesTest);
+
+test(
+	'View publication history for a web content edited on production after publish',
+	{tag: '@LPD-23181'},
+	async ({apiHelpers, changeTrackingPage, ctCollection, page}) => {
+
+		// Add a web content in the publication
+
+		await changeTrackingPage.workOnPublication(ctCollection);
+
+		const site =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+				'guest'
+			);
+
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		const title = getRandomString();
+
+		const webContent =
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				content: 'original',
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: title},
+			});
+
+		// Publish the publication and wait for the background task to finish
+
+		await apiHelpers.headlessChangeTracking.publishCTCollection(
+			ctCollection.body.id
+		);
+
+		await changeTrackingPage.assertStatus(
+			'Published',
+			ctCollection.body.name
+		);
+
+		// Edit the same web content directly on production to create v1.1
+
+		await changeTrackingPage.workOnProduction();
+
+		await apiHelpers.jsonWebServicesJournal.editWebContent(
+			{content: 'edited-on-production'},
+			site.id,
+			webContent
+		);
+
+		// Open the published publication in the History tab and click the
+		// web content entry
+
+		await changeTrackingPage.goToPublicationHistory();
+
+		await page.getByRole('link', {name: ctCollection.body.name}).click();
+
+		await changeTrackingPage.reviewChange(title);
+
+		// The publication's contribution (v1.0) and the current production
+		// state (v1.1) must both be selectable. Before the fix the request
+		// failed with NoSuchEntryException because the left model was queried
+		// in the published publication's CT context instead of production.
+
+		await expect(
+			page.getByText(
+				'Unable to display content due to an unexpected error'
+			)
+		).toBeHidden();
+
+		await changeTrackingPage.selectTab('Data');
+
+		await changeTrackingPage.selectRenderView('Production');
+
+		await expect(
+			page.locator('.publications-render-view-content')
+		).toContainText('edited-on-production');
+
+		await changeTrackingPage.selectRenderView(ctCollection.body.name);
+
+		await expect(
+			page.locator('.publications-render-view-content')
+		).toContainText('original');
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23181

## What Is Being Fixed

Viewing the publication history for a JournalArticle that was added in a publication and then edited on production after publish throws "Unable to display content due to an unexpected error". The cause is a `NoSuchEntryException` when looking up the article's `AssetEntry` — the renderer queried the left preview in the published publication's CT context, but after publish no rows live at that `ctCollectionId`, so the unique finder returned nothing.

## How It Is Being Fixed

In `GetEntryRenderDataMVCResourceCommand` the APPROVED override on `leftCtCollectionId` no longer applies to ADDITION change types. For additions in a published publication the left model now resolves against production, where its data actually lives. This restores the behavior the original LPS-136442 commit established before its follow-up regressed the lookup.

The second commit adds a Playwright spec under `tests/change-tracking-web/main` that adds a web content in a publication, publishes it, edits the same content directly on production, and then asserts both the Production and publication-name views are reachable in the Data tab of the publication history.

## PR Check

**pr-check: PASS** — tested on `f974334883777ba172ce5918d988d7737829b9ce`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f974334883777ba172ce5918d988d7737829b9ce"} -->
