### PR TITLE
LPD-41080 Allow clearing the Root Page in Site Map widget configuration

### DIFF
--- a/modules/apps/site-navigation/site-navigation-site-map-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-site-map-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -45,7 +45,7 @@
 				resourceValueKey="id"
 				selectEventName="selectLayout"
 				selectResourceURL="<%= siteNavigationSiteMapDisplayContext.getItemSelectorURL() %>"
-				showRemoveButton="<%= false %>"
+				showRemoveButton="<%= true %>"
 			/>
 
 			<aui:select name="preferences--displayDepth--">
@@ -63,7 +63,7 @@
 
 			</aui:select>
 
-			<div class="<%= Validator.isNotNull(siteNavigationSiteMapPortletInstanceConfiguration.rootLayoutUuid()) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />includeRootInTreeContainer">
+			<div class="<%= Validator.isNotNull(rootLayout) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />includeRootInTreeContainer">
 				<aui:input inlineLabel="right" labelCssClass="simple-toggle-switch" name="preferences--includeRootInTree--" type="toggle-switch" value="<%= siteNavigationSiteMapDisplayContext.isIncludeRootInTree() %>" />
 			</div>
 

--- a/modules/test/playwright/tests/site-navigation-site-map-web/main/navigationSitemap.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-site-map-web/main/navigationSitemap.spec.ts
@@ -105,3 +105,87 @@ test("Site Map multi column layout template should respect the 'Include Root in 
 		).toBeVisible();
 	});
 });
+
+test('Can remove the Root Page in Site Map widget configuration', async ({
+	apiHelpers,
+	page,
+	pageEditorPage,
+	pagesAdminPage,
+	site,
+}) => {
+	const childLayoutName = getRandomString();
+	const rootLayoutName = getRandomString();
+	const widgetId = getRandomString();
+
+	let rootLayout: Layout;
+
+	await test.step('Create a page with a Site Map Widget and its child page', async () => {
+		rootLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: widgetId,
+					widgetConfig: {
+						displayDepth: '0',
+						displayStyle:
+							'ddmTemplate_SITE-MAP-MULTI-COLUMN-LAYOUT-FTL',
+					},
+					widgetName:
+						'com_liferay_site_navigation_site_map_web_portlet_SiteNavigationSiteMapPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: rootLayoutName,
+		});
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+		await pagesAdminPage.createNewPage({
+			name: childLayoutName,
+			parent: rootLayoutName,
+		});
+	});
+
+	await test.step('Set a Root Page in the Site Map Widget configuration', async () => {
+		await pageEditorPage.goto(rootLayout, site.friendlyUrlPath);
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		const configurationIframe = page.frameLocator(
+			'iframe[title="Configuration"]'
+		);
+
+		await configurationIframe.getByRole('button', {name: 'Select'}).click();
+
+		const selectRootPageIframe = configurationIframe.frameLocator('iframe');
+
+		const rootLayoutTreeItem = selectRootPageIframe.locator(
+			'.treeview-link',
+			{hasText: rootLayoutName}
+		);
+
+		await expect(rootLayoutTreeItem).toBeVisible();
+
+		await rootLayoutTreeItem.click();
+
+		await configurationIframe.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			configurationIframe.getByText('Include Root in Tree')
+		).toBeVisible();
+	});
+
+	await test.step('Clear the Root Page and verify it is removed', async () => {
+		const configurationIframe = page.frameLocator(
+			'iframe[title="Configuration"]'
+		);
+
+		await configurationIframe.getByRole('button', {name: 'Remove'}).click();
+
+		await configurationIframe.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			configurationIframe.getByText('Include Root in Tree')
+		).toBeHidden();
+		await expect(
+			configurationIframe.getByText(rootLayoutName)
+		).toBeHidden();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41080

## What Is Being Fixed

The Site Map widget configuration provided no way to clear a Root Page once one had been set. The resource selector had no remove button, and the "Include Root in Tree" container's visibility was tied to the persisted configuration value rather than the current selection.

## How It Is Being Fixed

The resource selector now shows a remove button, letting the user clear the selected Root Page. The "Include Root in Tree" container's visibility is now driven by the resolved `rootLayout` object via `Validator.isNotNull(rootLayout)` — matching the null-check convention already used for the selector's `resourceName` and `resourceValue` in the same file — so the toggle hides as soon as the Root Page is removed. A Playwright test covers setting and then removing the Root Page.

## PR Check

**pr-check: PASS** — tested on `0092aa5771108666e264642b31d52c632c97f5e5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "0092aa5771108666e264642b31d52c632c97f5e5"} -->
