### PR TITLE
LPD-96637 Hide Launch objects from the Objects definitions table

### DIFF
--- a/modules/apps/launch/launch-impl/src/main/resources/com/liferay/launch/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/launch/launch-impl/src/main/resources/com/liferay/launch/internal/batch/01-object-definition.batch-engine-data.json
@@ -31,7 +31,7 @@
 			"objectDefinitionSettings": [
 				{
 					"name": "visible",
-					"value": "true"
+					"value": "false"
 				}
 			],
 			"objectFields": [
@@ -124,7 +124,7 @@
 			"objectDefinitionSettings": [
 				{
 					"name": "visible",
-					"value": "true"
+					"value": "false"
 				}
 			],
 			"objectFields": [


### PR DESCRIPTION
Hides the **Launch Entry** and **Launch Set** system object definitions from the Objects admin definitions table by flipping their `visible` object-definition setting from `true` to `false`.

These are internal, framework-provisioned objects backing the Launches feature; they should not appear alongside user-managed custom objects. Both are `modifiable`+`system` definitions, so `ObjectDefinitionImpl.isVisible()` reads the `visible` setting, which drives the `Field.HIDDEN` index flag that filters the definitions list. The batch config uses UPSERT/UPDATE, so the setting updates on redeploy for already-provisioned instances.

JIRA: LPD-96637