### PR TITLE
LPD-88837 Add Liferay Headless client and PageSpeed value classes

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -20,9 +20,11 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 dependencies {
+	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class Domain {
+
+	public Domain(JSONObject jsonObject) {
+		_hostname = jsonObject.optString("domainHostname", null);
+
+		JSONObject seoStudioInstanceJSONObject = jsonObject.optJSONObject(
+			"seoStudioInstance");
+
+		if (seoStudioInstanceJSONObject != null) {
+			_pageSpeedAPIKey = seoStudioInstanceJSONObject.optString(
+				"googlePageSpeedAPIKey", null);
+		}
+		else {
+			_pageSpeedAPIKey = null;
+		}
+	}
+
+	public String getHostname() {
+		return _hostname;
+	}
+
+	public String getPageSpeedAPIKey() {
+		return _pageSpeedAPIKey;
+	}
+
+	private final String _hostname;
+	private final String _pageSpeedAPIKey;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Sitemap.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Sitemap.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kiana Suetani
+ */
+@JacksonXmlRootElement
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Sitemap {
+
+	public List<SitemapEntry> getIndexSitemapEntries() {
+		return _indexSitemapEntries;
+	}
+
+	public List<SitemapEntry> getURLSitemapEntries() {
+		return _urlSitemapEntries;
+	}
+
+	@JacksonXmlElementWrapper(useWrapping = false)
+	@JacksonXmlProperty(localName = "sitemap")
+	private List<SitemapEntry> _indexSitemapEntries = new ArrayList<>();
+
+	@JacksonXmlElementWrapper(useWrapping = false)
+	@JacksonXmlProperty(localName = "url")
+	private List<SitemapEntry> _urlSitemapEntries = new ArrayList<>();
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/SitemapEntry.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/SitemapEntry.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * @author Kiana Suetani
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SitemapEntry {
+
+	public String getLoc() {
+		return _loc;
+	}
+
+	@JacksonXmlProperty(localName = "loc")
+	private String _loc;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayHeadlessService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayHeadlessService.java
@@ -1,0 +1,234 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.Sitemap;
+import com.liferay.seo.studio.model.SitemapEntry;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class LiferayHeadlessService extends BaseService {
+
+	public Domain getDomain(long domainId) {
+		try {
+			UriComponents uriComponents = UriComponentsBuilder.fromPath(
+				"/o/seo-studio/domains/" + domainId
+			).queryParam(
+				"nestedFields", "seoStudioInstance"
+			).build();
+
+			String domainJSON = get(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					"liferay-seostudio-etc-pagespeed-oahs"),
+				uriComponents.toUri());
+
+			if (Validator.isNull(domainJSON)) {
+				throw new IllegalArgumentException(
+					"Domain " + domainId + " was not found");
+			}
+
+			return new Domain(new JSONObject(domainJSON));
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to read domain " + domainId, jsonException);
+			}
+
+			throw new IllegalArgumentException(
+				"Domain " + domainId + " was not found", jsonException);
+		}
+	}
+
+	public List<String> getSitemapPageURLs(
+		String domainHostname, int maxPages) {
+
+		if ((maxPages <= 0) || Validator.isNull(domainHostname)) {
+			return Collections.emptyList();
+		}
+
+		String sitemapURL = "https://" + domainHostname + "/sitemap.xml";
+
+		String sitemapXML = _getSitemapXML(sitemapURL);
+
+		if (Validator.isNull(sitemapXML)) {
+			return Collections.emptyList();
+		}
+
+		return _parseSitemapURLs(0, maxPages, sitemapXML);
+	}
+
+	private String _getSitemapXML(String url) {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+				).uri(
+					URI.create(url)
+				).timeout(
+					Duration.ofSeconds(10)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to fetch sitemap ", url, ", HTTP ",
+							httpResponse.statusCode()));
+				}
+
+				return null;
+			}
+
+			return httpResponse.body();
+		}
+		catch (InterruptedException | IOException exception) {
+			if (exception instanceof InterruptedException) {
+				Thread thread = Thread.currentThread();
+
+				thread.interrupt();
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to fetch sitemap " + url, exception);
+			}
+
+			return null;
+		}
+	}
+
+	private List<String> _parseSitemapURLs(
+		int depth, int maxPages, String xml) {
+
+		if (maxPages <= 0) {
+			return Collections.emptyList();
+		}
+
+		if (depth > _MAX_SITEMAP_RECURSION_DEPTH) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Maximum sitemap recursion depth exceeded");
+			}
+
+			return Collections.emptyList();
+		}
+
+		Sitemap sitemap;
+
+		try {
+			sitemap = _xmlMapper.readValue(xml, Sitemap.class);
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to parse sitemap", ioException);
+			}
+
+			return Collections.emptyList();
+		}
+
+		List<SitemapEntry> indexSitemapEntries =
+			sitemap.getIndexSitemapEntries();
+
+		if (ListUtil.isEmpty(indexSitemapEntries)) {
+			List<SitemapEntry> urlSitemapEntries =
+				sitemap.getURLSitemapEntries();
+
+			if (ListUtil.isEmpty(urlSitemapEntries)) {
+				return Collections.emptyList();
+			}
+
+			List<String> urls = new ArrayList<>();
+
+			for (SitemapEntry sitemapEntry : urlSitemapEntries) {
+				String loc = sitemapEntry.getLoc();
+
+				if (Validator.isNotNull(loc)) {
+					urls.add(loc.trim());
+
+					if (urls.size() >= maxPages) {
+						break;
+					}
+				}
+			}
+
+			return urls;
+		}
+
+		List<String> urls = new ArrayList<>();
+
+		for (SitemapEntry sitemapEntry : indexSitemapEntries) {
+			String loc = sitemapEntry.getLoc();
+
+			if (Validator.isNull(loc)) {
+				continue;
+			}
+
+			String sitemapXML = _getSitemapXML(loc.trim());
+
+			if (Validator.isNotNull(sitemapXML)) {
+				urls.addAll(
+					_parseSitemapURLs(
+						depth + 1, maxPages - urls.size(), sitemapXML));
+			}
+
+			if (urls.size() >= maxPages) {
+				break;
+			}
+		}
+
+		return urls;
+	}
+
+	private static final int _MAX_SITEMAP_RECURSION_DEPTH = 3;
+
+	private static final Log _log = LogFactory.getLog(
+		LiferayHeadlessService.class);
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).build();
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	private final XmlMapper _xmlMapper = new XmlMapper();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

To collect Google PageSpeed scores for a domain's sitemap pages, the SEO Studio PageSpeed client extension needs a way to (a) load a domain configuration (with its PageSpeed API key) from the Headless API, and (b) discover the URLs to scan by parsing the domain's sitemap.xml. Neither piece exists yet in liferay-seostudio-etc-pagespeed.

## How It Is Being Fixed

This PR introduces the utility layer that the upcoming scanner will compose:

- Domain — value class wrapping the Headless Domain JSON response, exposing hostname and the nested seoStudioInstance.googlePageSpeedAPIKey.
- Sitemap and SitemapEntry — Jackson-XML bound value classes for parsing both index and url-style sitemap.xml documents.
- LiferayHeadlessService — Spring component extending BaseService. getDomain(long) calls /o/seo-studio/domains/{id} with nestedFields=seoStudioInstance and deserializes into a Domain. getSitemapPageURLs(hostname, maxPages) recursively walks the domain's sitemap (capped at depth 3) and returns up to maxPages page URLs.

The build.gradle adds the jackson-dataformat-xml and org.json dependencies these classes need. A follow-up PR will introduce the scanner that composes these utilities to call the Google PageSpeed API per discovered URL and write the scores back through Headless.

## Why Are There No Tests?

Tests come in a later PR alongside the scanner that composes these classes. The utilities landed here are value objects (Domain, Sitemap, SitemapEntry) plus thin Headless/HTTP wrappers (LiferayHeadlessService) whose behavior is more meaningfully exercised once the scanner wires them together.

## PR Check

**pr-check: PASS** — tested on `e1c3fb674f4c09f5962e4ad2504ac114526876c0`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "e1c3fb674f4c09f5962e4ad2504ac114526876c0"} -->
