### PR TITLE
LPD-96482 Pin available locales for localized friendly URL tests

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
@@ -57,6 +58,10 @@ import org.junit.runner.RunWith;
 /**
  * @author Adolfo Pérez
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "es_ES", "pt_BR", "zh_CN"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class FriendlyURLEntryLocalServiceTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96482

## What Is Being Fixed

Three tests in FriendlyURLEntryLocalServiceTest — testAddFriendlyURLEntryKeepsOldLocalizedValues, testDeleteFriendlyURLLocalizationEntry, and testFetchFriendlyURLEntryLocalizationByLanguageIdAndParentClassPKReturnsLocalization — fail intermittently depending on what ran earlier against the same server. Each uses the Chinese (zh_CN) locale, and FriendlyURLEntryLocalServiceImpl silently drops any url title whose locale is not among the group's available locales. When an earlier test module leaves the default company without zh_CN, the Chinese localizations are never persisted and the three assertions fail.

## How It Is Being Fixed

The test class now declares @LanguageIds with the exact locale set it exercises (en_US, es_ES, pt_BR, zh_CN) and en_US as the default. The rule forces those company locales before the class runs and restores them afterward, so the localized entries survive regardless of the bundle's inherited locale state. This removes the hidden dependency on locales the test never set, rather than chasing whichever earlier module leaked the state.

## Why Are There No Tests?

The change only hardens existing integration tests by pinning the locales they depend on; it adds no production code, so no new tests are warranted. The three previously failing tests now pass (verified 33/33 in FriendlyURLEntryLocalServiceTest).

## PR Check

**pr-check: PASS** — tested on `7a90bcf0b631af38514eb5c0cf4d8ffef90a5d37`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7a90bcf0b631af38514eb5c0cf4d8ffef90a5d37"} -->
