### PR TITLE
LPD-95471 Fix the failing FriendlyURLPublicMappingCheckerTest

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
@@ -14,11 +14,13 @@ import com.liferay.layout.friendly.url.LayoutFriendlyURLEntryHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -38,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -60,9 +63,21 @@ public class FriendlyURLPublicMappingCheckerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_defaultGroup = _groupLocalService.fetchGroup(
+		_originalVirtualHostsDefaultSiteName =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PropsValues.class, "VIRTUAL_HOSTS_DEFAULT_SITE_NAME",
+				GroupConstants.GUEST);
+
+		_defaultGroup = _groupLocalService.getGroup(
 			TestPropsValues.getCompanyId(),
 			PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME);
+	}
+
+	@After
+	public void tearDown() {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "VIRTUAL_HOSTS_DEFAULT_SITE_NAME",
+			_originalVirtualHostsDefaultSiteName);
 	}
 
 	@Test
@@ -314,6 +329,8 @@ public class FriendlyURLPublicMappingCheckerTest {
 
 	@DeleteAfterTestRun
 	private final List<Layout> _layouts = new ArrayList<>();
+
+	private String _originalVirtualHostsDefaultSiteName;
 
 	@Inject
 	private SiteFriendlyURLLocalService _siteFriendlyURLLocalService;

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -85,11 +86,14 @@ public class FriendlyURLPublicMappingCheckerTest {
 		throws Exception {
 
 		String defaultLocaleFriendlyURL =
-			StringPool.SLASH + RandomTestUtil.randomString();
+			StringPool.SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 		String nondefaultGroupFriendlyURL =
-			StringPool.SLASH + RandomTestUtil.randomString();
+			StringPool.SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 		String nondefaultLocaleFriendlyURL =
-			StringPool.SLASH + RandomTestUtil.randomString();
+			StringPool.SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		Group group1 = _addGroup();
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/checker/test/FriendlyURLPublicMappingCheckerTest.java
@@ -177,9 +177,12 @@ public class FriendlyURLPublicMappingCheckerTest {
 		for (FriendlyURLPublicMappingConflict friendlyURLPublicMappingConflict :
 				friendlyURLPublicMappingConflicts) {
 
-			Assert.assertEquals(
-				FriendlyURLPublicMappingConflict.TYPE_RESERVED_KEYWORD,
-				friendlyURLPublicMappingConflict.getType());
+			if (!Objects.equals(
+					FriendlyURLPublicMappingConflict.TYPE_RESERVED_KEYWORD,
+					friendlyURLPublicMappingConflict.getType())) {
+
+				continue;
+			}
 
 			String className = friendlyURLPublicMappingConflict.getClassName();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95471

## What Is Being Fixed

FriendlyURLPublicMappingCheckerTest failed on CI with a NullPointerException in all three tests, and failed locally with two assertion errors for different reasons.

The NullPointerException came from resolving the default group through `fetchGroup` with `VIRTUAL_HOSTS_DEFAULT_SITE_NAME`. On CI that property is not "Guest", so `fetchGroup` returned null and the test threw while building the service context. The two local assertion failures were genuine test bugs: the cross-site test compared a verbatim site friendly URL against a layout friendly URL that the system stores lower cased, and the reserved keyword test asserted that every conflict for the keyword was a reserved-keyword conflict when a legitimate cross-site conflict is also produced.

## How It Is Being Fixed

The default group is now resolved by forcing `VIRTUAL_HOSTS_DEFAULT_SITE_NAME` to `GroupConstants.GUEST` for the duration of the test and fetching the company's Guest group, which always exists. This keeps the test and the checker in agreement regardless of how the property is configured on CI.

The cross-site test now lower cases the generated friendly URLs so the test data matches the normalization the system always applies, allowing the conflict to be detected. The reserved keyword test now only inspects reserved-keyword conflicts when verifying that both a group and a layout conflict are present, tolerating the legitimate cross-site conflict on the same URL.

## Why Are There No Tests?

This change only fixes the existing integration test FriendlyURLPublicMappingCheckerTest. There is no production code change, so no additional test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `498ee3dc7f5d34c564dc5661d431d983723af8dc`

| Validation | Result |
| --- | --- |
| Integration Test Compile | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "498ee3dc7f5d34c564dc5661d431d983723af8dc"} -->
