### PR TITLE
LPD-95473 Create the CMS Administrator role on demand in SiteResourceTest

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -442,8 +443,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		User user = UserTestUtil.addUser(
 			testCompany, RandomTestUtil.randomString());
 
-		Role role = _roleLocalService.getRole(
-			testCompany.getCompanyId(), roleName);
+		Role role = RoleTestUtil.addRole(roleName, RoleConstants.TYPE_REGULAR);
 
 		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95473

## What Is Being Fixed

SiteResourceTest assumed the CMS Administrator regular role already existed in the test company, so _addUserWithRegularRole failed when the role was absent.

## How It Is Being Fixed

_addUserWithRegularRole now delegates to RoleTestUtil.addRole(roleName, RoleConstants.TYPE_REGULAR), the platform utility that fetches the role or creates it on demand. This replaces the hand-inlined fetch-or-create, matches the convention used by the sibling NavigationMenuResourceTest, and randomizes the role's external reference code.

## PR Check

**pr-check: PASS** — tested on `44c3184958b5b312aa0f8866d314be2a343cac43`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "44c3184958b5b312aa0f8866d314be2a343cac43"} -->
