### PR TITLE
LPD-95831 Scope site keyword duplicate check to the current site

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -1053,6 +1053,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 					existingKeyword = page.fetchFirstItem();
 				}
 				else {
+					groupId = serviceContext.getScopeGroupId();
+
 					Page<Keyword> page = keywordResource.getSiteKeywordsPage(
 						groupId, null, null,
 						keywordResource.toFilter(
@@ -1060,8 +1062,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 						null, null);
 
 					existingKeyword = page.fetchFirstItem();
-
-					groupId = serviceContext.getScopeGroupId();
 				}
 
 				if (existingKeyword != null) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95831

## What Is Being Fixed

When a site initializer ships a site-scoped keyword (`keywords/group/keywords.json`), the keyword is created on the first site but silently skipped on every later site in the same company that shares the keyword name. In `BundleSiteInitializer._addKeywords`, the site branch is entered because `groupId == 0`, and the duplicate-existence check calls `getSiteKeywordsPage` with that `0`. A `0` group id does not scope the query to a site — it degrades the lookup to a company-wide search by name, so a keyword already present on another site matches and the iteration is skipped. The skipped iteration also never registers the keyword's `_KEYWORD_ID` replacement token, leaving it unresolved for any content that references it.

## How It Is Being Fixed

The `groupId = serviceContext.getScopeGroupId()` assignment is moved above the lookup so the existence check runs against the current site's group id rather than `0`. Scoped correctly, the check finds only keywords already in the current site, so each site creates its own keyword and the replacement token is registered.

## Why Are There No Tests?

The existing BundleSiteInitializerTest runs both test bundles into a single shared group, so it only covers same-group re-runs — which dedup correctly even with the bug. Reproducing this defect requires a second group in the same company plus a full second initialize of the bundle, which is not worth bolting onto that test for a one-line scope fix. The fix was verified manually: a keyword that is created on the first site is now also created on a second site initialized from the same bundle.

## PR Check

**pr-check: PASS** — tested on `f5e7473e2dabe0cc067592f9055f7a9c0ab65e1b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f5e7473e2dabe0cc067592f9055f7a9c0ab65e1b"} -->
