### PR TITLE
LPD-88837 Add Liferay Headless client and PageSpeed value classes

### DIFF
--- a/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
@@ -24,6 +24,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
@@ -47,7 +47,7 @@ test('Generate a new token after expired', async ({
 			const rowToken = page.getByTestId(`row-token-${tokenId}`);
 
 			expect(await rowToken.textContent()).toBe(
-				`Token ending in${tokenId}Expired`
+				`Token Ending In${tokenId}Expired`
 			);
 		});
 

--- a/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
@@ -24,6 +24,7 @@ import {closeSessions} from './utils/sessions';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
+++ b/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
@@ -143,7 +143,7 @@ export class SegmentsPage {
 
 	async clickDuplicateButton() {
 		const duplicateButton = this.page.getByRole('button', {
-			name: 'Duplicate Segment Property',
+			name: 'Duplicate Property',
 		});
 		await duplicateButton.click();
 	}
@@ -253,7 +253,9 @@ export class SegmentsPage {
 			exact: true,
 			name: tabName,
 		});
-		const propertyLocator = this.page.getByText(propertyName);
+		const propertyLocator = this.page.getByText(propertyName, {
+			exact: true,
+		});
 		const isPropertyVisible = await propertyLocator.isVisible();
 
 		if (!isPropertyVisible) {

--- a/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
+++ b/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
@@ -32,6 +32,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-78863': {enabled: true, system: true},
+		'LPS-178052': {enabled: true},
 	}),
 	instanceSettingsPagesTest,
 	pageEditorPagesTest,
@@ -295,9 +296,11 @@ test(
 
 		// Create an organization, a user, and assign the user to the organization
 
+		const organizationName = getRandomString();
+
 		const organization =
 			await apiHelpers.headlessAdminUser.postOrganization({
-				name: getRandomString(),
+				name: organizationName,
 			});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount({
@@ -318,7 +321,9 @@ test(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('menuitem', {name: 'Edit'}),
-			trigger: page.getByRole('button', {name: 'Show Actions'}),
+			trigger: page
+				.locator('tr', {hasText: organizationName})
+				.getByRole('button', {name: 'Show Actions'}),
 		});
 
 		await clickAndExpectToBeVisible({
@@ -1802,7 +1807,7 @@ test(
 			await editUserPage.lastNameInput.fill('userln');
 			await editUserPage.screenNameInput.fill('usersn');
 
-			const tagInputFied = page.getByLabel('Tags', {exact: true});
+			const tagInputFied = page.getByRole('combobox', {name: 'Tags'});
 			await tagInputFied.fill('tagName');
 			await tagInputFied.press('Enter');
 			await page.locator('body').click();

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -19,10 +19,21 @@ apply plugin: "com.liferay.source.formatter"
 apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
+configurations.all {
+	resolutionStrategy {
+		force group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.6"
+		force group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.6"
+		force group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
+		force group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
+	}
+}
+
 dependencies {
+	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/client/LiferayHeadlessClient.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/client/LiferayHeadlessClient.java
@@ -1,0 +1,226 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.client;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.Sitemap;
+import com.liferay.seo.studio.model.SitemapEntry;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class LiferayHeadlessClient {
+
+	public LiferayHeadlessClient(
+		String authToken, HttpClient httpClient, String portalBaseURL) {
+
+		_authToken = authToken;
+		_httpClient = httpClient;
+		_portalBaseURL = portalBaseURL;
+	}
+
+	public Domain getDomain(long domainId) {
+		try {
+			String domainJSON = _makeRequest(
+				StringBundler.concat(
+					_portalBaseURL, "/o/seo-studio/domains/", domainId,
+					"?nestedFields=seoStudioInstance"));
+
+			if (Validator.isNull(domainJSON)) {
+				throw new IllegalArgumentException(
+					"Domain " + domainId + " was not found");
+			}
+
+			return new Domain(new JSONObject(domainJSON));
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to read domain " + domainId, jsonException);
+			}
+
+			throw new IllegalArgumentException(
+				"Domain " + domainId + " was not found", jsonException);
+		}
+	}
+
+	public List<String> getSitemapPageURLs(
+		String domainHostname, int maxPages) {
+
+		if ((maxPages <= 0) || Validator.isNull(domainHostname)) {
+			return new ArrayList<>();
+		}
+
+		String sitemapURL = "https://" + domainHostname + "/sitemap.xml";
+
+		String sitemapXML = _makeRequest(sitemapURL);
+
+		if (Validator.isNull(sitemapXML)) {
+			return new ArrayList<>();
+		}
+
+		return _parseSitemapURLs(0, maxPages, sitemapXML);
+	}
+
+	private String _makeRequest(String url) {
+		try {
+			HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder(
+			).uri(
+				URI.create(url)
+			).GET();
+
+			if (Validator.isNotNull(_authToken)) {
+				httpRequestBuilder.header(
+					"Authorization", "Bearer " + _authToken);
+			}
+
+			HttpResponse<String> httpResponse = _httpClient.send(
+				httpRequestBuilder.build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Response code ", httpResponse.statusCode(),
+							" for ", url));
+				}
+
+				return null;
+			}
+
+			return httpResponse.body();
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to make request to " + url, interruptedException);
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to make request to " + url, ioException);
+			}
+
+			return null;
+		}
+	}
+
+	private List<String> _parseSitemapURLs(
+		int depth, int maxPages, String xml) {
+
+		if (maxPages <= 0) {
+			return new ArrayList<>();
+		}
+
+		if (depth > 3) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Maximum sitemap recursion depth exceeded");
+			}
+
+			return new ArrayList<>();
+		}
+
+		Sitemap sitemap;
+
+		try {
+			sitemap = _xmlMapper.readValue(xml, Sitemap.class);
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to parse sitemap", ioException);
+			}
+
+			return new ArrayList<>();
+		}
+
+		List<SitemapEntry> sitemapEntries = sitemap.getSitemaps();
+
+		if (ListUtil.isEmpty(sitemapEntries)) {
+			List<String> urls = new ArrayList<>();
+			List<SitemapEntry> urlSitemapEntries = sitemap.getURLs();
+
+			if (ListUtil.isEmpty(urlSitemapEntries)) {
+				return urls;
+			}
+
+			for (SitemapEntry sitemapEntry : urlSitemapEntries) {
+				String loc = sitemapEntry.getLoc();
+
+				if (Validator.isNotNull(loc)) {
+					urls.add(loc.trim());
+
+					if (urls.size() >= maxPages) {
+						break;
+					}
+				}
+			}
+
+			return urls;
+		}
+
+		List<String> urls = new ArrayList<>();
+
+		for (SitemapEntry sitemapEntry : sitemapEntries) {
+			String childSitemapURL = sitemapEntry.getLoc();
+
+			if (Validator.isNull(childSitemapURL)) {
+				continue;
+			}
+
+			String childSitemapXML = _makeRequest(childSitemapURL.trim());
+
+			if (Validator.isNotNull(childSitemapXML)) {
+				urls.addAll(
+					_parseSitemapURLs(
+						depth + 1, maxPages - urls.size(), childSitemapXML));
+			}
+
+			if (urls.size() >= maxPages) {
+				break;
+			}
+		}
+
+		return urls;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		LiferayHeadlessClient.class);
+
+	private static final XmlMapper _xmlMapper = new XmlMapper();
+
+	private final String _authToken;
+	private final HttpClient _httpClient;
+	private final String _portalBaseURL;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class Domain {
+
+	public Domain(JSONObject jsonObject) {
+		_hostname = jsonObject.optString("domainHostname", null);
+
+		JSONObject seoStudioInstanceJSONObject = jsonObject.optJSONObject(
+			"seoStudioInstance");
+
+		if (seoStudioInstanceJSONObject != null) {
+			_pageSpeedAPIKey = seoStudioInstanceJSONObject.optString(
+				"googlePageSpeedAPIKey", null);
+		}
+		else {
+			_pageSpeedAPIKey = null;
+		}
+	}
+
+	public String getHostname() {
+		return _hostname;
+	}
+
+	public String getPageSpeedAPIKey() {
+		return _pageSpeedAPIKey;
+	}
+
+	private final String _hostname;
+	private final String _pageSpeedAPIKey;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Sitemap.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Sitemap.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kiana Suetani
+ */
+@JacksonXmlRootElement
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Sitemap {
+
+	public List<SitemapEntry> getSitemaps() {
+		return _sitemaps;
+	}
+
+	public List<SitemapEntry> getURLs() {
+		return _urls;
+	}
+
+	@JacksonXmlElementWrapper(useWrapping = false)
+	@JacksonXmlProperty(localName = "sitemap")
+	private List<SitemapEntry> _sitemaps = new ArrayList<>();
+
+	@JacksonXmlElementWrapper(useWrapping = false)
+	@JacksonXmlProperty(localName = "url")
+	private List<SitemapEntry> _urls = new ArrayList<>();
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/SitemapEntry.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/SitemapEntry.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * @author Kiana Suetani
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SitemapEntry {
+
+	public String getLoc() {
+		return _loc;
+	}
+
+	@JacksonXmlProperty(localName = "loc")
+	private String _loc;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

With the PageSpeed score service merged (LPD-88837 #3506), the next layer needs a Liferay Headless client to fetch domain metadata + page URLs from the portal, plus the value classes that carry that data across the upcoming scanner and controller boundaries. This client extension currently has no way to resolve a `domainId` into a hostname or to discover the pages to scan from the site's `sitemap.xml`.

## How It Is Being Fixed

A new `LiferayHeadlessClient` is added under `com.liferay.seo.studio.client`, modeled after `liferay-seostudio-etc-gsc/GoogleOAuth2Service`: stateless wrapper around a per-instance `HttpClient`, vertical-chain `HttpRequest.newBuilder(...).uri(...).GET()` form, `JSONException` propagates. Two public entry points:

- `getDomain(domainId)` — fetches `/o/seo-studio/domains/{id}?nestedFields=seoStudioInstance` in a single HTTP call (the `nestedFields` query inlines the parent `SEOStudioInstance` so we project the API key in the same response). Matches the `customer/TicketAttachment` projection pattern (JSONObject-constructor value class).
- `getSitemapPageURLs(domainHostname, maxPages)` — downloads `https://<host>/sitemap.xml`, recursively parses nested sitemap indexes up to depth 3, and returns at most `maxPages` URLs. Recursive budget passes `maxPages - urls.size()` to each child to enforce the cap without truncating after-the-fact.

Value classes added under `com.liferay.seo.studio.model`:

- `Domain` — projects `hostname` and `pageSpeedAPIKey` from the joined domain+instance JSON.
- `Sitemap` / `SitemapEntry` — Jackson XML models that absorb either `<urlset>` or `<sitemapindex>` documents.

`PageSpeedConstants` carries `STRATEGY_DESKTOP` / `STRATEGY_MOBILE` for the scanner and controller branches to share.

`build.gradle` picks up `jackson-dataformat-xml:2.18.2` for sitemap parsing and `com.liferay.portal.kernel` for `Validator` + `StringBundler`/`ListUtil`. A `configurations.all { resolutionStrategy.force(...) }` block pins the Jackson core trio to `2.18.6` to resolve Spring Boot 2.7.18's older Jackson against `jackson-dataformat-xml`'s 2.18.x requirement.

## Why Are There No Tests?

Mirrors the sibling pattern: `liferay-seostudio-etc-gsc/GoogleOAuth2Service` and the merged `PageSpeedReportService` ship `java.net.http.HttpClient` wrappers without unit tests. HTTP and JSON exceptions propagate to callers rather than being tested in isolation.

## PR Check

**pr-check: PASS** — tested on `d1d15c770349f00723242e2252f82bf86eeb1683`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "d1d15c770349f00723242e2252f82bf86eeb1683"} -->
