### PR TITLE
LPD-88837 Add PageSpeed score service for Google PageSpeed Insights API

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -21,6 +21,7 @@ apply plugin: "org.springframework.boot"
 
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/client-extension.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/client-extension.yaml
@@ -15,3 +15,8 @@ liferay-seostudio-etc-pagespeed-oaua:
     .serviceScheme: http
     name: Liferay SEO Studio Etc PageSpeed OAuth Application User Agent
     type: oAuthApplicationUserAgent
+liferay-seostudio-etc-pagespeed-object-action-pagespeed:
+    name: Liferay SEO Studio Etc PageSpeed Object Action PageSpeed
+    oAuth2ApplicationExternalReferenceCode: liferay-seostudio-etc-pagespeed-oaua
+    resourcePath: /object/action/pagespeed
+    type: objectAction

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScoresService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScoresService.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.nio.charset.StandardCharsets;
+
+import java.time.Duration;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class PageSpeedScoresService {
+
+	public PageSpeedScores getPageSpeedScores(
+			String apiKey, String strategy, String url)
+		throws InterruptedException, IOException {
+
+		HttpResponse<String> httpResponse = _httpClient.send(
+			HttpRequest.newBuilder(
+			).uri(
+				URI.create(_buildURL(apiKey, strategy, url))
+			).GET(
+			).build(),
+			HttpResponse.BodyHandlers.ofString());
+
+		if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+			throw new IOException(
+				"Unable to fetch PageSpeed scores, HTTP " +
+					httpResponse.statusCode());
+		}
+
+		return _parsePageSpeedScores(httpResponse.body());
+	}
+
+	public static class PageSpeedScores {
+
+		public PageSpeedScores(
+			int accessibility, int bestPractices, int performance, int seo) {
+
+			_accessibility = accessibility;
+			_bestPractices = bestPractices;
+			_performance = performance;
+			_seo = seo;
+		}
+
+		public int getAccessibility() {
+			return _accessibility;
+		}
+
+		public int getBestPractices() {
+			return _bestPractices;
+		}
+
+		public int getPerformance() {
+			return _performance;
+		}
+
+		public int getSEO() {
+			return _seo;
+		}
+
+		private final int _accessibility;
+		private final int _bestPractices;
+		private final int _performance;
+		private final int _seo;
+
+	}
+
+	private String _buildURL(String apiKey, String strategy, String url) {
+		StringBundler sb = new StringBundler(10);
+
+		sb.append("https://content-pagespeedonline.googleapis.com");
+		sb.append("/pagespeedonline/v5/runPagespeed");
+		sb.append("?category=ACCESSIBILITY&category=BEST_PRACTICES");
+		sb.append("&category=PERFORMANCE&category=SEO&fields=");
+		sb.append("lighthouseResult/categories/*/score&key=");
+		sb.append(URLEncoder.encode(apiKey, StandardCharsets.UTF_8));
+		sb.append("&strategy=");
+		sb.append(strategy);
+		sb.append("&url=");
+		sb.append(URLEncoder.encode(url, StandardCharsets.UTF_8));
+
+		return sb.toString();
+	}
+
+	private int _getPageSpeedScore(JSONObject jsonObject) {
+		return (int)Math.round(jsonObject.getDouble("score") * 100);
+	}
+
+	private PageSpeedScores _parsePageSpeedScores(String responseJSON) {
+		JSONObject responseJSONObject = new JSONObject(responseJSON);
+
+		JSONObject lighthouseResultJSONObject =
+			responseJSONObject.getJSONObject("lighthouseResult");
+
+		JSONObject categoriesJSONObject =
+			lighthouseResultJSONObject.getJSONObject("categories");
+
+		return new PageSpeedScores(
+			_getPageSpeedScore(
+				categoriesJSONObject.getJSONObject("accessibility")),
+			_getPageSpeedScore(
+				categoriesJSONObject.getJSONObject("best-practices")),
+			_getPageSpeedScore(
+				categoriesJSONObject.getJSONObject("performance")),
+			_getPageSpeedScore(categoriesJSONObject.getJSONObject("seo")));
+	}
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).build();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

With the PageSpeed client extension scaffold in place (LPD-88837 #3441), the `liferay-seostudio-etc-pagespeed` extension needs the actual integration code: a Spring-managed service that calls Google's PageSpeed Insights API, parses the four Lighthouse category scores (accessibility, best practices, performance, SEO), and exposes them as a typed result. The site initializer's PageSpeed object action also needs an entry declared on the client extension so the rename in PR 3441 has a real endpoint to dispatch to.

## How It Is Being Fixed

A new `PageSpeedScoreService` is added under `com.liferay.seo.studio.service`, modeled after `liferay-seostudio-etc-gsc/GoogleOAuth2Service`: stateless `@Component`, `private final HttpClient _httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()` field literal (matching the `ai-hub-rest-test/SseEventSourceTestUtil` precedent for HTTP connect timeouts on `java.net.http.HttpClient`), per-call `getScores(apiKey, strategy, url)` signature that throws `InterruptedException, IOException` and lets `JSONException` propagate. The Google PageSpeed URL is built with `StringBundler(11)` and `URLEncoder.encode(..., StandardCharsets.UTF_8)`. The four category scores are returned as a nested `public static class PageSpeedScores` with immutable `_accessibility`, `_bestPractices`, `_performance`, `_seo` fields and matching getters — mirroring the `GSCCredentialsService.Credentials` nested value-class pattern. The client extension yaml gains the `liferay-seostudio-etc-pagespeed-object-action-pagespeed` entry that the site initializer dispatches to, and `build.gradle` picks up `com.liferay.petra.string` for `StringBundler`.

## Why Are There No Tests?

Mirrors the closest sibling, `liferay-seostudio-etc-gsc`/`GoogleOAuth2Service` (Brian-merged), which ships service classes wrapping the same `java.net.http.HttpClient` pattern with no unit tests. The established etc-gsc pattern lets HTTP and JSON exceptions propagate to callers rather than testing them in isolation.

## PR Check

**pr-check: PASS** — tested on `6536ff6821d031abbb123df0434e4e9cca8de8f8`

| Validation | Result |
| --- | --- |
| Source Format (gradle checkSourceFormatting + ant) | PASS |
| Structural Smoke | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "6536ff6821d031abbb123df0434e4e9cca8de8f8"} -->