### PR TITLE
LPD-95829 Switch call to utilize _groupService instead

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -117,7 +117,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+		Group group = _groupService.getGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
 
 		File file = _siteInitializerSerializer.serialize(group.getGroupId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95829

## What Is Being Fixed

The site initializer export endpoint did not resolve the target site
through the permission-checked service that the rest of this resource
already uses.

## How It Is Being Fixed

Resolve the group through `_groupService` instead of `_groupLocalService`,
matching the existing usage elsewhere in the same resource.

## Why Are There No Tests?

The generated `getSiteSiteInitializer` integration test is an `@Ignore`d
no-op, and the endpoint sits behind the `LPD-19870` feature flag. This is a
one-line swap to a permission-checked service call already used elsewhere
in the same resource.

## PR Check

**pr-check: PASS** — tested on `f94db6c06f959d0fdc0b7059dea2c9131c4d839f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f94db6c06f959d0fdc0b7059dea2c9131c4d839f"} -->
