### PR TITLE
LPD-95832 Import fragments before layout content and page templates

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -5446,14 +5446,14 @@ public class BundleSiteInitializer implements SiteInitializer {
 			addLayoutPageTemplatesR,
 			_dependsOn(
 				addOrUpdateBlogPostingsR, addCPDefinitionsR,
-				addOrUpdateClientExtensionEntriesR, addOrUpdateJournalArticlesR,
-				addOrUpdateSXPBlueprintR)
+				addOrUpdateClientExtensionEntriesR, addFragmentEntriesR,
+				addOrUpdateJournalArticlesR, addOrUpdateSXPBlueprintR)
 		).put(
 			addLayoutUtilityPageEntriesR,
 			_dependsOn(
 				addOrUpdateBlogPostingsR, addCPDefinitionsR,
-				addOrUpdateClientExtensionEntriesR, addOrUpdateJournalArticlesR,
-				addOrUpdateSXPBlueprintR)
+				addOrUpdateClientExtensionEntriesR, addFragmentEntriesR,
+				addOrUpdateJournalArticlesR, addOrUpdateSXPBlueprintR)
 		).put(
 			addObjectDefinitionsR,
 			_dependsOn(
@@ -5495,7 +5495,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 			addOrUpdateKnowledgeBaseArticlesR,
 			_dependsOn(addOrUpdateExpandoColumnsR)
 		).put(
-			addOrUpdateLayoutsContentR, _dependsOn(addLayoutPageTemplatesR)
+			addOrUpdateLayoutsContentR,
+			_dependsOn(addFragmentEntriesR, addLayoutPageTemplatesR)
 		).put(
 			addOrUpdateLayoutsR, _dependsOn(addOrUpdateRolesR)
 		).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95832

## What Is Being Fixed

A site initializer could produce silently blank pages. When an initializer ships fragments together with a content page, page template, or utility page that references those fragments, the page content could be imported before the fragment entries existed. The layouts importer accepted the dangling fragment-entry key without complaint, the fragment was created too late to back the page element, and the page rendered blank with no error or warning logged. Whether it happened depended on undefined import ordering, so it surfaced intermittently across runs and JVMs.

## How It Is Being Fixed

The initializer runs its import steps through a dependency graph in `_createRMap`, scheduled topologically over a `HashMap`. No edge required `addFragmentEntries` to run before the steps that import `page-definition.json`, and nothing depended on `addFragmentEntries` at all, so the scheduler was free to import layout content first. This change adds `addFragmentEntries` as a dependency of the three steps that import page definitions — `addOrUpdateLayoutsContent`, `addLayoutPageTemplates`, and `addLayoutUtilityPageEntries` — guaranteeing fragments are imported first regardless of iteration order. No cycle is introduced, since the prerequisites of `addFragmentEntries` never reach those importers.

## Why Are There No Tests?

The defect is import-ordering nondeterminism driven by HashMap iteration order. An end-to-end "render the page" test is flaky in the failing direction: on JVMs whose iteration order already imports fragments first (the case on the development machine), it passes even with the fix reverted, so it is worthless as a regression guard. The meaningful test is a structural assertion on the dependency graph (fragments are a transitive prerequisite of every page-definition importer), but the graph is a private member behind constructor-injected services, so asserting it requires a reflection seam that was judged out of scope here. Correctness is instead established by topological analysis — no cycle, and fragments precede all three importers in every valid ordering — and verified end-to-end: forcing the bad order reproduced the blank page, the corrected order rendered it, and the existing BundleSiteInitializerTest integration suite passes.

## PR Check

**pr-check: PASS** — tested on `da70c68a873b229ba5ef4e374662dd1dcea79e7b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "da70c68a873b229ba5ef4e374662dd1dcea79e7b"} -->
