### PR TITLE
LPD-95401 Bump friendly-url-taglib package version to 2.1.0

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL Taglib
 Bundle-SymbolicName: com.liferay.friendly.url.taglib
-Bundle-Version: 2.0.18
+Bundle-Version: 2.1.0
 Export-Package: com.liferay.friendly.url.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/friendly-url/friendly-url-taglib/package.json
+++ b/modules/apps/friendly-url/friendly-url-taglib/package.json
@@ -24,5 +24,5 @@
 		"format": "node-scripts format",
 		"test": "node-scripts test"
 	},
-	"version": "2.0.18"
+	"version": "2.1.0"
 }

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95401

## What Is Being Fixed

The `friendly-url-taglib` bundle fails its bnd baseline check. The exported package `com.liferay.friendly.url.taglib.servlet.taglib` gained new methods on `InputTag` (`getAvailableLocales()` and `setAvailableLocales(java.util.Set)`) — a backward-compatible MINOR API addition — without the accompanying package version increase, so bnd reports "VERSION INCREASE REQUIRED".

## How It Is Being Fixed

Bump the exported package version from 2.0.0 to 2.1.0 in `packageinfo`, and raise the bundle metadata to match: `Bundle-Version` 2.0.18 → 2.1.0 in `bnd.bnd` and `version` 2.0.18 → 2.1.0 in `package.json`. With the package now exported at the recommended 2.1.0, the baseline check passes.

## Why Are There No Tests?

This change only updates version metadata (`packageinfo`, `bnd.bnd`, `package.json`) to satisfy the bnd baseline check; it introduces no code logic to test. The bnd baseline validation itself verifies the bump is correct.

## PR Check

**pr-check: PASS** — tested on `f13f61eb982d66e1575f5c36805cde7ed30ee92a`

| Validation | Result |
| --- | --- |
| Baseline | PASS |
| Source Format | PASS |
| Structural Smoke | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f13f61eb982d66e1575f5c36805cde7ed30ee92a"} -->
