### PR TITLE
LPD-95389 Fix CTPreferencesServiceTest permission grant

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
@@ -65,8 +65,8 @@ public class CTPreferencesServiceTest {
 	public void testCheckoutCTCollectionWithViewPermission() throws Exception {
 		RoleTestUtil.addResourcePermission(
 			_role, CTCollection.class.getName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(_ctCollection.getCtCollectionId()), ActionKeys.VIEW);
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(_role.getCompanyId()), ActionKeys.VIEW);
 
 		UserTestUtil.setUser(_user);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95389

## What Is Being Fixed

`CTPreferencesServiceTest.testCheckoutCTCollectionWithViewPermission` failed with `com.liferay.portal.kernel.exception.NoSuchResourcePermissionException` because it called `RoleTestUtil.addResourcePermission(...)` with `ResourceConstants.SCOPE_INDIVIDUAL`. That helper delegates to `ResourcePermissionLocalServiceUtil.addResourcePermission`, whose javadoc states it only supports company, group, and group-template scope.

## How It Is Being Fixed

Switched the grant from `SCOPE_INDIVIDUAL` with `ctCollectionId` as primKey to `SCOPE_COMPANY` with `companyId` as primKey, matching the existing pattern in the sibling change-tracking integration tests `AutocompleteUserMVCResourceCommandTest` and `CTCollectionTemplateServiceTest`. The permission check still passes because Liferay resolves the VIEW action at any broader scope.

Verified locally end-to-end: with this fix the test passes; reverting to the original `SCOPE_INDIVIDUAL` call reproduces the `NoSuchResourcePermissionException`.

## Why Are There No Tests?

The change repairs an existing integration test that could not pass against the API; no new test coverage is needed because the existing test exercises the fix.

## PR Check

**pr-check: PASS** — tested on `b1728c3f75ff3ed94a0bc9fd30f2ffe7b75cec01`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b1728c3f75ff3ed94a0bc9fd30f2ffe7b75cec01"} -->
