### PR TITLE
LPD-91213 Add SEO Studio scan status polling and orphan detection

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.constants;
+
+/**
+ * @author Brooke Dalton
+ */
+public interface SEOStudioScanConstants {
+
+	public static final String STATE_COMPLETED = "completed";
+
+	public static final String STATE_FAILED = "failed";
+
+	public static final String STATE_RUNNING = "running";
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -6,9 +6,25 @@
 package com.liferay.seo.studio.controller;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.service.KubernetesJobService;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONObject;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,9 +40,175 @@ public class CrawlerRestController extends BaseRestController {
 
 	@PostMapping
 	public ResponseEntity<String> post(@RequestBody String json) {
-		return ResponseEntity.ok(
-			new JSONObject(
-			).toString());
+		if (_log.isDebugEnabled()) {
+			_log.debug(json);
+		}
+
+		JSONObject objectEntryJSONObject = new JSONObject(
+			json
+		).getJSONObject(
+			"objectEntry"
+		);
+
+		long seoStudioScanId = objectEntryJSONObject.getLong("objectEntryId");
+
+		try {
+			JSONObject valuesJSONObject = objectEntryJSONObject.getJSONObject(
+				"values");
+
+			long seoStudioDomainId = valuesJSONObject.getLong(
+				"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+			String domainJSON = _seoStudioService.fetchDomain(
+				seoStudioDomainId);
+
+			if (domainJSON == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to dispatch scan " + seoStudioScanId);
+				}
+
+				return ResponseEntity.ok(
+					_seoStudioService.updateScan(
+						"No domain was found for SEO Studio domain ID " +
+							seoStudioDomainId,
+						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+			}
+
+			String hostname = new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			);
+
+			String domainURL = SEOStudioService.toDomainURL(
+				SEOStudioService.toCrawlURI(hostname));
+
+			String canonicalDomainURL = _resolveCanonicalDomainURL(domainURL);
+
+			if (!canonicalDomainURL.equals(domainURL)) {
+				_seoStudioService.updateDomain(
+					new JSONObject(
+					).put(
+						"hostname", canonicalDomainURL
+					),
+					seoStudioDomainId);
+			}
+
+			String sitemapURL = canonicalDomainURL + "/sitemap.xml";
+
+			if (!_isSitemapReachable(sitemapURL)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to dispatch scan " + seoStudioScanId);
+				}
+
+				return ResponseEntity.ok(
+					_seoStudioService.updateScan(
+						"Sitemap is unavailable at " + sitemapURL,
+						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+			}
+
+			_seoStudioService.updateScan(
+				null, seoStudioScanId, SEOStudioScanConstants.STATE_RUNNING);
+
+			JSONObject scopeConfigJSONObject = new JSONObject(
+				valuesJSONObject.getString("scopeConfig"));
+
+			Job job = _kubernetesJobService.createJob(
+				valuesJSONObject.getLong(
+					"r_accountToSEOStudioScans_accountEntryId"),
+				canonicalDomainURL,
+				scopeConfigJSONObject.getInt("maxCrawlDepth"),
+				scopeConfigJSONObject.getInt("maxDuration"),
+				SEOStudioService.toIndexName(seoStudioDomainId), sitemapURL);
+
+			JSONObject scanJSONObject = new JSONObject(
+			).put(
+				"executionId",
+				job.getMetadata(
+				).getName()
+			);
+
+			_seoStudioService.updateScan(scanJSONObject, seoStudioScanId);
+
+			return ResponseEntity.ok(scanJSONObject.toString());
+		}
+		catch (Exception exception) {
+			_log.error("Unable to dispatch scan " + seoStudioScanId, exception);
+
+			return ResponseEntity.ok(
+				_seoStudioService.updateScan(
+					"Unable to dispatch scan " + exception.getMessage(),
+					seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+		}
 	}
+
+	private boolean _isSitemapReachable(String sitemapURL) {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+					URI.create(sitemapURL)
+				).timeout(
+					Duration.ofSeconds(60)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != 200) {
+				return false;
+			}
+
+			String body = httpResponse.body();
+
+			if ((body != null) && !body.isBlank()) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Sitemap is unavailable at " + sitemapURL, exception);
+			}
+
+			return false;
+		}
+	}
+
+	private String _resolveCanonicalDomainURL(String domainURL)
+		throws Exception {
+
+		HttpResponse<Void> httpResponse = _httpClient.send(
+			HttpRequest.newBuilder(
+				URI.create(domainURL)
+			).timeout(
+				Duration.ofSeconds(60)
+			).GET(
+			).build(),
+			HttpResponse.BodyHandlers.discarding());
+
+		URI uri = httpResponse.uri();
+
+		if ((uri == null) || (uri.getHost() == null)) {
+			return domainURL;
+		}
+
+		return SEOStudioService.toDomainURL(uri);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerRestController.class);
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).followRedirects(
+		HttpClient.Redirect.NORMAL
+	).build();
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
 
 }

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/BaseDetectionCrawler.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/BaseDetectionCrawler.java
@@ -1,0 +1,318 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.crawler;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Noor Najjar
+ */
+public abstract class BaseDetectionCrawler {
+
+	public abstract void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI hostname,
+			long seoStudioScanId)
+		throws Exception;
+
+	protected static String getPageURL(CrawlHit crawlHit) {
+		String canonicalURL = crawlHit.getCanonicalURL();
+
+		if ((canonicalURL != null) && !canonicalURL.isBlank()) {
+			return canonicalURL;
+		}
+
+		String url = crawlHit.getURL();
+
+		if ((url != null) && !url.isBlank()) {
+			return url;
+		}
+
+		return null;
+	}
+
+	protected Map<String, Long> ensurePages(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		Map<String, Long> pageIdsByURLMap = _readPages(seoStudioScanId);
+
+		List<String> missingPageURLs = new ArrayList<>();
+
+		for (String pageURL : pageURLs) {
+			if (!pageIdsByURLMap.containsKey(pageURL)) {
+				missingPageURLs.add(pageURL);
+			}
+		}
+
+		if (missingPageURLs.isEmpty()) {
+			return pageIdsByURLMap;
+		}
+
+		_createPagesBatch(accountEntryId, missingPageURLs, seoStudioScanId);
+
+		long time = System.currentTimeMillis() + _PAGE_FETCH_TIMEOUT;
+
+		while (true) {
+			Set<String> readPageURLs = pageIdsByURLMap.keySet();
+
+			if (readPageURLs.containsAll(pageURLs)) {
+				break;
+			}
+
+			if (System.currentTimeMillis() > time) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Timed out waiting for pages to be readable for scan " +
+							seoStudioScanId);
+				}
+
+				break;
+			}
+
+			Thread.sleep(_PAGE_FETCH_POLL_INTERVAL);
+
+			pageIdsByURLMap = _readPages(seoStudioScanId);
+		}
+
+		return pageIdsByURLMap;
+	}
+
+	protected void writeInsights(
+			long accountEntryId, JSONObject definitionJSONObject,
+			Map<String, Long> pageIdsByURLMap, List<String> pageURLs,
+			long seoStudioScanId)
+		throws Exception {
+
+		if (ListUtil.isEmpty(pageURLs)) {
+			return;
+		}
+
+		long seoStudioInsightTypeId = _createInsightTypeId(
+			accountEntryId, definitionJSONObject, seoStudioScanId);
+
+		_createScanInsightsBatch(
+			accountEntryId, definitionJSONObject.getString("classification"),
+			pageIdsByURLMap, pageURLs, seoStudioInsightTypeId, seoStudioScanId);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Wrote ", pageURLs.size(), " ",
+					definitionJSONObject.getString("insightType"),
+					" scan insights for insight type ",
+					seoStudioInsightTypeId));
+		}
+	}
+
+	private long _createInsightTypeId(
+		long accountEntryId, JSONObject definitionJSONObject,
+		long seoStudioScanId) {
+
+		JSONObject bodyJSONObject = new JSONObject();
+
+		String externalReferenceCode =
+			definitionJSONObject.getString("insightType") + ":" +
+				seoStudioScanId;
+
+		bodyJSONObject.put(
+			"category", definitionJSONObject.getString("category")
+		).put(
+			"description", definitionJSONObject.optString("description")
+		).put(
+			"externalReferenceCode", externalReferenceCode
+		).put(
+			"name", definitionJSONObject.getString("name")
+		).put(
+			"r_accountToSEOStudioInsightTypes_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"severity", definitionJSONObject.getString("severity")
+		).put(
+			"whyItMatters", definitionJSONObject.optString("whyItMatters")
+		);
+
+		return new JSONObject(
+			_seoStudioService.createInsightType(bodyJSONObject)
+		).getLong(
+			"id"
+		);
+	}
+
+	private void _createPagesBatch(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> chunk = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray pagesJSONArray = new JSONArray();
+
+			for (String pageURL : chunk) {
+				pagesJSONArray.put(
+					_toPageJSONObject(
+						accountEntryId, pageURL, seoStudioScanId));
+			}
+
+			_seoStudioService.createPagesBatch(pagesJSONArray);
+		}
+	}
+
+	private void _createScanInsightsBatch(
+			long accountEntryId, String classification,
+			Map<String, Long> pageIdsByURLMap, List<String> pageURLs,
+			long seoStudioInsightTypeId, long seoStudioScanId)
+		throws Exception {
+
+		String detectedDate = Instant.now(
+		).truncatedTo(
+			ChronoUnit.SECONDS
+		).toString();
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> chunk = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray scanInsightsJSONArray = new JSONArray();
+
+			for (String pageURL : chunk) {
+				Long seoStudioPageId = pageIdsByURLMap.get(pageURL);
+
+				if (seoStudioPageId == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"No page was found for URL " + pageURL +
+								"; skipping scan insight");
+					}
+
+					continue;
+				}
+
+				scanInsightsJSONArray.put(
+					_toScanInsightJSONObject(
+						accountEntryId, classification, detectedDate,
+						seoStudioInsightTypeId, seoStudioPageId,
+						seoStudioScanId));
+			}
+
+			if (scanInsightsJSONArray.length() == 0) {
+				continue;
+			}
+
+			_seoStudioService.createScanInsightsBatch(scanInsightsJSONArray);
+		}
+	}
+
+	private Map<String, Long> _readPages(long seoStudioScanId) {
+		Map<String, Long> pageIdsByURLMap = new HashMap<>();
+
+		int page = 1;
+
+		while (true) {
+			JSONArray itemsJSONArray = new JSONObject(
+				_seoStudioService.fetchPage(page, 2000, seoStudioScanId)
+			).optJSONArray(
+				"items"
+			);
+
+			if ((itemsJSONArray == null) || (itemsJSONArray.length() == 0)) {
+				break;
+			}
+
+			for (Object itemObject : itemsJSONArray) {
+				JSONObject itemJSONObject = (JSONObject)itemObject;
+
+				pageIdsByURLMap.put(
+					itemJSONObject.getString("pageURL"),
+					itemJSONObject.getLong("id"));
+			}
+
+			page++;
+		}
+
+		return pageIdsByURLMap;
+	}
+
+	private JSONObject _toPageJSONObject(
+		long accountEntryId, String pageURL, long seoStudioScanId) {
+
+		JSONObject pageJSONObject = new JSONObject();
+
+		pageJSONObject.put(
+			"pageURL", pageURL
+		).put(
+			"r_accountToSEOStudioPages_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId", seoStudioScanId
+		);
+
+		return pageJSONObject;
+	}
+
+	private JSONObject _toScanInsightJSONObject(
+		long accountEntryId, String classification, String detectedDate,
+		long seoStudioInsightTypeId, long seoStudioPageId,
+		long seoStudioScanId) {
+
+		JSONObject scanInsightJSONObject = new JSONObject();
+
+		scanInsightJSONObject.put(
+			"classification", classification
+		).put(
+			"detectedDate", detectedDate
+		).put(
+			"r_accountToSEOStudioScanInsights_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioInsightTypeToScanInsights_seoStudioInsightTypeId",
+			seoStudioInsightTypeId
+		).put(
+			"r_seoStudioPageToSEOStudioScanInsights_seoStudioPageId",
+			seoStudioPageId
+		).put(
+			"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+			seoStudioScanId
+		);
+
+		return scanInsightJSONObject;
+	}
+
+	private static final int _BATCH_SIZE = 100;
+
+	private static final long _PAGE_FETCH_POLL_INTERVAL = 1000;
+
+	private static final long _PAGE_FETCH_TIMEOUT = 60000;
+
+	private static final Log _log = LogFactory.getLog(
+		BaseDetectionCrawler.class);
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/OrphanPagesDetectionCrawler.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/OrphanPagesDetectionCrawler.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.crawler;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class OrphanPagesDetectionCrawler extends BaseDetectionCrawler {
+
+	@Override
+	public void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI hostname,
+			long seoStudioScanId)
+		throws Exception {
+
+		Set<String> canonicalURLs = new LinkedHashSet<>();
+		Set<String> linkedCanonicalURLs = new HashSet<>();
+
+		for (CrawlHit crawlHit : crawlHits) {
+			String canonicalURL = crawlHit.getCanonicalURL();
+
+			if ((canonicalURL == null) || canonicalURL.isBlank()) {
+				continue;
+			}
+
+			canonicalURLs.add(canonicalURL);
+
+			for (String link : crawlHit.getLinks()) {
+				if ((link != null) && !link.isBlank() &&
+					!link.equals(canonicalURL)) {
+
+					linkedCanonicalURLs.add(link);
+				}
+			}
+		}
+
+		List<String> orphans = new ArrayList<>();
+
+		String domainURL = SEOStudioService.toDomainURL(hostname);
+
+		for (String canonicalURL : canonicalURLs) {
+			if (canonicalURL.equals(domainURL) ||
+				linkedCanonicalURLs.contains(canonicalURL)) {
+
+				continue;
+			}
+
+			orphans.add(canonicalURL);
+		}
+
+		if (ListUtil.isEmpty(orphans)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"No orphan pages were detected for scan " +
+						seoStudioScanId);
+			}
+
+			return;
+		}
+
+		writeInsights(
+			accountEntryId,
+			new JSONObject(
+			).put(
+				"category", "linksAndURLs"
+			).put(
+				"classification", "problem"
+			).put(
+				"insightType", "orphan_page"
+			).put(
+				"name", "orphanPages"
+			).put(
+				"severity", "2"
+			),
+			ensurePages(accountEntryId, orphans, seoStudioScanId), orphans,
+			seoStudioScanId);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrphanPagesDetectionCrawler.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/CrawlHit.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/CrawlHit.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Brooke Dalton
+ */
+public class CrawlHit {
+
+	public CrawlHit(JSONObject jsonObject) {
+		_canonicalURL = jsonObject.optString("canonicalUrl", null);
+		_url = jsonObject.optString("url", null);
+
+		JSONArray linksJSONArray = jsonObject.optJSONArray("links");
+
+		if (linksJSONArray != null) {
+			for (Object linkObject : linksJSONArray) {
+				if (linkObject instanceof String) {
+					_links.add((String)linkObject);
+				}
+			}
+		}
+	}
+
+	public String getCanonicalURL() {
+		return _canonicalURL;
+	}
+
+	public List<String> getLinks() {
+		return _links;
+	}
+
+	public String getURL() {
+		return _url;
+	}
+
+	private final String _canonicalURL;
+	private final List<String> _links = new ArrayList<>();
+	private final String _url;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.crawler.OrphanPagesDetectionCrawler;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+
+import java.net.URI;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class CrawlerJobStatusService {
+
+	@Scheduled(fixedDelay = 60000)
+	public void updateStatuses() {
+		JSONArray itemsJSONArray = new JSONObject(
+			_seoStudioService.fetchActiveScans()
+		).optJSONArray(
+			"items"
+		);
+
+		if (itemsJSONArray == null) {
+			return;
+		}
+
+		for (int i = 0; i < itemsJSONArray.length(); i++) {
+			JSONObject scanJSONObject = itemsJSONArray.getJSONObject(i);
+
+			long seoStudioScanId = scanJSONObject.getLong("id");
+
+			try {
+				String executionId = scanJSONObject.optString("executionId");
+
+				if (executionId.isEmpty()) {
+					continue;
+				}
+
+				Job job = _kubernetesJobService.getJob(executionId);
+
+				String state = _getScanState(job);
+
+				if ((state == null) ||
+					state.equals(scanJSONObject.optString("state"))) {
+
+					continue;
+				}
+
+				if (state.equals(SEOStudioScanConstants.STATE_COMPLETED)) {
+					String errorMessage = _detectOrphanPages(
+						scanJSONObject, seoStudioScanId);
+
+					if (errorMessage != null) {
+						_seoStudioService.updateScan(
+							errorMessage, seoStudioScanId,
+							SEOStudioScanConstants.STATE_FAILED);
+					}
+					else {
+						_seoStudioService.updateScan(
+							null, seoStudioScanId,
+							SEOStudioScanConstants.STATE_COMPLETED);
+					}
+				}
+				else if (state.equals(SEOStudioScanConstants.STATE_FAILED)) {
+					String errorMessage = "Kubernetes job does not exist";
+
+					if (job != null) {
+						errorMessage = _getErrorMessage(job.getStatus());
+					}
+
+					_seoStudioService.updateScan(
+						errorMessage, seoStudioScanId,
+						SEOStudioScanConstants.STATE_FAILED);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to update status of scan " + seoStudioScanId,
+					exception);
+			}
+		}
+	}
+
+	private String _detectOrphanPages(
+			JSONObject scanJSONObject, long seoStudioScanId)
+		throws Exception {
+
+		long seoStudioDomainId = scanJSONObject.getLong(
+			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+		String domainJSON = _seoStudioService.fetchDomain(seoStudioDomainId);
+
+		if (domainJSON == null) {
+			return "No domain was found for SEO Studio domain ID " +
+				seoStudioDomainId;
+		}
+
+		List<CrawlHit> crawlHits = _seoStudioService.fetchCrawlHits(
+			seoStudioDomainId);
+
+		if (crawlHits.isEmpty()) {
+			return "No crawl hits were found for SEO Studio domain ID " +
+				seoStudioDomainId;
+		}
+
+		URI hostname = SEOStudioService.toCrawlURI(
+			new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			));
+
+		_orphanPagesDetectionCrawler.detect(
+			scanJSONObject.getLong("r_accountToSEOStudioScans_accountEntryId"),
+			crawlHits, hostname, seoStudioScanId);
+
+		return null;
+	}
+
+	private String _getErrorMessage(JobStatus jobStatus) {
+		List<JobCondition> jobConditions = jobStatus.getConditions();
+
+		if (jobConditions == null) {
+			return "Kubernetes job failed";
+		}
+
+		for (JobCondition jobCondition : jobConditions) {
+			if (!Objects.equals(jobCondition.getType(), "Failed") ||
+				!Objects.equals(jobCondition.getStatus(), "True")) {
+
+				continue;
+			}
+
+			String message = jobCondition.getMessage();
+
+			if (message != null) {
+				return message;
+			}
+		}
+
+		return "Kubernetes job failed";
+	}
+
+	private String _getScanState(Job job) {
+		if (job == null) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		if (jobStatus == null) {
+			return null;
+		}
+
+		Integer active = jobStatus.getActive();
+
+		if ((active != null) && (active > 0)) {
+			return SEOStudioScanConstants.STATE_RUNNING;
+		}
+
+		Integer failed = jobStatus.getFailed();
+
+		if ((failed != null) && (failed > 0)) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		Integer succeeded = jobStatus.getSucceeded();
+
+		if ((succeeded != null) && (succeeded > 0)) {
+			return SEOStudioScanConstants.STATE_COMPLETED;
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerJobStatusService.class);
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private OrphanPagesDetectionCrawler _orphanPagesDetectionCrawler;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import java.net.URI;
+import java.net.URLEncoder;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class SEOStudioService extends BaseService {
+
+	public static URI toCrawlURI(String hostname) {
+		if ((hostname == null) || hostname.isBlank()) {
+			throw new IllegalArgumentException("Hostname is required");
+		}
+
+		String hostnameString = StringUtil.toLowerCase(hostname.trim());
+
+		if (!hostnameString.startsWith("http://") &&
+			!hostnameString.startsWith("https://")) {
+
+			hostnameString = "https://" + hostnameString;
+		}
+
+		URI uri = URI.create(hostnameString);
+
+		if (uri.getHost() == null) {
+			throw new IllegalArgumentException(
+				"Hostname \"" + hostname + "\" has no host component");
+		}
+
+		return uri;
+	}
+
+	public static String toDomainURL(URI uri) {
+		String host = StringUtil.toLowerCase(uri.getHost());
+		String scheme = StringUtil.toLowerCase(uri.getScheme());
+
+		if (uri.getPort() == -1) {
+			return scheme + "://" + host;
+		}
+
+		return StringBundler.concat(scheme, "://", host, ":", uri.getPort());
+	}
+
+	public static String toIndexName(long seoStudioDomainId) {
+		return "seo_studio_" + seoStudioDomainId;
+	}
+
+	public String createInsightType(JSONObject jsonObject) {
+		return post(
+			_authorization(), jsonObject.toString(),
+			URI.create("/o/seo-studio/insight-types"));
+	}
+
+	public String createPagesBatch(JSONArray jsonArray) {
+		return post(
+			_authorization(), jsonArray.toString(),
+			URI.create(_PAGES + "/batch"));
+	}
+
+	public String createScanInsightsBatch(JSONArray jsonArray) {
+		return post(
+			_authorization(), jsonArray.toString(),
+			URI.create("/o/seo-studio/scan-insights/batch"));
+	}
+
+	public String fetchActiveScans() {
+		return get(
+			_authorization(),
+			URI.create(
+				StringBundler.concat(
+					"/o/seo-studio/scans?filter=",
+					URLEncoder.encode(
+						"state in ('queued','running')",
+						StandardCharsets.UTF_8),
+					"&pageSize=100")));
+	}
+
+	public List<CrawlHit> fetchCrawlHits(long seoStudioDomainId) {
+		List<CrawlHit> crawlHits = new ArrayList<>();
+
+		String lastURL = null;
+
+		while (true) {
+			JSONObject hitsJSONObject = new JSONObject(
+				_fetchCrawlHits(lastURL, 2000, seoStudioDomainId));
+
+			JSONArray hitsJSONArray = hitsJSONObject.optJSONArray("items");
+
+			if ((hitsJSONArray == null) || (hitsJSONArray.length() == 0)) {
+				break;
+			}
+
+			String previousLastURL = lastURL;
+
+			for (Object hitObject : hitsJSONArray) {
+				CrawlHit crawlHit = new CrawlHit((JSONObject)hitObject);
+
+				crawlHits.add(crawlHit);
+
+				lastURL = crawlHit.getURL();
+			}
+
+			if (Objects.equals(previousLastURL, lastURL)) {
+				break;
+			}
+		}
+
+		return crawlHits;
+	}
+
+	public String fetchDomain(long seoStudioDomainId) {
+		return get(
+			_authorization(), URI.create(_DOMAINS + "/" + seoStudioDomainId));
+	}
+
+	public String fetchPage(int page, int pageSize, long seoStudioScanId) {
+		String filterString = StringBundler.concat(
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId eq '",
+			seoStudioScanId, "'");
+
+		return get(
+			_authorization(),
+			URI.create(
+				StringBundler.concat(
+					_PAGES, "?filter=",
+					URLEncoder.encode(filterString, StandardCharsets.UTF_8),
+					"&page=", page, "&pageSize=", pageSize)));
+	}
+
+	public String updateDomain(JSONObject jsonObject, long seoStudioDomainId) {
+		return patch(
+			_authorization(), jsonObject.toString(),
+			URI.create(_DOMAINS + "/" + seoStudioDomainId));
+	}
+
+	public String updateScan(JSONObject jsonObject, long seoStudioScanId) {
+		return patch(
+			_authorization(), jsonObject.toString(),
+			URI.create("/o/seo-studio/scans/" + seoStudioScanId));
+	}
+
+	public String updateScan(
+		String errorMessage, long seoStudioScanId, String state) {
+
+		JSONObject jsonObject = new JSONObject();
+
+		if (errorMessage != null) {
+			jsonObject.put("errorMessage", errorMessage);
+		}
+
+		jsonObject.put("state", state);
+
+		return updateScan(jsonObject, seoStudioScanId);
+	}
+
+	private String _authorization() {
+		return _liferayOAuth2AccessTokenManager.getAuthorization(
+			"liferay-seostudio-etc-crawler-oahs");
+	}
+
+	private String _fetchCrawlHits(
+		String lastURL, int pageSize, long seoStudioDomainId) {
+
+		String crawlHitsURL = StringBundler.concat(
+			"/o/seo-studio/v1.0/seo-studio-domains/", seoStudioDomainId,
+			"/crawl-hits?pageSize=", pageSize);
+
+		if ((lastURL != null) && !lastURL.isBlank()) {
+			crawlHitsURL = StringBundler.concat(
+				crawlHitsURL, "&lastURL=",
+				URLEncoder.encode(lastURL, StandardCharsets.UTF_8));
+		}
+
+		return get(_authorization(), URI.create(crawlHitsURL));
+	}
+
+	private static final String _DOMAINS = "/o/seo-studio/domains";
+
+	private static final String _PAGES = "/o/seo-studio/pages";
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213

## What Is Being Fixed

Once a SEO Studio crawl job is dispatched there was nothing to track its progress or act on its results, so a completed crawl produced no insights and a failed crawl left its scan stuck.

This PR is stacked on #3517 and should be reviewed and merged after it. Until #3517 merges into master, this PR's diff also shows #3517's four files; once #3517 merges, the diff reduces to the three files below (`BaseDetectionCrawler`, `OrphanPagesDetectionCrawler`, `CrawlerJobStatusService`).

## How It Is Being Fixed

Adds the scheduled poller and the first detection crawler. CrawlerJobStatusService polls active scans on a fixed delay, reads the matching Kubernetes job status, and transitions each scan to completed or failed, surfacing the job's failure condition as the scan error message. On completion it runs orphan page detection. BaseDetectionCrawler provides the shared machinery for a detection crawler: reading and batch creating pages, resolving insight types, and writing scan insights in batches. OrphanPagesDetectionCrawler builds the set of canonical URLs and the set of linked URLs from the crawl hits and flags every reachable page that nothing links to as an orphan.

## PR Check

**pr-check: PASS** — tested on `fe1f6fb3f199eb78c335f7c172357705934d5363`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "fe1f6fb3f199eb78c335f7c172357705934d5363"} -->
