### PR TITLE
LPD-88837 Add Liferay Headless client and PageSpeed value classes

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -20,9 +20,11 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 dependencies {
+	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class Domain {
+
+	public Domain(JSONObject jsonObject) {
+		_domainHostname = jsonObject.optString("domainHostname", null);
+
+		JSONObject seoStudioInstanceJSONObject = jsonObject.optJSONObject(
+			"seoStudioInstance");
+
+		if (seoStudioInstanceJSONObject != null) {
+			_googlePageSpeedAPIKey = seoStudioInstanceJSONObject.optString(
+				"googlePageSpeedAPIKey", null);
+		}
+		else {
+			_googlePageSpeedAPIKey = null;
+		}
+	}
+
+	public String getDomainHostname() {
+		return _domainHostname;
+	}
+
+	public String getGooglePageSpeedAPIKey() {
+		return _googlePageSpeedAPIKey;
+	}
+
+	private final String _domainHostname;
+	private final String _googlePageSpeedAPIKey;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -1,0 +1,234 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.Domain;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class LiferayService extends BaseService {
+
+	public Domain getDomain(long domainId) {
+		JSONObject jsonObject = null;
+
+		try {
+			jsonObject = new JSONObject(
+				get(
+					_liferayOAuth2AccessTokenManager.getAuthorization(
+						"liferay-seostudio-etc-pagespeed-oahs"),
+					UriComponentsBuilder.fromPath(
+						"/o/seo-studio/domains/" + domainId
+					).queryParam(
+						"nestedFields", "seoStudioInstance"
+					).build(
+					).toUri()));
+		}
+		catch (JSONException | NullPointerException exception) {
+			String message = "Domain " + domainId + " was not found";
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(message, exception);
+			}
+
+			throw new IllegalArgumentException(message, exception);
+		}
+
+		return new Domain(jsonObject);
+	}
+
+	public List<String> getSitemapPageURLs(String hostname, int limit) {
+		if ((limit <= 0) || Validator.isNull(hostname)) {
+			return Collections.emptyList();
+		}
+
+		String sitemapXML = _getSitemapXML(
+			"https://" + hostname + "/sitemap.xml");
+
+		if (Validator.isNull(sitemapXML)) {
+			return Collections.emptyList();
+		}
+
+		return _parseSitemapPageURLs(0, limit, sitemapXML);
+	}
+
+	private String _getSitemapXML(String url) {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+				).uri(
+					URI.create(url)
+				).timeout(
+					Duration.ofSeconds(10)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to fetch sitemap ", url, ", HTTP ",
+							httpResponse.statusCode()));
+				}
+
+				return null;
+			}
+
+			return httpResponse.body();
+		}
+		catch (IllegalArgumentException | IOException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to fetch sitemap " + url, exception);
+			}
+
+			return null;
+		}
+		catch (InterruptedException interruptedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to fetch sitemap " + url, interruptedException);
+			}
+
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			return null;
+		}
+	}
+
+	private List<String> _parseSitemapPageURLs(
+		int depth, int limit, String sitemapXML) {
+
+		if (limit <= 0) {
+			return Collections.emptyList();
+		}
+
+		if (depth > 3) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Maximum sitemap recursion depth exceeded");
+			}
+
+			return Collections.emptyList();
+		}
+
+		List<String> urls = new ArrayList<>();
+
+		JsonNode jsonNode = null;
+
+		try {
+			jsonNode = _xmlMapper.readTree(sitemapXML);
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to parse sitemap", ioException);
+			}
+
+			return urls;
+		}
+
+		if (jsonNode == null) {
+			return urls;
+		}
+
+		boolean hasSitemap = jsonNode.has("sitemap");
+
+		JsonNode entriesJsonNode =
+			hasSitemap ? jsonNode.path("sitemap") : jsonNode.path("url");
+
+		List<JsonNode> entryJsonNodes = new ArrayList<>();
+
+		if (entriesJsonNode.isArray()) {
+			entriesJsonNode.forEach(entryJsonNodes::add);
+		}
+		else if (!entriesJsonNode.isMissingNode()) {
+			entryJsonNodes.add(entriesJsonNode);
+		}
+
+		for (JsonNode entryJsonNode : entryJsonNodes) {
+			if (urls.size() >= limit) {
+				break;
+			}
+
+			JsonNode locJsonNode = entryJsonNode.path("loc");
+
+			String loc = locJsonNode.asText(null);
+
+			if (Validator.isNull(loc)) {
+				continue;
+			}
+
+			loc = loc.trim();
+
+			if (Validator.isNull(loc)) {
+				continue;
+			}
+
+			if (hasSitemap) {
+				String childSitemapXML = _getSitemapXML(loc);
+
+				if (Validator.isNotNull(childSitemapXML)) {
+					urls.addAll(
+						_parseSitemapPageURLs(
+							depth + 1, limit - urls.size(), childSitemapXML));
+				}
+			}
+			else {
+				urls.add(loc);
+			}
+		}
+
+		return urls;
+	}
+
+	private static final Log _log = LogFactory.getLog(LiferayService.class);
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).followRedirects(
+		HttpClient.Redirect.NORMAL
+	).build();
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	private final XmlMapper _xmlMapper = new XmlMapper();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

The PageSpeed client extension needs to fetch domain metadata and enumerate site page URLs from the portal's Headless APIs so the scanner (landing in a downstream stacked branch) can queue PageSpeed scans for a domain's pages. There was no client-side abstraction for those Headless calls.

## How It Is Being Fixed

Adds a `LiferayService` Spring `@Component` that talks to the portal's Headless API from the client extension. `getDomain(long domainId)` fetches an SEO Studio domain and its embedded PageSpeed API key. `getSitemapPageURLs(String domainHostname, int maxPages)` fetches the domain's `sitemap.xml`, follows sitemap-index nesting up to a small recursion cap, and returns URLs from the leaf `<urlset>` entries. Sitemap XML is parsed with `Pattern`-based `<loc>` capture rather than a full XML parser to avoid `SecureXMLFactoryProviderUtil`, which requires OSGi wiring not available in a standalone Spring Boot CET. A companion `Domain` model deserializes the JSON response from `/o/seo-studio/domains/{id}`.

## Why Are There No Tests?

CET modules under `workspaces/` intentionally carry no local unit tests to match every other workspace CET's shape. Coverage for the `LiferayService` methods lands in the downstream stacked branch (`LPD-88837.3-scanner`) via the portal's end-to-end Playwright suite where the scanner exercises these utilities against a running Liferay.

## PR Check

**pr-check: PASS** — tested on `c3f3714fbec904697e8ee065780d91d1acfa4164`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "c3f3714fbec904697e8ee065780d91d1acfa4164"} -->
