### PR TITLE
LPD-96041 Fix My Sites tags test broken by categorization locators

### DIFF
--- a/modules/test/playwright/tests/site-my-sites-web/main/mySitesWidget.spec.ts
+++ b/modules/test/playwright/tests/site-my-sites-web/main/mySitesWidget.spec.ts
@@ -459,7 +459,7 @@ test('Assert that site tags appear in My Sites widget', async ({
 
 	await page.getByRole('menuitem', {name: 'Categorization'}).click();
 
-	const tagInputField = page.getByLabel('Tags', {exact: true});
+	const tagInputField = page.getByRole('combobox', {name: 'Tags'});
 
 	const tags = ['apple', 'banana', 'mango'];
 
@@ -469,7 +469,7 @@ test('Assert that site tags appear in My Sites widget', async ({
 		await tagInputField.press('Enter');
 	}
 
-	await page.getByLabel('Topic', {exact: true}).click();
+	await tagInputField.press('Escape');
 
 	await page.getByText('Save').click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96041

## What Is Being Fixed

The Playwright test "Assert that site tags appear in My Sites widget" (`modules/test/playwright/tests/site-my-sites-web/main/mySitesWidget.spec.ts`) was failing with a strict-mode locator violation. The asset categorization MultiSelect widgets now wrap their input in a labelled `div[role=grid]` container that shares the same `aria-labelledby` as the underlying input, so `getByLabel('Tags', {exact: true})` and `getByLabel('Topic', {exact: true})` each resolved to two elements and threw.

## How It Is Being Fixed

The Tags input is now targeted by role with `getByRole('combobox', {name: 'Tags'})`, matching the pattern already used elsewhere in the suite. The subsequent click on the "Topic" field — which only existed to blur the Tags input and dismiss its open autocomplete dropdown before saving, and which no longer renders as an editable combobox — is replaced with `tagInputField.press('Escape')`. The test now passes.

## Why Are There No Tests?

This change is itself a fix to an existing Playwright test; the modified spec is the test coverage and was verified to pass locally.

## PR Check

**pr-check: PASS** — tested on `6930b3d08617eb474918cbe81dc2fdf3c94cdfac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "6930b3d08617eb474918cbe81dc2fdf3c94cdfac"} -->
