### PR TITLE
LPD-95475 Fix failing sitemap mapping test

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -1092,12 +1092,10 @@ public class PropsValues {
 	public static final String LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING =
 		PropsUtil.get(PropsKeys.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING);
 
-	public static final boolean
-		LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED =
-			GetterUtil.getBoolean(
-				PropsUtil.get(
-					PropsKeys.
-						LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED));
+	public static boolean LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED));
 
 	public static final boolean LAYOUT_GUEST_SHOW_MAX_ICON =
 		GetterUtil.getBoolean(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95475

## Problem

`SitemapManagerTest.testSitemapURLsWithLayoutFriendlyURLPublicServletMappingDisabled` failed in CI: with `LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED` swapped to `false`, the generated friendly URLs still contained `/web`. The same root cause failed two `PortalImplTest` cases (`testGetLayoutFriendlyURLWithPublicServletMappingDisabled` and `testGetLayoutFriendlyURLWithPublicServletMappingDisabledAndCompanyVirtualHost`). The test only passed when run under a debugger.

## Root Cause

`LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED` was a `static final` field. HotSpot constant-folds initialized `static final` fields into JIT-compiled code, and `PortalImpl`'s URL builders are among the hottest methods in a running portal, so they were compiled with the value folded to `true`. `PropsValuesTestUtil.swapWithSafeCloseable` reflectively rewrites the field but cannot deoptimize the already-compiled readers, so the swap to `false` was invisible and `/web` was still emitted. A debugger breakpoint deoptimizes the method back to the interpreter, which reads the field fresh — which is why it only "passed" while debugging.

## Fix

Drop `final` so the field is no longer constant-folded and the test swap takes effect, leaving it a plain runtime read on the hot path. This follows the precedent of LPS-147709, which made the sibling URL properties `VIRTUAL_HOSTS_DEFAULT_SITE_NAME`, `WEB_SERVER_HTTP_PORT`, and `WEB_SERVER_HTTPS_PORT` non-final for the same JIT inlining reason.

## Tests

- `SitemapManagerTest` — full class passes, including the previously failing `testSitemapURLsWithLayoutFriendlyURLPublicServletMappingDisabled`.
- `PortalImplTest.testGetLayoutFriendlyURLWithPublicServletMappingDisabled` and `testGetLayoutFriendlyURLWithPublicServletMappingDisabledAndCompanyVirtualHost` — pass.
