### PR TITLE
LPD-95473 Create CMS Administrator role on demand in SiteResourceTest

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -442,8 +442,14 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		User user = UserTestUtil.addUser(
 			testCompany, RandomTestUtil.randomString());
 
-		Role role = _roleLocalService.getRole(
+		Role role = _roleLocalService.fetchRole(
 			testCompany.getCompanyId(), roleName);
+
+		if (role == null) {
+			role = _roleLocalService.addRole(
+				null, TestPropsValues.getUserId(), null, 0, roleName, null,
+				null, RoleConstants.TYPE_REGULAR, null, null);
+		}
 
 		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95473

## What Is Being Fixed

`SiteResourceTest.testGetSitesPage` failed with `NoSuchRoleException: No Role exists with the key {name=cms administrator}`. The `_addUserWithRegularRole` helper resolved the "CMS Administrator" role through `RoleLocalService.getRole(...)`, which throws when the role is absent. That role is no longer created at portal startup — commit f53ac92a9f345 reverted LPD-83058 and removed `CMS_ADMINISTRATOR` from the `SYSTEM_ROLES` array — so a clean integration-test bundle, which has no CMS site to create it on demand, has no such role and the lookup throws.

## How It Is Being Fixed

The helper now resolves the role with the fetch-or-add pattern already used by `RoleLocalServiceTest` and `BulkActionResourceTest`: `fetchRole` returns null instead of throwing, and the role is created as an empty `TYPE_REGULAR` role when missing. The role carries no permissions even when it exists as a system role, so an empty role reproduces the exact state the test was written against, and site visibility in the assertion does not depend on it.

## PR Check

**pr-check: PASS** — tested on `79f35f42cc0d9161d2e00f30bae9f36c406f4aae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "79f35f42cc0d9161d2e00f30bae9f36c406f4aae"} -->
