### PR TITLE
LPD-93368 Add scheduled scan sweeper for Auto Scan

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-domain-object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-domain-object-actions.json
@@ -2,6 +2,19 @@
 	"object-actions": [
 		{
 			"active": true,
+			"conditionExpression": "(oldValue(\"autoScanEnabled\") != autoScanEnabled) || (oldValue(\"scanDayOfMonth\") != scanDayOfMonth) || (oldValue(\"scanDayOfWeek\") != scanDayOfWeek) || (oldValue(\"scanFrequency\") != scanFrequency) || (oldValue(\"scanTime\") != scanTime) || (oldValue(\"scanTimeZone\") != scanTimeZone)",
+			"externalReferenceCode": "L_SEO_STUDIO_DOMAIN_COMPUTE_NEXT_SCAN_DATE",
+			"label": {
+				"en_US": "Compute Next Scan Date"
+			},
+			"name": "computeNextScanDate",
+			"objectActionExecutorKey": "compute-seo-studio-domain-next-scan-date",
+			"objectActionTriggerKey": "onAfterUpdate",
+			"parameters": {
+			}
+		},
+		{
+			"active": true,
 			"errorMessage": {
 				"en_US": "Unable to create the scans. Please try again later or contact support."
 			},

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/03-seo-studio-scan-object-definition.json
@@ -84,6 +84,19 @@
 		},
 		{
 			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SCAN_KEY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Scan Key"
+			},
+			"name": "scanKey",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
 			"businessType": "Picklist",
 			"externalReferenceCode": "SCAN_RANGE",
 			"indexed": true,

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -1,0 +1,277 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@FeatureFlag("LPD-44511")
+@RunWith(Arquillian.class)
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.seo.studio.site.initializer");
+
+		siteInitializer.initialize(_group.getGroupId());
+
+		_seoStudioDomainObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
+		_seoStudioInstanceObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			_objectActionLocalService.deleteObjectAction(objectAction);
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_seoStudioDomainObjectEntry != null) {
+			for (ObjectEntry seoStudioScanObjectEntry :
+					_getSEOStudioScanObjectEntries(
+						_seoStudioDomainObjectEntry)) {
+
+				_objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanObjectEntry.getObjectEntryId());
+			}
+
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioDomainObjectEntry.getObjectEntryId());
+		}
+
+		if (_seoStudioInstanceObjectEntry != null) {
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioInstanceObjectEntry.getObjectEntryId());
+		}
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testExecute() throws Exception {
+		_addSEOStudioDomainObjectEntry(true);
+
+		Date nextScanDate = (Date)_getValues(
+			_seoStudioDomainObjectEntry
+		).get(
+			"nextScanDate"
+		);
+
+		Assert.assertTrue(nextScanDate.after(new Date()));
+	}
+
+	@Test
+	public void testExecuteWithAutoScanDisabled() throws Exception {
+		_addSEOStudioDomainObjectEntry(false);
+
+		Assert.assertNull(
+			_getValues(
+				_seoStudioDomainObjectEntry
+			).get(
+				"nextScanDate"
+			));
+	}
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		return _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _addSEOStudioDomainObjectEntry(boolean autoScanEnabled)
+		throws Exception {
+
+		AccountEntry accountEntry = _addAccountEntry();
+
+		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
+			accountEntry);
+
+		_seoStudioDomainObjectEntry = _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"autoScanEnabled", autoScanEnabled
+			).put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				_seoStudioInstanceObjectEntry.getObjectEntryId()
+			).put(
+				"scanConfig",
+				JSONUtil.put(
+					"engines",
+					JSONUtil.put(
+						"crawler", JSONUtil.put("enabled", true)
+					).put(
+						"pageSpeed", JSONUtil.put("enabled", true)
+					)
+				).toString()
+			).put(
+				"scanFrequency", "daily"
+			).put(
+				"scanTime", "09:00"
+			).put(
+				"scanTimeZone", "UTC"
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private ObjectEntry _addSEOStudioInstanceObjectEntry(
+			AccountEntry accountEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioInstances_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+				"seoStudioDomainToSEOStudioScans");
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioDomainObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private Map<String, Serializable> _getValues(ObjectEntry objectEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+	}
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectActionLocalService _objectActionLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private ObjectDefinition _seoStudioDomainObjectDefinition;
+	private ObjectEntry _seoStudioDomainObjectEntry;
+	private ObjectDefinition _seoStudioInstanceObjectDefinition;
+	private ObjectEntry _seoStudioInstanceObjectEntry;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -5,46 +5,23 @@
 
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
-import com.liferay.account.constants.AccountConstants;
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectAction;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectActionLocalService;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.initializer.SiteInitializer;
-import com.liferay.site.initializer.SiteInitializerRegistry;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +32,8 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
-public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
+	extends BaseSEOStudioTestCase {
 
 	@ClassRule
 	@Rule
@@ -64,214 +42,44 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(
-				"com.liferay.seo.studio.site.initializer");
-
-		siteInitializer.initialize(_group.getGroupId());
-
-		_seoStudioDomainObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
-		_seoStudioInstanceObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
-
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
-
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
-
-			_objectActionLocalService.deleteObjectAction(objectAction);
-		}
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_seoStudioDomainObjectEntry != null) {
-			for (ObjectEntry seoStudioScanObjectEntry :
-					_getSEOStudioScanObjectEntries(
-						_seoStudioDomainObjectEntry)) {
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanObjectEntry.getObjectEntryId());
-			}
-
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioInstanceObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
-		ServiceContextThreadLocal.popServiceContext();
-	}
-
 	@Test
 	public void testExecute() throws Exception {
-		_addSEOStudioDomainObjectEntry(true);
+		addSEOStudioDomainObjectEntry(false);
 
-		Date nextScanDate = (Date)_getValues(
-			_seoStudioDomainObjectEntry
-		).get(
-			"nextScanDate"
-		);
+		_updateAutoScanEnabled(true);
+
+		Map<String, Serializable> values = getValues(
+			seoStudioDomainObjectEntry);
+
+		Date nextScanDate = (Date)values.get("nextScanDate");
 
 		Assert.assertTrue(nextScanDate.after(new Date()));
 	}
 
 	@Test
 	public void testExecuteWithAutoScanDisabled() throws Exception {
-		_addSEOStudioDomainObjectEntry(false);
+		addSEOStudioDomainObjectEntry(false);
 
-		Assert.assertNull(
-			_getValues(
-				_seoStudioDomainObjectEntry
-			).get(
-				"nextScanDate"
-			));
+		_updateAutoScanEnabled(false);
+
+		Map<String, Serializable> values = getValues(
+			seoStudioDomainObjectEntry);
+
+		Assert.assertNull(values.get("nextScanDate"));
 	}
 
-	private AccountEntry _addAccountEntry() throws Exception {
-		return _accountEntryLocalService.addAccountEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
-			RandomTestUtil.randomString(), null, null,
-			RandomTestUtil.randomString() + "@liferay.com", null, null,
-			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
-			WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext());
-	}
-
-	private void _addSEOStudioDomainObjectEntry(boolean autoScanEnabled)
+	private void _updateAutoScanEnabled(boolean autoScanEnabled)
 		throws Exception {
 
-		AccountEntry accountEntry = _addAccountEntry();
-
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
-			accountEntry);
-
-		_seoStudioDomainObjectEntry = _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+		objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(),
+			seoStudioDomainObjectEntry.getObjectEntryId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
 			HashMapBuilder.<String, Serializable>put(
 				"autoScanEnabled", autoScanEnabled
-			).put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioDomains_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).put(
-				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				_seoStudioInstanceObjectEntry.getObjectEntryId()
-			).put(
-				"scanConfig",
-				JSONUtil.put(
-					"engines",
-					JSONUtil.put(
-						"crawler", JSONUtil.put("enabled", true)
-					).put(
-						"pageSpeed", JSONUtil.put("enabled", true)
-					)
-				).toString()
-			).put(
-				"scanFrequency", "daily"
-			).put(
-				"scanTime", "09:00"
-			).put(
-				"scanTimeZone", "UTC"
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
-
-	private ObjectEntry _addSEOStudioInstanceObjectEntry(
-			AccountEntry accountEntry)
-		throws Exception {
-
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioInstances_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScans");
-
-		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioDomainObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-	}
-
-	private Map<String, Serializable> _getValues(ObjectEntry objectEntry)
-		throws Exception {
-
-		return _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-	}
-
-	@Inject
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	private Group _group;
-
-	@Inject
-	private ObjectActionLocalService _objectActionLocalService;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	private ObjectDefinition _seoStudioDomainObjectDefinition;
-	private ObjectEntry _seoStudioDomainObjectEntry;
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectEntry _seoStudioInstanceObjectEntry;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
@@ -5,41 +5,26 @@
 
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
-import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectAction;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectActionLocalService;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.initializer.SiteInitializer;
-import com.liferay.site.initializer.SiteInitializerRegistry;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -47,9 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,7 +43,8 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
-public class CreateSEOStudioScansObjectActionExecutorTest {
+public class CreateSEOStudioScansObjectActionExecutorTest
+	extends BaseSEOStudioTestCase {
 
 	@ClassRule
 	@Rule
@@ -69,77 +53,18 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(
-				"com.liferay.seo.studio.site.initializer");
-
-		siteInitializer.initialize(_group.getGroupId());
-
-		_seoStudioDomainObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
-		_seoStudioInstanceObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
-
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
-
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
-
-			_objectActionLocalService.deleteObjectAction(objectAction);
-		}
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_seoStudioDomainObjectEntry != null) {
-			for (ObjectEntry seoStudioScanObjectEntry :
-					_getSEOStudioScanObjectEntries(
-						_seoStudioDomainObjectEntry)) {
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanObjectEntry.getObjectEntryId());
-			}
-
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioInstanceObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
-		ServiceContextThreadLocal.popServiceContext();
-	}
-
 	@Test
 	public void testExecute() throws Exception {
-		AccountEntry accountEntry = _addAccountEntry();
+		AccountEntry accountEntry = addAccountEntry();
 
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
+		seoStudioInstanceObjectEntry = addSEOStudioInstanceObjectEntry(
 			accountEntry);
 
 		String includedPaths = RandomTestUtil.randomString();
 		int maxPagesPerScan = RandomTestUtil.randomInt();
 		String scope = RandomTestUtil.randomString();
 
-		_seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
 			accountEntry,
 			JSONUtil.put(
 				"engines",
@@ -162,12 +87,12 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 					)
 				)
 			).toString(),
-			_seoStudioInstanceObjectEntry);
+			seoStudioInstanceObjectEntry);
 
-		_executeCreateScans(_seoStudioDomainObjectEntry);
+		_executeCreateScans(seoStudioDomainObjectEntry);
 
 		List<ObjectEntry> seoStudioScanObjectEntries =
-			_getSEOStudioScanObjectEntries(_seoStudioDomainObjectEntry);
+			getSEOStudioScanObjectEntries(seoStudioDomainObjectEntry);
 
 		Assert.assertEquals(
 			seoStudioScanObjectEntries.toString(), 3,
@@ -183,7 +108,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 		ObjectEntry seoStudioScanObjectEntry = seoStudioScanObjectEntryMap.get(
 			"pageSpeed");
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
 			seoStudioScanObjectEntry.getObjectEntryId());
 
 		Assert.assertEquals(
@@ -206,25 +131,14 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 		Assert.assertEquals(scope, scopeConfigJSONObject.getString("scope"));
 	}
 
-	private AccountEntry _addAccountEntry() throws Exception {
-		return _accountEntryLocalService.addAccountEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
-			RandomTestUtil.randomString(), null, null,
-			RandomTestUtil.randomString() + "@liferay.com", null, null,
-			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
-			WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext());
-	}
-
 	private ObjectEntry _addSEOStudioDomainObjectEntry(
 			AccountEntry accountEntry, String scanConfigJSON,
 			ObjectEntry seoStudioInstanceObjectEntry)
 		throws Exception {
 
-		return _objectEntryLocalService.addObjectEntry(
+		return objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
@@ -241,28 +155,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 				"scanConfig", scanConfigJSON
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
-	private ObjectEntry _addSEOStudioInstanceObjectEntry(
-			AccountEntry accountEntry)
-		throws Exception {
-
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioInstances_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	private void _executeCreateScans(ObjectEntry seoStudioDomainObjectEntry)
@@ -270,7 +163,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 
 		_objectActionEngine.executeObjectAction(
 			"createScans", ObjectActionTriggerConstants.KEY_STANDALONE,
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
 			JSONUtil.put(
 				"classPK", seoStudioDomainObjectEntry.getObjectEntryId()
 			).put(
@@ -282,22 +175,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 				).build()
 			),
 			TestPropsValues.getUserId());
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScans");
-
-		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioDomainObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 	}
 
 	private Map<String, ObjectEntry> _getSEOStudioScanObjectEntryMap(
@@ -312,7 +189,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 
 			seoStudioScanObjectEntryMap.put(
 				MapUtil.getString(
-					_objectEntryLocalService.getValues(
+					objectEntryLocalService.getValues(
 						seoStudioScanObjectEntry.getObjectEntryId()),
 					"scanType"),
 				seoStudioScanObjectEntry);
@@ -322,31 +199,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 	}
 
 	@Inject
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	private Group _group;
-
-	@Inject
 	private ObjectActionEngine _objectActionEngine;
-
-	@Inject
-	private ObjectActionLocalService _objectActionLocalService;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	private ObjectDefinition _seoStudioDomainObjectDefinition;
-	private ObjectEntry _seoStudioDomainObjectEntry;
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectEntry _seoStudioInstanceObjectEntry;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scheduler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@FeatureFlag("LPD-44511")
+@RunWith(Arquillian.class)
+public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
+	extends BaseSEOStudioTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testCheckSEOStudioDomainsCreatesScans() throws Exception {
+		addSEOStudioDomainObjectEntry(true);
+
+		_setNextScanDate(
+			new Date(System.currentTimeMillis() - Time.MINUTE),
+			seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		List<ObjectEntry> seoStudioScanObjectEntries =
+			getSEOStudioScanObjectEntries(seoStudioDomainObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanObjectEntries.toString(), 2,
+			seoStudioScanObjectEntries.size());
+
+		for (ObjectEntry seoStudioScanObjectEntry :
+				seoStudioScanObjectEntries) {
+
+			Map<String, Serializable> values =
+				objectEntryLocalService.getValues(
+					seoStudioScanObjectEntry.getObjectEntryId());
+
+			Assert.assertEquals("queued", MapUtil.getString(values, "state"));
+			Assert.assertEquals(
+				"scheduled", MapUtil.getString(values, "triggeredBy"));
+		}
+
+		Map<String, Serializable> values = getValues(
+			seoStudioDomainObjectEntry);
+
+		Date nextScanDate = (Date)values.get("nextScanDate");
+
+		Assert.assertTrue(nextScanDate.after(new Date()));
+	}
+
+	@Test
+	public void testCheckSEOStudioDomainsDoesNotCreateDuplicateScans()
+		throws Exception {
+
+		addSEOStudioDomainObjectEntry(true);
+
+		Date nextScanDate = new Date(System.currentTimeMillis() - Time.MINUTE);
+
+		_setNextScanDate(nextScanDate, seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		Assert.assertEquals(
+			2, _getSEOStudioScanObjectEntriesCount(seoStudioDomainObjectEntry));
+
+		_setNextScanDate(nextScanDate, seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		Assert.assertEquals(
+			2, _getSEOStudioScanObjectEntriesCount(seoStudioDomainObjectEntry));
+	}
+
+	@Test
+	public void testCheckSEOStudioDomainsDoesNotCreateScansForDisabledDomain()
+		throws Exception {
+
+		addSEOStudioDomainObjectEntry(false);
+
+		_setNextScanDate(
+			new Date(System.currentTimeMillis() - Time.MINUTE),
+			seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		Assert.assertEquals(
+			0, _getSEOStudioScanObjectEntriesCount(seoStudioDomainObjectEntry));
+	}
+
+	private int _getSEOStudioScanObjectEntriesCount(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		List<ObjectEntry> seoStudioScanObjectEntries =
+			getSEOStudioScanObjectEntries(seoStudioDomainObjectEntry);
+
+		return seoStudioScanObjectEntries.size();
+	}
+
+	private void _runJob() throws Exception {
+		UnsafeRunnable<Exception> unsafeRunnable =
+			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
+
+		unsafeRunnable.run();
+	}
+
+	private void _setNextScanDate(
+			Date nextScanDate, ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(),
+			seoStudioDomainObjectEntry.getObjectEntryId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate", nextScanDate
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.seo.studio.web.internal.scheduler.CheckSEOStudioDomainsSchedulerJobConfiguration"
+	)
+	private SchedulerJobConfiguration _schedulerJobConfiguration;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * @author Jonathan McCann
+ */
+public abstract class BaseSEOStudioTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalName = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		group = GroupTestUtil.addGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.seo.studio.site.initializer");
+
+		siteInitializer.initialize(group.getGroupId());
+
+		seoStudioDomainObjectDefinition =
+			objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
+		seoStudioInstanceObjectDefinition =
+			objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			objectActionLocalService.deleteObjectAction(objectAction);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+
+		PrincipalThreadLocal.setName(_originalName);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (seoStudioDomainObjectEntry != null) {
+			for (ObjectEntry seoStudioScanObjectEntry :
+					getSEOStudioScanObjectEntries(seoStudioDomainObjectEntry)) {
+
+				objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanObjectEntry.getObjectEntryId());
+			}
+
+			objectEntryLocalService.deleteObjectEntry(
+				seoStudioDomainObjectEntry.getObjectEntryId());
+
+			seoStudioDomainObjectEntry = null;
+		}
+
+		if (seoStudioInstanceObjectEntry != null) {
+			objectEntryLocalService.deleteObjectEntry(
+				seoStudioInstanceObjectEntry.getObjectEntryId());
+
+			seoStudioInstanceObjectEntry = null;
+		}
+	}
+
+	protected AccountEntry addAccountEntry() throws Exception {
+		return accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	protected void addSEOStudioDomainObjectEntry(boolean autoScanEnabled)
+		throws Exception {
+
+		AccountEntry accountEntry = addAccountEntry();
+
+		seoStudioInstanceObjectEntry = addSEOStudioInstanceObjectEntry(
+			accountEntry);
+
+		seoStudioDomainObjectEntry = objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"autoScanEnabled", autoScanEnabled
+			).put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				seoStudioInstanceObjectEntry.getObjectEntryId()
+			).put(
+				"scanConfig",
+				JSONUtil.put(
+					"engines",
+					JSONUtil.put(
+						"crawler", JSONUtil.put("enabled", true)
+					).put(
+						"pageSpeed", JSONUtil.put("enabled", true)
+					)
+				).toString()
+			).put(
+				"scanFrequency", "daily"
+			).put(
+				"scanTime", "09:00"
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	protected ObjectEntry addSEOStudioInstanceObjectEntry(
+			AccountEntry accountEntry)
+		throws Exception {
+
+		return objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioInstances_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	protected List<ObjectEntry> getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			objectRelationshipLocalService.fetchObjectRelationship(
+				seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+				"seoStudioDomainToSEOStudioScans");
+
+		return objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioDomainObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	protected Map<String, Serializable> getValues(ObjectEntry objectEntry)
+		throws Exception {
+
+		return objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+	}
+
+	protected static Group group;
+
+	@Inject
+	protected static ObjectActionLocalService objectActionLocalService;
+
+	@Inject
+	protected static ObjectDefinitionLocalService objectDefinitionLocalService;
+
+	protected static ObjectDefinition seoStudioDomainObjectDefinition;
+	protected static ObjectDefinition seoStudioInstanceObjectDefinition;
+
+	@Inject
+	protected static SiteInitializerRegistry siteInitializerRegistry;
+
+	@Inject
+	protected AccountEntryLocalService accountEntryLocalService;
+
+	@Inject
+	protected ObjectEntryLocalService objectEntryLocalService;
+
+	@Inject
+	protected ObjectRelationshipLocalService objectRelationshipLocalService;
+
+	protected ObjectEntry seoStudioDomainObjectEntry;
+	protected ObjectEntry seoStudioInstanceObjectEntry;
+
+	private static String _originalName;
+	private static PermissionChecker _originalPermissionChecker;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor;
+
+import com.liferay.object.action.executor.BaseObjectActionExecutor;
+import com.liferay.object.action.executor.ObjectActionExecutor;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.scope.ObjectDefinitionScoped;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.seo.studio.web.internal.util.SEOStudioScanScheduleUtil;
+
+import java.io.Serializable;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = ObjectActionExecutor.class)
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl
+	extends BaseObjectActionExecutor implements ObjectDefinitionScoped {
+
+	@Override
+	public List<String> getAllowedObjectDefinitionNames() {
+		return List.of("SEOStudioDomain");
+	}
+
+	@Override
+	public String getKey() {
+		return "compute-seo-studio-domain-next-scan-date";
+	}
+
+	@Override
+	protected void doExecute(
+			long companyId, long objectActionId,
+			UnicodeProperties parametersUnicodeProperties,
+			JSONObject payloadJSONObject, long userId)
+		throws Exception {
+
+		long seoStudioDomainId = payloadJSONObject.getLong("classPK");
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			seoStudioDomainId);
+
+		Date nextScanDate = null;
+
+		if (MapUtil.getBoolean(values, "autoScanEnabled")) {
+			nextScanDate = SEOStudioScanScheduleUtil.getNextScanDate(
+				Instant.now(), MapUtil.getInteger(values, "scanDayOfMonth"),
+				MapUtil.getString(values, "scanDayOfWeek"),
+				MapUtil.getString(values, "scanFrequency"),
+				MapUtil.getString(values, "scanTime"),
+				MapUtil.getString(values, "scanTimeZone"));
+		}
+
+		if (Objects.equals(nextScanDate, values.get("nextScanDate"))) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			userId, seoStudioDomainId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate", nextScanDate
+			).build(),
+			serviceContext);
+	}
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
@@ -7,24 +7,12 @@ package com.liferay.seo.studio.web.internal.object.action.executor;
 
 import com.liferay.object.action.executor.BaseObjectActionExecutor;
 import com.liferay.object.action.executor.ObjectActionExecutor;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.scope.ObjectDefinitionScoped;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.web.internal.scan.SEOStudioScanCreator;
 
-import java.io.Serializable;
-
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,99 +41,11 @@ public class CreateSEOStudioScansObjectActionExecutorImpl
 			JSONObject payloadJSONObject, long userId)
 		throws Exception {
 
-		long seoStudioDomainId = payloadJSONObject.getLong("classPK");
-
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			seoStudioDomainId);
-
-		String scanConfigJSON = GetterUtil.getString(values.get("scanConfig"));
-
-		if (Validator.isNull(scanConfigJSON)) {
-			return;
-		}
-
-		JSONObject scanConfigJSONObject = _jsonFactory.createJSONObject(
-			scanConfigJSON);
-
-		JSONObject enginesJSONObject = scanConfigJSONObject.getJSONObject(
-			"engines");
-
-		if (enginesJSONObject == null) {
-			return;
-		}
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", companyId);
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setCompanyId(companyId);
-		serviceContext.setUserId(userId);
-
-		for (String engineKey : enginesJSONObject.keySet()) {
-			JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
-				engineKey);
-
-			if ((engineJSONObject == null) ||
-				!engineJSONObject.getBoolean("enabled")) {
-
-				continue;
-			}
-
-			_objectEntryLocalService.addObjectEntry(
-				0, userId, objectDefinition.getObjectDefinitionId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"name",
-					engineKey + " - " +
-						GetterUtil.getString(values.get("hostname"))
-				).put(
-					"r_accountToSEOStudioScans_accountEntryId",
-					GetterUtil.getLong(
-						values.get(
-							"r_accountToSEOStudioDomains_accountEntryId"))
-				).put(
-					"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId",
-					seoStudioDomainId
-				).put(
-					"requestDate", new Date()
-				).put(
-					"scanRange", "full"
-				).put(
-					"scanScope", "entireDomain"
-				).put(
-					"scanType", engineKey
-				).put(
-					"scopeConfig",
-					() -> {
-						JSONObject scopeConfigJSONObject =
-							_jsonFactory.createJSONObject(
-								engineJSONObject.toString());
-
-						scopeConfigJSONObject.remove("enabled");
-
-						return scopeConfigJSONObject.toString();
-					}
-				).put(
-					"triggeredBy", "manual"
-				).put(
-					"triggeringUserId", userId
-				).build(),
-				serviceContext);
-		}
+		_seoStudioScanCreator.createScans(
+			payloadJSONObject.getLong("classPK"), "manual", userId);
 	}
 
 	@Reference
-	private JSONFactory _jsonFactory;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
+	private SEOStudioScanCreator _seoStudioScanCreator;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scan;
+
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = SEOStudioScanCreator.class)
+public class SEOStudioScanCreator {
+
+	public void createScans(
+			long seoStudioDomainId, String triggeredBy, long userId)
+		throws Exception {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			seoStudioDomainId);
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		String scanConfigJSON = GetterUtil.getString(values.get("scanConfig"));
+
+		if (Validator.isNull(scanConfigJSON)) {
+			return;
+		}
+
+		JSONObject scanConfigJSONObject = _jsonFactory.createJSONObject(
+			scanConfigJSON);
+
+		JSONObject enginesJSONObject = scanConfigJSONObject.getJSONObject(
+			"engines");
+
+		if (enginesJSONObject == null) {
+			return;
+		}
+
+		long companyId = objectEntry.getCompanyId();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", companyId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		for (String engineKey : enginesJSONObject.keySet()) {
+			JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
+				engineKey);
+
+			if ((engineJSONObject == null) ||
+				!engineJSONObject.getBoolean("enabled")) {
+
+				continue;
+			}
+
+			_objectEntryLocalService.addObjectEntry(
+				0, userId, objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"name",
+					engineKey + " - " +
+						GetterUtil.getString(values.get("hostname"))
+				).put(
+					"r_accountToSEOStudioScans_accountEntryId",
+					GetterUtil.getLong(
+						values.get(
+							"r_accountToSEOStudioDomains_accountEntryId"))
+				).put(
+					"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId",
+					seoStudioDomainId
+				).put(
+					"requestDate", new Date()
+				).put(
+					"scanRange", "full"
+				).put(
+					"scanScope", "entireDomain"
+				).put(
+					"scanType", engineKey
+				).put(
+					"scopeConfig",
+					() -> {
+						JSONObject scopeConfigJSONObject =
+							_jsonFactory.createJSONObject(
+								engineJSONObject.toString());
+
+						scopeConfigJSONObject.remove("enabled");
+
+						return scopeConfigJSONObject.toString();
+					}
+				).put(
+					"triggeredBy", triggeredBy
+				).put(
+					"triggeringUserId", userId
+				).build(),
+				serviceContext);
+		}
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
@@ -10,14 +10,22 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
+
+import java.text.Format;
 
 import java.util.Date;
 import java.util.Map;
@@ -32,7 +40,8 @@ import org.osgi.service.component.annotations.Reference;
 public class SEOStudioScanCreator {
 
 	public void createScans(
-			long seoStudioDomainId, String triggeredBy, long userId)
+			Date scheduledScanDate, long seoStudioDomainId, String triggeredBy,
+			long userId)
 		throws Exception {
 
 		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
@@ -78,6 +87,17 @@ public class SEOStudioScanCreator {
 				continue;
 			}
 
+			String scanKey = null;
+
+			if (scheduledScanDate != null) {
+				scanKey = _getScanKey(
+					engineKey, scheduledScanDate, seoStudioDomainId);
+
+				if (_hasScan(objectDefinition, scanKey)) {
+					continue;
+				}
+			}
+
 			_objectEntryLocalService.addObjectEntry(
 				0, userId, objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
@@ -97,6 +117,8 @@ public class SEOStudioScanCreator {
 					seoStudioDomainId
 				).put(
 					"requestDate", new Date()
+				).put(
+					"scanKey", scanKey
 				).put(
 					"scanRange", "full"
 				).put(
@@ -123,6 +145,42 @@ public class SEOStudioScanCreator {
 		}
 	}
 
+	public void createScans(
+			long seoStudioDomainId, String triggeredBy, long userId)
+		throws Exception {
+
+		createScans(null, seoStudioDomainId, triggeredBy, userId);
+	}
+
+	private String _getScanKey(
+		String engineKey, Date scheduledScanDate, long seoStudioDomainId) {
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddHHmm", TimeZoneUtil.getTimeZone("UTC"));
+
+		return StringBundler.concat(
+			seoStudioDomainId, StringPool.UNDERLINE, engineKey,
+			StringPool.UNDERLINE, format.format(scheduledScanDate));
+	}
+
+	private boolean _hasScan(ObjectDefinition objectDefinition, String scanKey)
+		throws Exception {
+
+		Column<?, String> column =
+			(Column<?, String>)_objectFieldLocalService.getColumn(
+				objectDefinition.getObjectDefinitionId(), "scanKey");
+
+		long objectEntriesCount =
+			_objectEntryLocalService.getObjectEntriesCount(
+				0, null, objectDefinition, column.eq(scanKey));
+
+		if (objectEntriesCount > 0) {
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference
 	private JSONFactory _jsonFactory;
 
@@ -131,5 +189,8 @@ public class SEOStudioScanCreator {
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scheduler;
+
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.seo.studio.web.internal.scan.SEOStudioScanCreator;
+import com.liferay.seo.studio.web.internal.util.SEOStudioScanScheduleUtil;
+
+import java.io.Serializable;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = SchedulerJobConfiguration.class)
+public class CheckSEOStudioDomainsSchedulerJobConfiguration
+	implements SchedulerJobConfiguration {
+
+	@Override
+	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
+		return () -> _companyLocalService.forEachCompanyId(
+			this::_checkSEOStudioDomains);
+	}
+
+	@Override
+	public TriggerConfiguration getTriggerConfiguration() {
+		return TriggerConfiguration.createTriggerConfiguration(
+			5, TimeUnit.MINUTE);
+	}
+
+	private void _checkSEOStudioDomains(long companyId) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-44511")) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", companyId);
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		Column<?, Boolean> autoScanEnabledColumn =
+			(Column<?, Boolean>)_objectFieldLocalService.getColumn(
+				objectDefinition.getObjectDefinitionId(), "autoScanEnabled");
+		Column<?, Date> nextScanDateColumn =
+			(Column<?, Date>)_objectFieldLocalService.getColumn(
+				objectDefinition.getObjectDefinitionId(), "nextScanDate");
+
+		List<Long> seoStudioDomainIds = _objectEntryLocalService.getPrimaryKeys(
+			new Long[] {0L}, companyId, 0,
+			objectDefinition.getObjectDefinitionId(),
+			autoScanEnabledColumn.eq(
+				true
+			).and(
+				nextScanDateColumn.lte(new Date())
+			),
+			false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (long seoStudioDomainId : seoStudioDomainIds) {
+			try {
+				_createSEOStudioScans(seoStudioDomainId);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to create scans for SEO Studio domain " +
+						seoStudioDomainId,
+					exception);
+			}
+		}
+	}
+
+	private void _createSEOStudioScans(long seoStudioDomainId)
+		throws Exception {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			seoStudioDomainId);
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long userId = objectEntry.getUserId();
+
+		_seoStudioScanCreator.createScans(
+			(Date)values.get("nextScanDate"), seoStudioDomainId, "scheduled",
+			userId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(objectEntry.getCompanyId());
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			userId, seoStudioDomainId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate",
+				SEOStudioScanScheduleUtil.getNextScanDate(
+					Instant.now(), MapUtil.getInteger(values, "scanDayOfMonth"),
+					MapUtil.getString(values, "scanDayOfWeek"),
+					MapUtil.getString(values, "scanFrequency"),
+					MapUtil.getString(values, "scanTime"),
+					MapUtil.getString(values, "scanTimeZone"))
+			).build(),
+			serviceContext);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CheckSEOStudioDomainsSchedulerJobConfiguration.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private SEOStudioScanCreator _seoStudioScanCreator;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtil.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtil.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.time.DateTimeException;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+
+import java.util.Date;
+
+/**
+ * @author Jonathan McCann
+ */
+public class SEOStudioScanScheduleUtil {
+
+	public static Date getNextScanDate(
+		Instant instant, Integer scanDayOfMonth, String scanDayOfWeek,
+		String scanFrequency, String scanTime, String scanTimeZone) {
+
+		if (Validator.isNull(scanFrequency) || Validator.isNull(scanTime)) {
+			return null;
+		}
+
+		LocalTime localTime = _getLocalTime(scanTime);
+
+		if (localTime == null) {
+			return null;
+		}
+
+		ZoneId zoneId = _getZoneId(scanTimeZone);
+
+		ZonedDateTime currentZonedDateTime = instant.atZone(zoneId);
+
+		ZonedDateTime nextZonedDateTime = null;
+
+		if (scanFrequency.equals("daily")) {
+			LocalDate localDate = currentZonedDateTime.toLocalDate();
+
+			nextZonedDateTime = _getZonedDateTime(localDate, localTime, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localDate.plusDays(1), localTime, zoneId);
+			}
+		}
+		else if (scanFrequency.equals("weekly")) {
+			DayOfWeek dayOfWeek = _getDayOfWeek(scanDayOfWeek);
+
+			if (dayOfWeek == null) {
+				return null;
+			}
+
+			LocalDate localDate = currentZonedDateTime.toLocalDate();
+
+			localDate = localDate.with(TemporalAdjusters.nextOrSame(dayOfWeek));
+
+			nextZonedDateTime = _getZonedDateTime(localDate, localTime, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localDate.plusWeeks(1), localTime, zoneId);
+			}
+		}
+		else if (scanFrequency.equals("monthly")) {
+			if ((scanDayOfMonth == null) || (scanDayOfMonth < 1)) {
+				return null;
+			}
+
+			YearMonth yearMonth = YearMonth.from(currentZonedDateTime);
+
+			nextZonedDateTime = _getZonedDateTime(
+				localTime, scanDayOfMonth, yearMonth, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localTime, scanDayOfMonth, yearMonth.plusMonths(1), zoneId);
+			}
+		}
+		else {
+			return null;
+		}
+
+		return Date.from(nextZonedDateTime.toInstant());
+	}
+
+	private static DayOfWeek _getDayOfWeek(String scanDayOfWeek) {
+		if (Validator.isNull(scanDayOfWeek)) {
+			return null;
+		}
+
+		if (scanDayOfWeek.equals("SU")) {
+			return DayOfWeek.SUNDAY;
+		}
+		else if (scanDayOfWeek.equals("MO")) {
+			return DayOfWeek.MONDAY;
+		}
+		else if (scanDayOfWeek.equals("TU")) {
+			return DayOfWeek.TUESDAY;
+		}
+		else if (scanDayOfWeek.equals("WE")) {
+			return DayOfWeek.WEDNESDAY;
+		}
+		else if (scanDayOfWeek.equals("TH")) {
+			return DayOfWeek.THURSDAY;
+		}
+		else if (scanDayOfWeek.equals("FR")) {
+			return DayOfWeek.FRIDAY;
+		}
+		else if (scanDayOfWeek.equals("SA")) {
+			return DayOfWeek.SATURDAY;
+		}
+
+		return null;
+	}
+
+	private static LocalTime _getLocalTime(String scanTime) {
+		try {
+			return LocalTime.parse(
+				scanTime, DateTimeFormatter.ofPattern("HH:mm"));
+		}
+		catch (DateTimeParseException dateTimeParseException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(dateTimeParseException);
+			}
+
+			return null;
+		}
+	}
+
+	private static ZonedDateTime _getZonedDateTime(
+		LocalDate localDate, LocalTime localTime, ZoneId zoneId) {
+
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			localDate, localTime, zoneId);
+
+		return zonedDateTime.withLaterOffsetAtOverlap();
+	}
+
+	private static ZonedDateTime _getZonedDateTime(
+		LocalTime localTime, int scanDayOfMonth, YearMonth yearMonth,
+		ZoneId zoneId) {
+
+		int dayOfMonth = Math.min(scanDayOfMonth, yearMonth.lengthOfMonth());
+
+		return _getZonedDateTime(
+			yearMonth.atDay(dayOfMonth), localTime, zoneId);
+	}
+
+	private static ZoneId _getZoneId(String scanTimeZone) {
+		if (Validator.isNull(scanTimeZone)) {
+			return ZoneId.of("UTC");
+		}
+
+		try {
+			return ZoneId.of(scanTimeZone);
+		}
+		catch (DateTimeException dateTimeException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(dateTimeException);
+			}
+
+			return ZoneId.of("UTC");
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SEOStudioScanScheduleUtil.class);
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/test/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtilTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/test/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtilTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.util;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAdjusters;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jonathan McCann
+ */
+public class SEOStudioScanScheduleUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetNextScanDateDaily() {
+		LocalDate localDate = LocalDate.of(2026, Month.JANUARY, 1);
+
+		Assert.assertEquals(
+			_toDate(localDate, 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 8), null, null, "daily", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 2), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 9), null, null, "daily", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 2), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 10), null, null, "daily", "09:00",
+				"UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringDST() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JULY, 2), 13),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JULY, 1), 20), null, null,
+				"daily", "09:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringFallBackOverlap() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.NOVEMBER, 1), 6),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.NOVEMBER, 1), 5, 30), null,
+				null, "daily", "01:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringNoDST() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 2), 14),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 1), 20), null,
+				null, "daily", "09:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringSpringForwardGap() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.MARCH, 9), 6),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.MARCH, 8), 12), null, null,
+				"daily", "02:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateMonthly() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 15), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 1), 8), 15, null,
+				"monthly", "09:00", "UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateMonthlyWhenDayOfMonthExceedsMonthLength() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.FEBRUARY, 28), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 31), 10), 31, null,
+				"monthly", "09:00", "UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateWeekly() {
+		LocalDate localDate = LocalDate.of(2026, Month.JANUARY, 1);
+
+		LocalDate wednesdayLocalDate = localDate.with(
+			TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
+
+		Instant instant = _toInstant(wednesdayLocalDate, 8);
+
+		Assert.assertEquals(
+			_toDate(
+				wednesdayLocalDate.with(
+					TemporalAdjusters.next(DayOfWeek.MONDAY)),
+				9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				instant, null, "MO", "weekly", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(wednesdayLocalDate, 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				instant, null, "WE", "weekly", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(wednesdayLocalDate.plusWeeks(1), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(wednesdayLocalDate, 10), null, "WE", "weekly",
+				"09:00", "UTC"));
+	}
+
+	private Date _toDate(LocalDate localDate, int hour) {
+		return Date.from(_toInstant(localDate, hour));
+	}
+
+	private Instant _toInstant(LocalDate localDate, int hour) {
+		return _toInstant(localDate, hour, 0);
+	}
+
+	private Instant _toInstant(LocalDate localDate, int hour, int minute) {
+		LocalDateTime localDateTime = localDate.atTime(hour, minute);
+
+		return localDateTime.toInstant(ZoneOffset.UTC);
+	}
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1187,6 +1187,7 @@
         modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal,\
         modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java,\
         modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal,\
+        modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java,\
         modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository,\
         modules/extender/internal/resolution/BrowserModulesResolver.java,\
         modules/extender/internal/servlet/JSResolveModulesServlet.java,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93368

## What Is Being Fixed

SEO Studio's Auto Scan let a domain be configured with a schedule (frequency, time, timezone, and enabled engines), but nothing acted on that schedule. There was no computation of when a domain was next due, and no mechanism to create scans when that time arrived, so Auto Scan never actually ran. This is subtask 4 of LPD-92309.

## How It Is Being Fixed

A `scanKey` field is added to the scan object to serve as a deterministic, per-slot idempotency token. A new `SEOStudioScanScheduleUtil` computes a domain's next scan date from its frequency/day/time/timezone, handling daily, weekly, and monthly cadences along with DST gaps, fall-back overlaps, and month-length clamping. A `computeNextScanDate` object action recomputes `nextScanDate` on save, gated by a condition so it only fires when a schedule field actually changes.

Scan creation is extracted into a reusable `SEOStudioScanCreator` shared by the existing manual path and the new scheduled path. A cluster-single (`MEMORY_CLUSTERED`) `SchedulerJobConfiguration` runs every five minutes, queries domains whose indexed `nextScanDate` is due, creates a queued scan (`triggeredBy=scheduled`) for each enabled engine, skips duplicates for a slot via the deterministic `scanKey`, and advances `nextScanDate` to the next occurrence. The scan key is derived from the stored slot date rather than the fire time, so a crash between creating scans and advancing the date is recovered safely on the next sweep.

Coverage includes unit tests for the schedule computation (including DST and month-length edges) and integration tests for both object-action executors and the scheduler job, sharing a new `BaseSEOStudioTestCase`.

## PR Check

**pr-check: PASS** — tested on `5454206da70c259d082442ad6b5bfba05bfb42ef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5454206da70c259d082442ad6b5bfba05bfb42ef"} -->
