### PR TITLE
LPD-97002 Add SEOStudioIntegration object with scoped relationships

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -295,6 +295,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"SEOStudioInstance", "/seo-studio/instances"
 		).put(
+			"SEOStudioIntegration", "/seo-studio/integrations"
+		).put(
 			"SEOStudioPage", "/seo-studio/pages"
 		).put(
 			"SEOStudioScan", "/seo-studio/scans"

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-scopes-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-scopes-list-type-definition.json
@@ -1,0 +1,19 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_INTEGRATION_SCOPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "DOMAIN",
+			"key": "domain",
+			"name": "Domain",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "INSTANCE",
+			"key": "instance",
+			"name": "Instance",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Integration Scopes",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-states-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-states-list-type-definition.json
@@ -1,0 +1,25 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_INTEGRATION_STATES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "ACTIVE",
+			"key": "active",
+			"name": "Active",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "INACTIVE",
+			"key": "inactive",
+			"name": "Inactive",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "UNAVAILABLE",
+			"key": "unavailable",
+			"name": "Unavailable",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Integration States",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-types-list-type-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/list-type-definitions/seo-studio-integration-types-list-type-definition.json
@@ -1,0 +1,19 @@
+{
+	"externalReferenceCode": "L_SEO_STUDIO_INTEGRATION_TYPES",
+	"listTypeEntries": [
+		{
+			"externalReferenceCode": "GSC",
+			"key": "gsc",
+			"name": "Google Search Console",
+			"system": true
+		},
+		{
+			"externalReferenceCode": "PAGESPEED",
+			"key": "pageSpeed",
+			"name": "PageSpeed",
+			"system": true
+		}
+	],
+	"name": "SEO Studio Integration Types",
+	"system": true
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/10-seo-studio-integration-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/10-seo-studio-integration-object-definition.json
@@ -1,0 +1,161 @@
+{
+	"accountEntryRestricted": false,
+	"className": "com.liferay.object.model.ObjectDefinition#S0I9",
+	"enableFormContainer": false,
+	"enableIndexSearch": false,
+	"externalReferenceCode": "L_SEO_STUDIO_INTEGRATION",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio Integration"
+	},
+	"modifiable": true,
+	"name": "SEOStudioIntegration",
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "SCOPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Scope"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_INTEGRATION_SCOPES",
+			"name": "scope",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"defaultValue": "active",
+			"externalReferenceCode": "STATE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "State"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_INTEGRATION_STATES",
+			"name": "state",
+			"objectFieldSettings": [
+				{
+					"name": "stateFlow",
+					"value": {
+						"objectStates": [
+							{
+								"key": "active",
+								"objectStateTransitions": [
+									{
+										"key": "inactive"
+									},
+									{
+										"key": "unavailable"
+									}
+								]
+							},
+							{
+								"key": "inactive",
+								"objectStateTransitions": [
+									{
+										"key": "active"
+									}
+								]
+							},
+							{
+								"key": "unavailable",
+								"objectStateTransitions": [
+									{
+										"key": "active"
+									}
+								]
+							}
+						]
+					}
+				}
+			],
+			"required": true,
+			"state": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "TYPE",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Type"
+			},
+			"listTypeDefinitionExternalReferenceCode": "L_SEO_STUDIO_INTEGRATION_TYPES",
+			"name": "type",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_DOMAIN_TO_SEO_STUDIO_INTEGRATIONS",
+			"indexed": true,
+			"label": {
+				"en_US": "SEO Studio Domain to SEO Studio Integrations"
+			},
+			"name": "r_seoStudioDomainToSEOStudioIntegrations_seoStudioDomainId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_DOMAIN",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioDomain"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioDomainToSEOStudioIntegrations_seoStudioDomainERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_DOMAIN_TO_L_SEO_STUDIO_INTEGRATIONS",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": false,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_TO_SEO_STUDIO_INTEGRATIONS",
+			"indexed": true,
+			"label": {
+				"en_US": "SEO Studio Instance to SEO Studio Integrations"
+			},
+			"name": "r_seoStudioInstanceToSEOStudioIntegrations_seoStudioInstanceId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_INSTANCE",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioInstance"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioInstanceToSEOStudioIntegrations_seoStudioInstanceERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_INTEGRATIONS",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": false,
+			"system": true,
+			"type": "Long"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio Integrations"
+	},
+	"portlet": false,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "type"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-integration-object-relationship-1.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-integration-object-relationship-1.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_DOMAIN_TO_L_SEO_STUDIO_INTEGRATIONS",
+	"label": {
+		"en_US": "SEO Studio Domain to SEO Studio Integrations"
+	},
+	"name": "seoStudioDomainToSEOStudioIntegrations",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioDomain$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioIntegration$]",
+	"objectDefinitionName2": "SEOStudioIntegration",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-integration-object-relationship-2.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/seo-studio-integration-object-relationship-2.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_INTEGRATIONS",
+	"label": {
+		"en_US": "SEO Studio Instance to SEO Studio Integrations"
+	},
+	"name": "seoStudioInstanceToSEOStudioIntegrations",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioInstance$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioIntegration$]",
+	"objectDefinitionName2": "SEOStudioIntegration",
+	"system": true,
+	"type": "oneToMany"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97002

## What Is Being Fixed

SEO Studio integrations need to attach at either an instance scope or a domain scope, but the existing `SEOStudioIntegration` object (from LPD-94550's initial version) hard-locked to a single required Instance relationship. This PR reshapes the object so a single row can carry either scope, in the same shape SEO Studio already uses everywhere else (`SEOStudioScan`, `SEOStudioPage`, `SEOStudioGSCCredentials` — all rely on transitive parent inference through the many-side FK).

## How It Is Being Fixed

Two commits under `seo-studio-site-initializer`, plus a small companion entry in `object-api`'s `ObjectDefinitionUtil`:

1. Add two picklists: `L_SEO_STUDIO_INTEGRATION_STATES` (moved out of LPD-94550) and the new `L_SEO_STUDIO_INTEGRATION_SCOPES` with entries `instance` and `domain`.

2. Introduce `10-seo-studio-integration-object-definition.json` with three picklists (`scope`, `state`, `type`) and two optional relationships (Domain, Instance) so exactly one FK is set per row; register the two relationships via `seo-studio-integration-object-relationship-1/2.json`; and register `SEOStudioIntegration` in `ObjectDefinitionUtil` for URL routing.

The scope XOR validation belongs on a separate follow-up ticket alongside the Java-side changes in `seo-studio-web`; this PR is intentionally schema-only so it can be forwarded and reviewed independently. LPD-94550 depends on this landing first and will rebase on master afterwards.

## Why Are There No Tests?

The changes are Liferay Object site-initializer JSON (picklists, object definition, relationships) plus a 2-line map entry in `ObjectDefinitionUtil`. Object definitions are validated at runtime by the site initializer; unit tests are not the right layer for schema data. Runtime coverage comes from LPD-94550's integrations card once it lands on top of this.

## PR Check

**pr-check: PASS** — tested on `929f2be533b1fd5a7fbb7d1c910660a6de5051d5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS (no signature change) |
| Baseline | PASS (no signature change → no version bump needed) |
| Java Unit Tests | PASS (no counterpart tests exist) |

<!-- pr-check {"result": "success", "sha": "929f2be533b1fd5a7fbb7d1c910660a6de5051d5"} -->
