### PR TITLE
LPD-96879 Detect the popup via a native dialog listener

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
@@ -536,6 +536,14 @@ test(
 		tag: '@LPD-69499',
 	},
 	async ({apiHelpers, membershipsPage, page}) => {
+		let dialogMessage: null | string = null;
+
+		page.on('dialog', async (dialog) => {
+			dialogMessage = dialog.message();
+
+			await dialog.dismiss();
+		});
+
 		const user = await apiHelpers.headlessAdminUser.postUserAccount({
 			familyName: `"><script>alert(2)</script>`,
 			givenName: `"><script>alert(1)</script>`,
@@ -568,9 +576,9 @@ test(
 
 		await userCard.click({force: true});
 
-		const alert = page.locator('.alert');
+		await expect(userCard.locator('input[type="checkbox"]')).toBeChecked();
 
-		await expect(alert).toHaveCount(0);
+		expect(dialogMessage).toBeNull();
 	}
 );
 
@@ -587,6 +595,14 @@ test(
 		site,
 		siteSettingsPage,
 	}) => {
+		let dialogMessage: null | string = null;
+
+		page.on('dialog', async (dialog) => {
+			dialogMessage = dialog.message();
+
+			await dialog.dismiss();
+		});
+
 		const site2 = await apiHelpers.headlessAdminSite.postSite({
 			membershipType: 'restricted',
 			name: getRandomString(),
@@ -677,9 +693,9 @@ test(
 			})
 			.click();
 
-		const alert = page.locator('.alert');
+		await expect(page.locator('p.approved.status')).toBeVisible();
 
-		await expect(alert).toHaveCount(0);
+		expect(dialogMessage).toBeNull();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96879
https://liferay.atlassian.net/browse/LPD-96882

### What

Fix the two site memberships Playwright tests (`memberships.spec.ts`) so they detect an actual popup instead of counting unrelated alert banners.

### Why

Both tests were migrated from Poshi, where `AssertAlertNotPresent()` verified that no native `window.alert()` dialog fired — i.e. the popup payload `<script>alert(1)</script>` did not execute. The migration mistranslated that into `expect(page.locator('.alert')).toHaveCount(0)`, but in CSS `.alert` matches Clay/Bootstrap alert banners, which have nothing to do with `window.alert`.

The assertion only passed by accident (no `.alert` banners on the page at migration time). It broke when LPD-87301 added a permanent "inherited memberships" info banner to the site memberships users list (`users.jsp`), which is itself a `.alert` element — so the count is now unconditionally ≥1.

The popup is correctly prevented (name is HTML-escaped server-side and by React), so this is a test-only fix.

### How

Both tests now register a `page.on('dialog', ...)` listener and assert no dialog appeared, matching the original Poshi intent.

### Tests

Both tests pass locally:

- `Confirm that no pop up appears when select user card with XSS name in memberships` — PASS
- `Assert no pop up when viewing membership request detail` — PASS

---

**pr-check: PASS** — tested on `43dfc555c9b9e26cf6fe431b5ef243cc388781a0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
