### PR TITLE
LPD-95389 Fix CTPreferencesServiceTest permission grant

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -63,10 +64,11 @@ public class CTPreferencesServiceTest {
 
 	@Test
 	public void testCheckoutCTCollectionWithViewPermission() throws Exception {
-		RoleTestUtil.addResourcePermission(
-			_role, CTCollection.class.getName(),
+		ResourcePermissionLocalServiceUtil.setResourcePermissions(
+			_role.getCompanyId(), CTCollection.class.getName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(_ctCollection.getCtCollectionId()), ActionKeys.VIEW);
+			String.valueOf(_ctCollection.getCtCollectionId()),
+			_role.getRoleId(), new String[] {ActionKeys.VIEW});
 
 		UserTestUtil.setUser(_user);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95389

## What Is Being Fixed

`CTPreferencesServiceTest.testCheckoutCTCollectionWithViewPermission` failed with `com.liferay.portal.kernel.exception.NoSuchResourcePermissionException` because it called `RoleTestUtil.addResourcePermission(...)` with `ResourceConstants.SCOPE_INDIVIDUAL`. That helper delegates to `ResourcePermissionLocalServiceUtil.addResourcePermission`, whose implementation rejects `SCOPE_INDIVIDUAL` by design (see `ResourcePermissionLocalServiceImpl.java:322-323` and the javadoc at lines 285-286: "This method only supports company, group, and group-template scope"). The test had never passed since it was added.

## How It Is Being Fixed

Switched the grant to `ResourcePermissionLocalServiceUtil.setResourcePermissions(...)`, which supports `SCOPE_INDIVIDUAL` (its javadoc notes it is "generally only used at the individual scope"). This matches the prevailing convention for individual-scope grants in tests: 86 other test files already call `setResourcePermissions` directly with `SCOPE_INDIVIDUAL`, while zero use the `addResourcePermission` form for that scope.

Verified locally end-to-end: with the fix the test passes; reverting the fix and re-running reproduces the original `NoSuchResourcePermissionException`.

## Why Are There No Tests?

The change repairs an existing integration test that could not pass against the API; no new test coverage is needed because the existing test exercises the fix.

## PR Check

**pr-check: PASS** — tested on `b46d71b9319ed4237218a9e1745447020cbd5643`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b46d71b9319ed4237218a9e1745447020cbd5643"} -->
