### PR TITLE
LPD-96018 Escape the portlet title in the synchronize screen

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/init.jsp
@@ -13,6 +13,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.model.Group" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@
 		<aui:form action="<%= synchronizeSiteInitializerActionURL %>" method="post" name="fm">
 			<clay:sheet-header>
 				<div class="sheet-title">
-					<%= portletDisplay.getTitle() %>
+					<%= HtmlUtil.escape(portletDisplay.getTitle()) %>
 				</div>
 			</clay:sheet-header>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96018

## What Is Being Fixed

The Site Initializer Extender synchronize screen (`view.jsp`) wrote the portlet title into the page with `<%= portletDisplay.getTitle() %>` and no `HtmlUtil.escape`. `getTitle()` returns the configurable `portletSetupTitle_<languageId>` preference verbatim, so a configured title reached the rendered markup unencoded. This is the only JSP in the repository that emits `portletDisplay.getTitle()` without escaping — every other emission site (`frontend-taglib` fieldset, `portal-web` aui fieldset and form, `site-navigation-breadcrumb-web`, `portlet-configuration-web` edit_sharing) wraps it in `HtmlUtil.escape`.

## How It Is Being Fixed

Wrap the title in `HtmlUtil.escape` in `view.jsp` and add the `HtmlUtil` import to `init.jsp`, bringing the JSP in line with the escaping convention every other emission site already follows.

## Why Are There No Tests?

This is a one-line JSP output-encoding change. JSP scriptlet escaping is not unit-testable, and the affected portlet is a hidden control-panel panel app whose custom-title preference UI is not reachable, so there is no UI-level path to assert against in an integration or Playwright test. The change is verified by JSP compilation and by matching the established escaping convention.

## PR Check

**pr-check: PASS** — tested on `161b731e71825b04db93942179bfb5ae06377109`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "161b731e71825b04db93942179bfb5ae06377109"} -->
