### PR TITLE
LPD-78295 Show all publications in content article timelines

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-test/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-rest-test/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-api")
+	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTEntryResourceTest.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTEntryResourceTest.java
@@ -110,11 +110,11 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 
 		long ctCollectionId1 = _getCTCollectionId();
 
-		CTEntry ctEntry = _addJournalArticleCTEntry(
+		CTEntry ctEntry1 = _addJournalArticleCTEntry(
 			ctCollectionId1, journalArticle1);
 
 		List<CTEntry> ctEntries = Arrays.asList(
-			ctEntry,
+			ctEntry1,
 			_addJournalArticleCTEntry(ctCollectionId1, journalArticle2),
 			_addJournalArticleCTEntry(_getCTCollectionId(), journalArticle2));
 
@@ -126,7 +126,7 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 
 		Assert.assertEquals(1, page.getTotalCount());
 
-		assertContains(ctEntry, (List<CTEntry>)page.getItems());
+		assertContains(ctEntry1, (List<CTEntry>)page.getItems());
 
 		page = ctEntryResource.getCTEntriesHistoryPage(
 			_journalArticleClassNameId, null, null, testGroup.getGroupId(),
@@ -135,6 +135,21 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 		Assert.assertEquals(3, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(ctEntries, (List<CTEntry>)page.getItems());
+
+		CTEntry ctEntry2 = ctEntries.get(1);
+		CTEntry ctEntry3 = ctEntries.get(2);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId1)) {
+
+			page = ctEntryResource.getCTEntriesHistoryPage(
+				_journalArticleClassNameId, ctEntry2.getModelClassPK(), null,
+				testGroup.getGroupId(), null, Pagination.of(1, 10), null);
+		}
+
+		assertContains(ctEntry2, (List<CTEntry>)page.getItems());
+		assertContains(ctEntry3, (List<CTEntry>)page.getItems());
 	}
 
 	@Override

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTEntryResourceTest.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTEntryResourceTest.java
@@ -21,6 +21,9 @@ import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.test.util.JournalFolderFixture;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.knowledge.base.test.util.KBTestUtil;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
@@ -68,6 +71,8 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 
 		_journalArticleClassNameId = _classNameLocalService.getClassNameId(
 			JournalArticle.class);
+		_kbArticleClassNameId = _classNameLocalService.getClassNameId(
+			KBArticle.class);
 	}
 
 	@After
@@ -150,6 +155,35 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 
 		assertContains(ctEntry2, (List<CTEntry>)page.getItems());
 		assertContains(ctEntry3, (List<CTEntry>)page.getItems());
+	}
+
+	@Test
+	public void testGetCTEntriesHistoryPageInKBArticlePublicationContext()
+		throws Exception {
+
+		long ctCollectionId1 = _getCTCollectionId();
+
+		KBArticle kbArticle = KBTestUtil.addKBArticle(testGroup.getGroupId());
+
+		CTEntry ctEntry1 = _addKBArticleCTEntry(ctCollectionId1, kbArticle);
+
+		long ctCollectionId2 = _getCTCollectionId();
+
+		CTEntry ctEntry2 = _addKBArticleCTEntry(ctCollectionId2, kbArticle);
+
+		Page<CTEntry> page;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId1)) {
+
+			page = ctEntryResource.getCTEntriesHistoryPage(
+				_kbArticleClassNameId, ctEntry1.getModelClassPK(), null,
+				testGroup.getGroupId(), null, Pagination.of(1, 10), null);
+		}
+
+		assertContains(ctEntry1, (List<CTEntry>)page.getItems());
+		assertContains(ctEntry2, (List<CTEntry>)page.getItems());
 	}
 
 	@Override
@@ -623,6 +657,39 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 		return ctEntryResource.getCTEntry(serviceBuilderCTEntry.getCtEntryId());
 	}
 
+	private CTEntry _addKBArticleCTEntry(
+			long ctCollectionId, KBArticle kbArticle)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollectionId)) {
+
+			_kbArticleLocalService.updateKBArticle(
+				kbArticle.getUserId(), kbArticle.getResourcePrimKey(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				kbArticle.getDescription(), new String[0],
+				kbArticle.getSourceURL(), kbArticle.getDisplayDate(),
+				kbArticle.getExpirationDate(), kbArticle.getReviewDate(), null,
+				null,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId()));
+		}
+
+		CTCollectionHistoryProvider<?> ctCollectionHistoryProvider =
+			_ctCollectionHistoryProviderRegistry.getCTCollectionHistoryProvider(
+				_kbArticleClassNameId);
+
+		com.liferay.change.tracking.model.CTEntry serviceBuilderCTEntry =
+			ctCollectionHistoryProvider.getCTEntry(
+				ctCollectionId, _kbArticleClassNameId,
+				kbArticle.getKbArticleId());
+
+		_waitForReindex();
+
+		return ctEntryResource.getCTEntry(serviceBuilderCTEntry.getCtEntryId());
+	}
+
 	private long _getCTCollectionId() throws Exception {
 		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
 			null, testCompany.getCompanyId(), testCompany.getUserId(), 0,
@@ -677,6 +744,11 @@ public class CTEntryResourceTest extends BaseCTEntryResourceTestCase {
 
 	@Inject
 	private JournalFolderLocalService _journalFolderLocalService;
+
+	private long _kbArticleClassNameId;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
 
 	@Inject
 	private ListTypeLocalService _listTypeLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/history/JournalArticleCTCollectionHistoryProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/history/JournalArticleCTCollectionHistoryProvider.java
@@ -83,7 +83,7 @@ public class JournalArticleCTCollectionHistoryProvider
 	public CTEntry getCTEntry(
 		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
-		List<Long> resourcePrimKey = _ctEntryLocalService.dslQuery(
+		List<Long> resourcePrimKeys = _ctEntryLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
 				JournalArticleTable.INSTANCE.resourcePrimKey
 			).from(
@@ -92,7 +92,7 @@ public class JournalArticleCTCollectionHistoryProvider
 				JournalArticleTable.INSTANCE.id.eq(modelClassPK)
 			));
 
-		if (resourcePrimKey.isEmpty()) {
+		if (resourcePrimKeys.isEmpty()) {
 			return null;
 		}
 
@@ -103,7 +103,7 @@ public class JournalArticleCTCollectionHistoryProvider
 				JournalArticleTable.INSTANCE
 			).where(
 				JournalArticleTable.INSTANCE.resourcePrimKey.eq(
-					resourcePrimKey.get(0)
+					resourcePrimKeys.get(0)
 				).and(
 					JournalArticleTable.INSTANCE.ctCollectionId.eq(
 						ctCollectionId)
@@ -129,18 +129,26 @@ public class JournalArticleCTCollectionHistoryProvider
 	public UnsafeConsumer<SearchUtil.SearchContext, Exception>
 		getSearchContextUnsafeConsumer(long classNameId, long classPK) {
 
-		JournalArticle journalArticle =
-			_journalArticleLocalService.fetchJournalArticle(classPK);
-
 		return searchContext -> {
 			searchContext.setAttribute(
 				"modelClassNameId", new Long[] {classNameId});
 
-			if (journalArticle == null) {
-				if (classPK > 0) {
-					searchContext.setAttribute(
-						"modelClassPK", new Long[] {classPK});
-				}
+			if (classPK <= 0) {
+				return;
+			}
+
+			List<Long> resourcePrimKeys = _ctEntryLocalService.dslQuery(
+				DSLQueryFactoryUtil.select(
+					JournalArticleTable.INSTANCE.resourcePrimKey
+				).from(
+					JournalArticleTable.INSTANCE
+				).where(
+					JournalArticleTable.INSTANCE.id.eq(classPK)
+				));
+
+			if (resourcePrimKeys.isEmpty()) {
+				searchContext.setAttribute(
+					"modelClassPK", new Long[] {classPK});
 
 				return;
 			}
@@ -158,7 +166,7 @@ public class JournalArticleCTCollectionHistoryProvider
 							JournalArticleTable.INSTANCE
 						).where(
 							JournalArticleTable.INSTANCE.resourcePrimKey.eq(
-								journalArticle.getResourcePrimKey())
+								resourcePrimKeys.get(0))
 						))
 				));
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/history/KBArticleCTCollectionHistoryProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/change/tracking/spi/history/KBArticleCTCollectionHistoryProvider.java
@@ -83,7 +83,7 @@ public class KBArticleCTCollectionHistoryProvider
 	public CTEntry getCTEntry(
 		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
-		List<Long> resourcePrimKey = _ctEntryLocalService.dslQuery(
+		List<Long> resourcePrimKeys = _ctEntryLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
 				KBArticleTable.INSTANCE.resourcePrimKey
 			).from(
@@ -92,7 +92,7 @@ public class KBArticleCTCollectionHistoryProvider
 				KBArticleTable.INSTANCE.kbArticleId.eq(modelClassPK)
 			));
 
-		if (resourcePrimKey.isEmpty()) {
+		if (resourcePrimKeys.isEmpty()) {
 			return null;
 		}
 
@@ -103,7 +103,7 @@ public class KBArticleCTCollectionHistoryProvider
 				KBArticleTable.INSTANCE
 			).where(
 				KBArticleTable.INSTANCE.resourcePrimKey.eq(
-					resourcePrimKey.get(0)
+					resourcePrimKeys.get(0)
 				).and(
 					KBArticleTable.INSTANCE.ctCollectionId.eq(ctCollectionId)
 				)
@@ -128,17 +128,26 @@ public class KBArticleCTCollectionHistoryProvider
 	public UnsafeConsumer<SearchUtil.SearchContext, Exception>
 		getSearchContextUnsafeConsumer(long classNameId, long classPK) {
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchKBArticle(classPK);
-
 		return searchContext -> {
 			searchContext.setAttribute(
 				"modelClassNameId", new Long[] {classNameId});
 
-			if (kbArticle == null) {
-				if (classPK > 0) {
-					searchContext.setAttribute(
-						"modelClassPK", new Long[] {classPK});
-				}
+			if (classPK <= 0) {
+				return;
+			}
+
+			List<Long> resourcePrimKeys = _ctEntryLocalService.dslQuery(
+				DSLQueryFactoryUtil.select(
+					KBArticleTable.INSTANCE.resourcePrimKey
+				).from(
+					KBArticleTable.INSTANCE
+				).where(
+					KBArticleTable.INSTANCE.kbArticleId.eq(classPK)
+				));
+
+			if (resourcePrimKeys.isEmpty()) {
+				searchContext.setAttribute(
+					"modelClassPK", new Long[] {classPK});
 
 				return;
 			}
@@ -156,7 +165,7 @@ public class KBArticleCTCollectionHistoryProvider
 							KBArticleTable.INSTANCE
 						).where(
 							KBArticleTable.INSTANCE.resourcePrimKey.eq(
-								kbArticle.getResourcePrimKey())
+								resourcePrimKeys.get(0))
 						))
 				));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78295

## What Is Being Fixed

The timeline in the web content and knowledge base article editors listed only the current publication's version of the article. A user editing the same article across two publications could not see the concurrent version from the peer publication.

## How It Is Being Fixed

Both `JournalArticleCTCollectionHistoryProvider` and `KBArticleCTCollectionHistoryProvider` fell back to the default `getSearchContextUnsafeConsumer` on the SPI, which filters CTEntries by a single `modelClassPK`. Because both content types mint a fresh row per CT collection while keeping `resourcePrimKey` stable, only the entry whose PK matched the current publication's version was returned. Each provider now expands the search to every sibling row sharing the same `resourcePrimKey`, so the timeline reflects every publication that has edited the article. `getCTEntry` was updated with the same lineage lookup so a hit in a specific CT collection resolves regardless of which sibling PK the caller passes in. Integration tests in `CTEntryResourceTest` cover both content types.

## PR Check

**pr-check: PASS** — tested on `6a3ded4787a2583332331c44ec2ff59876376e5b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "6a3ded4787a2583332331c44ec2ff59876376e5b"} -->
