### PR TITLE
LPD-78184 Block fragment soft-delete during pending CT modification

### DIFF
--- a/modules/apps/fragment/fragment-service/build.gradle
+++ b/modules/apps/fragment/fragment-service/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:asset:asset-list-api")
+	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -5,6 +5,8 @@
 
 package com.liferay.fragment.service.impl;
 
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.service.CTEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.listener.FragmentEntryLinkListener;
@@ -35,6 +37,8 @@ import com.liferay.petra.sql.dsl.query.LimitStep;
 import com.liferay.petra.sql.dsl.query.OrderByStep;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.change.tracking.CTRequiredModelException;
 import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -47,6 +51,7 @@ import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -60,6 +65,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -598,6 +604,28 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		_checkUnlockedLayout(fragmentEntryLink.getPlid(), userId);
 
+		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
+
+		if (deleted &&
+			(ctCollectionId == CTConstants.CT_COLLECTION_ID_PRODUCTION)) {
+
+			long modelClassNameId = _classNameLocalService.getClassNameId(
+				fragmentEntryLink.getModelClass());
+
+			if (PropsValues.CHANGE_TRACKING_DELETION_PROTECTION_ENABLED &&
+				_ctEntryLocalService.hasUnpublishedCTEntries(
+					modelClassNameId, fragmentEntryLinkId,
+					CTConstants.CT_CHANGE_TYPE_MODIFICATION)) {
+
+				throw new CTRequiredModelException(
+					String.format(
+						"Model %s %s cannot be deleted because it is being " +
+							"modified in one or more publications",
+						fragmentEntryLink.getModelClassName(),
+						fragmentEntryLinkId));
+			}
+		}
+
 		fragmentEntryLink.setDeleted(deleted);
 
 		return fragmentEntryLinkPersistence.update(fragmentEntryLink);
@@ -1078,6 +1106,12 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	private static final Pattern _pattern = Pattern.compile(
 		"\\[resources:(.+?)\\]");
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private CTEntryLocalService _ctEntryLocalService;
 
 	@Reference
 	private DLURLHelper _dlURLHelper;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/change/tracking/test/FragmentEntryLinkDeletionProtectionTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/change/tracking/test/FragmentEntryLinkDeletionProtectionTest.java
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.change.tracking.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTEntry;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTEntryLocalService;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.change.tracking.CTRequiredModelException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kiana Suetani
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryLinkDeletionProtectionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, FragmentEntryLinkDeletionProtectionTest.class.getSimpleName(),
+			null);
+
+		_ctCollections.add(_ctCollection);
+
+		_group = GroupTestUtil.addGroup();
+
+		_fragmentEntryLinkClassNameId = _classNameLocalService.getClassNameId(
+			FragmentEntryLink.class);
+	}
+
+	@Test
+	public void testUpdateDeletedBlockedWhenModifiedInPublication()
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink();
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			_fragmentEntryLinkLocalService.updateFragmentEntryLink(
+				TestPropsValues.getUserId(),
+				fragmentEntryLink.getFragmentEntryLinkId(),
+				"{\"key\":\"" + RandomTestUtil.randomString() + "\"}", false);
+		}
+
+		CTEntry ctEntry = _ctEntryLocalService.fetchCTEntry(
+			_ctCollection.getCtCollectionId(), _fragmentEntryLinkClassNameId,
+			fragmentEntryLink.getFragmentEntryLinkId());
+
+		Assert.assertEquals(
+			CTConstants.CT_CHANGE_TYPE_MODIFICATION, ctEntry.getChangeType());
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"CHANGE_TRACKING_DELETION_PROTECTION_ENABLED", true,
+					false)) {
+
+			try {
+				_fragmentEntryLinkLocalService.updateDeleted(
+					TestPropsValues.getUserId(),
+					fragmentEntryLink.getFragmentEntryLinkId(), true);
+
+				Assert.fail(
+					"Expected CTRequiredModelException because the fragment " +
+						"entry link is being modified in a publication");
+			}
+			catch (Exception exception) {
+				Throwable throwable = exception;
+
+				while ((throwable != null) &&
+					   !(throwable instanceof CTRequiredModelException)) {
+
+					throwable = throwable.getCause();
+				}
+
+				Assert.assertNotNull(
+					"Expected CTRequiredModelException in the cause chain " +
+						"but got: " + exception,
+					throwable);
+			}
+		}
+
+		FragmentEntryLink reloadedFragmentEntryLink =
+			_fragmentEntryLinkLocalService.getFragmentEntryLink(
+				fragmentEntryLink.getFragmentEntryLinkId());
+
+		Assert.assertFalse(reloadedFragmentEntryLink.isDeleted());
+	}
+
+	@Test
+	public void testUpdateDeletedSucceedsWithoutPublicationModification()
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"CHANGE_TRACKING_DELETION_PROTECTION_ENABLED", true,
+					false)) {
+
+			FragmentEntryLink updatedFragmentEntryLink =
+				_fragmentEntryLinkLocalService.updateDeleted(
+					TestPropsValues.getUserId(),
+					fragmentEntryLink.getFragmentEntryLinkId(), true);
+
+			Assert.assertTrue(updatedFragmentEntryLink.isDeleted());
+		}
+	}
+
+	private FragmentEntryLink _addFragmentEntryLink() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+
+		return FragmentTestUtil.addFragmentEntryLink(
+			_group.getGroupId(), fragmentEntry.getFragmentEntryId(),
+			layout.getPlid());
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private CTCollection _ctCollection;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@DeleteAfterTestRun
+	private final List<CTCollection> _ctCollections = new ArrayList<>();
+
+	@Inject
+	private CTEntryLocalService _ctEntryLocalService;
+
+	private long _fragmentEntryLinkClassNameId;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseContentPageEditorTransactionalMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseContentPageEditorTransactionalMVCActionCommand.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.exception.FragmentCompositionNameException;
 import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.exception.NoninstanceablePortletException;
 import com.liferay.layout.manager.LayoutLockManager;
+import com.liferay.portal.kernel.change.tracking.CTRequiredModelException;
 import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -97,7 +98,16 @@ public abstract class BaseContentPageEditorTransactionalMVCActionCommand
 
 		String errorMessage = "an-unexpected-error-occurred";
 
-		if (exception instanceof FormContainerParentItemRequiredException) {
+		if ((exception instanceof CTRequiredModelException) ||
+			(exception.getCause() instanceof CTRequiredModelException)) {
+
+			errorMessage =
+				"item-cannot-be-deleted-because-it-is-being-modified-in-one-" +
+					"or-more-publications";
+		}
+		else if (exception instanceof
+					FormContainerParentItemRequiredException) {
+
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -323,6 +323,11 @@ public class PropsValues {
 	public static final String CDN_HOST_HTTPS = PropsUtil.get(
 		PropsKeys.CDN_HOST_HTTPS);
 
+	public static final boolean CHANGE_TRACKING_DELETION_PROTECTION_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.CHANGE_TRACKING_DELETION_PROTECTION_ENABLED));
+
 	public static final boolean CLUSTER_LINK_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.CLUSTER_LINK_ENABLED));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78184

## What Is Being Fixed

Deleting a fragment from a page in production silently succeeded even when that fragment was being modified in an open publication. The page editor's draft saved with the fragment removed, but the underlying delete was actually blocked downstream by change-tracking deletion protection. The "block deletion" guard that already protects hard deletes never fired for the soft-delete path that the page editor uses to mark items for removal.

## How It Is Being Fixed

Apply the same `CHANGE_TRACKING_DELETION_PROTECTION_ENABLED` guard that `CTPersistenceHelperImpl.isRemove` enforces for hard deletes to `FragmentEntryLinkLocalServiceImpl.updateDeleted` when the caller is in production mode and is marking a fragment as deleted. The check throws `CTRequiredModelException` so the structure mutation rolls back before the page editor's draft data persists. To surface this to the user, map `CTRequiredModelException` in `BaseContentPageEditorTransactionalMVCActionCommand.processException` to the existing language key that the page-delete path already uses, so the user sees the publication-aware error message instead of a generic toast. Restore (`updateDeleted(false)`) is unaffected — the guard is direction-gated on `deleted == true`.

## PR Check

**pr-check: PASS** — tested on `a641bb4e49d9daeeb78a43df26a976073a0917b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a641bb4e49d9daeeb78a43df26a976073a0917b6"} -->
