### PR TITLE
LPD-95444 Make severity sortable via numeric list type keys

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-severities-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-scan-insight-severities-list-type-definition.json
@@ -2,26 +2,20 @@
 	"externalReferenceCode": "L_SEO_STUDIO_SCAN_INSIGHT_SEVERITIES",
 	"listTypeEntries": [
 		{
-			"externalReferenceCode": "CRITICAL",
-			"key": "critical",
-			"name": "Critical",
-			"system": true
-		},
-		{
 			"externalReferenceCode": "HIGH",
-			"key": "high",
+			"key": "3",
 			"name": "High",
 			"system": true
 		},
 		{
 			"externalReferenceCode": "LOW",
-			"key": "low",
+			"key": "1",
 			"name": "Low",
 			"system": true
 		},
 		{
 			"externalReferenceCode": "MEDIUM",
-			"key": "medium",
+			"key": "2",
 			"name": "Medium",
 			"system": true
 		}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/insights_view/cell_renderers/ImpactCellRenderer.tsx
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/insights_view/cell_renderers/ImpactCellRenderer.tsx
@@ -6,14 +6,20 @@
 import ClayLabel from '@clayui/label';
 import React from 'react';
 
+enum SEVERITY {
+	HIGH = '3',
+	LOW = '1',
+	MEDIUM = '2',
+}
+
 function getDisplayType(severityKey: string) {
 	switch (severityKey) {
-		case 'critical':
+		case SEVERITY.HIGH:
 			return 'danger';
-		case 'high':
+		case SEVERITY.LOW:
+			return 'secondary';
+		case SEVERITY.MEDIUM:
 			return 'warning';
-		case 'medium':
-			return 'info';
 		default:
 			return 'secondary';
 	}
@@ -33,6 +39,7 @@ export default function ImpactCellRenderer({
 	return (
 		<ClayLabel
 			displayType={getDisplayType(itemData?.severity?.key ?? '')}
+			inverse
 			withClose={false}
 		>
 			{value}

--- a/modules/test/playwright/tests/seo-studio-web/main/insightDetail.spec.ts
+++ b/modules/test/playwright/tests/seo-studio-web/main/insightDetail.spec.ts
@@ -43,7 +43,7 @@ test.beforeEach(async ({apiHelpers, onPagePage, seoStudioSite}) => {
 				type: 'Document',
 			},
 		],
-		severity: 'critical',
+		severity: '3',
 	};
 
 	scan = await apiHelpers.seoStudio.createScan('full');

--- a/modules/test/playwright/tests/seo-studio-web/main/onPage.spec.ts
+++ b/modules/test/playwright/tests/seo-studio-web/main/onPage.spec.ts
@@ -65,13 +65,13 @@ test(
 					'https://example.com/b',
 					'https://example.com/c',
 				],
-				severity: 'critical',
+				severity: '3',
 			},
 			{
 				category: 'images',
 				name: 'missingAltText',
 				pageURLs: ['https://example.com/d', 'https://example.com/e'],
-				severity: 'medium',
+				severity: '2',
 			},
 			{
 				category: 'urls',
@@ -82,7 +82,7 @@ test(
 					'https://example.com/h',
 					'https://example.com/i',
 				],
-				severity: 'high',
+				severity: '3',
 			},
 		];
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95444

## What Is Being Fixed

The insight severity picklist stored text keys (critical, high, medium, low), so ordering insights by severity sorted them alphabetically — critical, high, low, medium — instead of by impact. The Enhanced Insights table needs to present the most severe insights first, which this ordering could not support. Critical was also no longer used.

## How It Is Being Fixed

The severity list type entries are reassigned numeric keys — high=3, medium=2, low=1 — so the picklist sorts by impact directly, and the unused critical entry is removed. The impact badge renderer is updated to map the numeric keys to Clay label display types (high to danger, medium to warning, low to secondary) using the inverse variant, and the existing Playwright specs are updated to seed the new numeric keys.

## Why Are There No Tests?

This change reassigns severity picklist keys and updates the dependent badge renderer; it introduces no behavior that is not already exercised by the existing seo-studio-web Playwright specs (onPage and insightDetail), which are updated in this branch to seed the numeric keys. The sorting behavior these keys enable is delivered and tested under the parent story LPD-91181.

## PR Check

**pr-check: PASS** — tested on `a51f9e06a33f594442233735c8ac49f5fc2eb0c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a51f9e06a33f594442233735c8ac49f5fc2eb0c2"} -->
