### PR TITLE
LPD-41080 Allow clearing the Root Page in Site Map widget configuration

### DIFF
--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -45,7 +45,7 @@
 				resourceValueKey="id"
 				selectEventName="selectLayout"
 				selectResourceURL="<%= siteNavigationSiteMapDisplayContext.getItemSelectorURL() %>"
-				showRemoveButton="<%= false %>"
+				showRemoveButton="<%= true %>"
 			/>
 
 			<aui:select name="preferences--displayDepth--">
@@ -63,7 +63,7 @@
 
 			</aui:select>
 
-			<div class="<%= Validator.isNotNull(siteNavigationSiteMapPortletInstanceConfiguration.rootLayoutUuid()) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />includeRootInTreeContainer">
+			<div class="<%= (rootLayout != null) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />includeRootInTreeContainer">
 				<aui:input inlineLabel="right" labelCssClass="simple-toggle-switch" name="preferences--includeRootInTree--" type="toggle-switch" value="<%= siteNavigationSiteMapDisplayContext.isIncludeRootInTree() %>" />
 			</div>
 

--- a/modules/test/playwright/tests/site-navigation-site-map-web/main/navigationSitemap.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-site-map-web/main/navigationSitemap.spec.ts
@@ -105,3 +105,87 @@ test("Site Map multi column layout template should respect the 'Include Root in 
 		).toBeVisible();
 	});
 });
+
+test('Site Map widget configuration should allow clearing the Root Page', async ({
+	apiHelpers,
+	page,
+	pageEditorPage,
+	pagesAdminPage,
+	site,
+}) => {
+	const childLayoutName = getRandomString();
+	const rootLayoutName = getRandomString();
+	const widgetId = getRandomString();
+
+	let rootLayout: Layout;
+
+	await test.step('Create a page with a Site Map Widget and its child page', async () => {
+		rootLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: widgetId,
+					widgetConfig: {
+						displayDepth: '0',
+						displayStyle:
+							'ddmTemplate_SITE-MAP-MULTI-COLUMN-LAYOUT-FTL',
+					},
+					widgetName:
+						'com_liferay_site_navigation_site_map_web_portlet_SiteNavigationSiteMapPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: rootLayoutName,
+		});
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+		await pagesAdminPage.createNewPage({
+			name: childLayoutName,
+			parent: rootLayoutName,
+		});
+	});
+
+	await test.step('Set a Root Page in the Site Map Widget configuration', async () => {
+		await pageEditorPage.goto(rootLayout, site.friendlyUrlPath);
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		const configurationIframe = page.frameLocator(
+			'iframe[title="Configuration"]'
+		);
+
+		await configurationIframe.getByRole('button', {name: 'Select'}).click();
+
+		const selectRootPageIframe = configurationIframe.frameLocator('iframe');
+
+		const rootLayoutTreeItem = selectRootPageIframe.locator(
+			'.treeview-link',
+			{hasText: rootLayoutName}
+		);
+
+		await expect(rootLayoutTreeItem).toBeVisible();
+
+		await rootLayoutTreeItem.click();
+
+		await configurationIframe.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			configurationIframe.getByText('Include Root in Tree')
+		).toBeVisible();
+	});
+
+	await test.step('Clear the Root Page and verify it is removed', async () => {
+		const configurationIframe = page.frameLocator(
+			'iframe[title="Configuration"]'
+		);
+
+		await configurationIframe.getByRole('button', {name: 'Remove'}).click();
+
+		await configurationIframe.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			configurationIframe.getByText('Include Root in Tree')
+		).toBeHidden();
+		await expect(
+			configurationIframe.getByText(rootLayoutName)
+		).toBeHidden();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41080

## What Is Being Fixed

In the Site Map widget configuration, once a Root Page was selected there was no way to clear it. The page selector's remove button was disabled, so the chosen Root Page could only ever be swapped for another, never unset. Compounding this, the "Include Root in Tree" toggle's visibility was driven off the persisted configuration value (`rootLayoutUuid`) rather than the page currently selected in the form, so the UI could not react to a cleared selection.

## How It Is Being Fixed

The page selector's remove button is enabled (`showRemoveButton="<%= true %>"`), giving the user a way to clear the Root Page. The "Include Root in Tree" container's visibility is now derived from the currently resolved `rootLayout` (`rootLayout != null`) instead of the stored `rootLayoutUuid`, so the toggle hides as soon as the page is removed rather than staying tied to the last-saved value. A Playwright test exercises the full flow: setting a Root Page, then clearing it and verifying both the Root Page and the "Include Root in Tree" toggle disappear.

## PR Check

**pr-check: PASS** — tested on `be0cee018c44dc924caaae3c82ebf26ae14338d7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "be0cee018c44dc924caaae3c82ebf26ae14338d7"} -->
