### PR TITLE
LPD-91213 Add orphan page detection and scan status polling to the crawler client extension

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/BaseDetectionCrawler.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/BaseDetectionCrawler.java
@@ -1,0 +1,312 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.crawler;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Noor Najjar
+ */
+public abstract class BaseDetectionCrawler {
+
+	public abstract void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI hostname,
+			long seoStudioScanId)
+		throws Exception;
+
+	protected static String getPageURL(CrawlHit crawlHit) {
+		String canonicalURL = crawlHit.getCanonicalURL();
+
+		if (Validator.isNotNull(canonicalURL)) {
+			return canonicalURL;
+		}
+
+		String url = crawlHit.getURL();
+
+		if (Validator.isNotNull(url)) {
+			return url;
+		}
+
+		return null;
+	}
+
+	protected Map<String, Long> ensurePages(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		Map<String, Long> pageIdsByURLMap = _readPages(seoStudioScanId);
+
+		List<String> missingPageURLs = ListUtil.filter(
+			pageURLs, pageURL -> !pageIdsByURLMap.containsKey(pageURL));
+
+		if (ListUtil.isEmpty(missingPageURLs)) {
+			return pageIdsByURLMap;
+		}
+
+		_createPagesBatch(accountEntryId, missingPageURLs, seoStudioScanId);
+
+		long time = System.currentTimeMillis() + _PAGE_FETCH_TIMEOUT;
+
+		while (true) {
+			Set<String> readPageURLs = pageIdsByURLMap.keySet();
+
+			if (readPageURLs.containsAll(pageURLs)) {
+				break;
+			}
+
+			if (System.currentTimeMillis() > time) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Timed out waiting for pages to be readable for scan " +
+							seoStudioScanId);
+				}
+
+				break;
+			}
+
+			Thread.sleep(_PAGE_FETCH_POLL_INTERVAL);
+
+			pageIdsByURLMap = _readPages(seoStudioScanId);
+		}
+
+		return pageIdsByURLMap;
+	}
+
+	protected void writeInsights(
+			long accountEntryId, JSONObject definitionJSONObject,
+			Map<String, Long> pageIdsByURLMap, List<String> pageURLs,
+			long seoStudioScanId)
+		throws Exception {
+
+		if (ListUtil.isEmpty(pageURLs)) {
+			return;
+		}
+
+		long seoStudioInsightTypeId = _createInsightTypeId(
+			accountEntryId, definitionJSONObject, seoStudioScanId);
+
+		_createScanInsightsBatch(
+			accountEntryId, definitionJSONObject.getString("classification"),
+			pageIdsByURLMap, pageURLs, seoStudioInsightTypeId, seoStudioScanId);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Wrote ", pageURLs.size(), " ",
+					definitionJSONObject.getString("name"),
+					" scan insights for insight type ",
+					seoStudioInsightTypeId));
+		}
+	}
+
+	private long _createInsightTypeId(
+		long accountEntryId, JSONObject definitionJSONObject,
+		long seoStudioScanId) {
+
+		JSONObject bodyJSONObject = new JSONObject();
+
+		bodyJSONObject.put(
+			"category", definitionJSONObject.getString("category")
+		).put(
+			"description", definitionJSONObject.optString("description")
+		).put(
+			"externalReferenceCode",
+			definitionJSONObject.getString("name") + "_" + seoStudioScanId
+		).put(
+			"name", definitionJSONObject.getString("name")
+		).put(
+			"r_accountToSEOStudioInsightTypes_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"severity", definitionJSONObject.getString("severity")
+		).put(
+			"whyItMatters", definitionJSONObject.optString("whyItMatters")
+		);
+
+		return new JSONObject(
+			_seoStudioService.createInsightType(bodyJSONObject)
+		).getLong(
+			"id"
+		);
+	}
+
+	private void _createPagesBatch(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray pagesJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				pagesJSONArray.put(
+					_toPageJSONObject(
+						accountEntryId, pageURL, seoStudioScanId));
+			}
+
+			_seoStudioService.createPagesBatch(pagesJSONArray);
+		}
+	}
+
+	private void _createScanInsightsBatch(
+			long accountEntryId, String classification,
+			Map<String, Long> pageIdsByURLMap, List<String> pageURLs,
+			long seoStudioInsightTypeId, long seoStudioScanId)
+		throws Exception {
+
+		String detectedDateString = Instant.now(
+		).truncatedTo(
+			ChronoUnit.SECONDS
+		).toString();
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray scanInsightsJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				Long seoStudioPageId = pageIdsByURLMap.get(pageURL);
+
+				if (seoStudioPageId == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"No page was found for URL " + pageURL +
+								"; skipping scan insight");
+					}
+
+					continue;
+				}
+
+				scanInsightsJSONArray.put(
+					_toScanInsightJSONObject(
+						accountEntryId, classification, detectedDateString,
+						seoStudioInsightTypeId, seoStudioPageId,
+						seoStudioScanId));
+			}
+
+			if (scanInsightsJSONArray.length() == 0) {
+				continue;
+			}
+
+			_seoStudioService.createScanInsightsBatch(scanInsightsJSONArray);
+		}
+	}
+
+	private Map<String, Long> _readPages(long seoStudioScanId) {
+		Map<String, Long> pageIdsByURLMap = new HashMap<>();
+
+		int page = 1;
+
+		while (true) {
+			JSONArray itemsJSONArray = new JSONObject(
+				_seoStudioService.fetchPage(page, _PAGE_SIZE, seoStudioScanId)
+			).optJSONArray(
+				"items"
+			);
+
+			if ((itemsJSONArray == null) || (itemsJSONArray.length() == 0)) {
+				break;
+			}
+
+			for (Object itemObject : itemsJSONArray) {
+				JSONObject itemJSONObject = (JSONObject)itemObject;
+
+				pageIdsByURLMap.put(
+					itemJSONObject.getString("pageURL"),
+					itemJSONObject.getLong("id"));
+			}
+
+			page++;
+		}
+
+		return pageIdsByURLMap;
+	}
+
+	private JSONObject _toPageJSONObject(
+		long accountEntryId, String pageURL, long seoStudioScanId) {
+
+		JSONObject pageJSONObject = new JSONObject();
+
+		pageJSONObject.put(
+			"pageURL", pageURL
+		).put(
+			"r_accountToSEOStudioPages_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId", seoStudioScanId
+		);
+
+		return pageJSONObject;
+	}
+
+	private JSONObject _toScanInsightJSONObject(
+		long accountEntryId, String classification, String detectedDateString,
+		long seoStudioInsightTypeId, long seoStudioPageId,
+		long seoStudioScanId) {
+
+		JSONObject scanInsightJSONObject = new JSONObject();
+
+		scanInsightJSONObject.put(
+			"classification", classification
+		).put(
+			"detectedDate", detectedDateString
+		).put(
+			"r_accountToSEOStudioScanInsights_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioInsightTypeToScanInsights_seoStudioInsightTypeId",
+			seoStudioInsightTypeId
+		).put(
+			"r_seoStudioPageToSEOStudioScanInsights_seoStudioPageId",
+			seoStudioPageId
+		).put(
+			"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+			seoStudioScanId
+		);
+
+		return scanInsightJSONObject;
+	}
+
+	private static final int _BATCH_SIZE = 100;
+
+	private static final long _PAGE_FETCH_POLL_INTERVAL = 1000;
+
+	private static final long _PAGE_FETCH_TIMEOUT = 60000;
+
+	private static final int _PAGE_SIZE = 2000;
+
+	private static final Log _log = LogFactory.getLog(
+		BaseDetectionCrawler.class);
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/OrphanPagesDetectionCrawler.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/crawler/OrphanPagesDetectionCrawler.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.crawler;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class OrphanPagesDetectionCrawler extends BaseDetectionCrawler {
+
+	@Override
+	public void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI hostname,
+			long seoStudioScanId)
+		throws Exception {
+
+		Set<String> canonicalURLs = new LinkedHashSet<>();
+		Set<String> linkedURLs = new HashSet<>();
+
+		for (CrawlHit crawlHit : crawlHits) {
+			String canonicalURL = crawlHit.getCanonicalURL();
+
+			if (Validator.isNull(canonicalURL)) {
+				continue;
+			}
+
+			canonicalURLs.add(canonicalURL);
+
+			for (String linkURL : crawlHit.getLinks()) {
+				if (Validator.isNotNull(linkURL) &&
+					!linkURL.equals(canonicalURL)) {
+
+					linkedURLs.add(linkURL);
+				}
+			}
+		}
+
+		List<String> orphanPageURLs = new ArrayList<>();
+
+		String domainURL = SEOStudioService.toDomainURL(hostname);
+
+		for (String canonicalURL : canonicalURLs) {
+			if (canonicalURL.equals(domainURL) ||
+				linkedURLs.contains(canonicalURL)) {
+
+				continue;
+			}
+
+			orphanPageURLs.add(canonicalURL);
+		}
+
+		if (ListUtil.isEmpty(orphanPageURLs)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"No orphan pages were detected for scan " +
+						seoStudioScanId);
+			}
+
+			return;
+		}
+
+		JSONObject definitionJSONObject = new JSONObject();
+
+		definitionJSONObject.put(
+			"category", "linksAndURLs"
+		).put(
+			"classification", "problem"
+		).put(
+			"name", "orphanPages"
+		).put(
+			"severity", "2"
+		);
+
+		writeInsights(
+			accountEntryId, definitionJSONObject,
+			ensurePages(accountEntryId, orphanPageURLs, seoStudioScanId),
+			orphanPageURLs, seoStudioScanId);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrphanPagesDetectionCrawler.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.crawler.OrphanPagesDetectionCrawler;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+
+import java.net.URI;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class CrawlerJobStatusService {
+
+	@Scheduled(fixedDelay = 60000)
+	public void updateStatuses() {
+		JSONArray itemsJSONArray = new JSONObject(
+			_seoStudioService.fetchActiveScans()
+		).optJSONArray(
+			"items"
+		);
+
+		if (itemsJSONArray == null) {
+			return;
+		}
+
+		for (Object scanObject : itemsJSONArray) {
+			JSONObject scanJSONObject = (JSONObject)scanObject;
+
+			long seoStudioScanId = scanJSONObject.getLong("id");
+
+			try {
+				String executionId = scanJSONObject.optString("executionId");
+
+				if (Validator.isNull(executionId)) {
+					continue;
+				}
+
+				Job job = _kubernetesJobService.getJob(executionId);
+
+				String state = _getScanState(job);
+
+				if (Validator.isNull(state) ||
+					state.equals(scanJSONObject.optString("state"))) {
+
+					continue;
+				}
+
+				if (state.equals(SEOStudioScanConstants.STATE_COMPLETED)) {
+					String errorMessage = _detectOrphanPages(
+						scanJSONObject, seoStudioScanId);
+
+					if (Validator.isNotNull(errorMessage)) {
+						_seoStudioService.updateScan(
+							errorMessage, seoStudioScanId,
+							SEOStudioScanConstants.STATE_FAILED);
+					}
+					else {
+						_seoStudioService.updateScan(
+							null, seoStudioScanId,
+							SEOStudioScanConstants.STATE_COMPLETED);
+					}
+				}
+				else if (state.equals(SEOStudioScanConstants.STATE_FAILED)) {
+					_seoStudioService.updateScan(
+						_getErrorMessage(job), seoStudioScanId,
+						SEOStudioScanConstants.STATE_FAILED);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to update status of scan " + seoStudioScanId,
+					exception);
+			}
+		}
+	}
+
+	private String _detectOrphanPages(
+			JSONObject scanJSONObject, long seoStudioScanId)
+		throws Exception {
+
+		long seoStudioDomainId = scanJSONObject.getLong(
+			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+		String domainJSON = _seoStudioService.fetchDomain(seoStudioDomainId);
+
+		if (Validator.isNull(domainJSON)) {
+			return "No domain was found for SEO Studio domain ID " +
+				seoStudioDomainId;
+		}
+
+		List<CrawlHit> crawlHits = _seoStudioService.fetchCrawlHits(
+			seoStudioDomainId);
+
+		if (ListUtil.isEmpty(crawlHits)) {
+			return "No crawl hits were found for SEO Studio domain ID " +
+				seoStudioDomainId;
+		}
+
+		URI hostname = SEOStudioService.toCrawlURI(
+			new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			));
+
+		_orphanPagesDetectionCrawler.detect(
+			scanJSONObject.getLong("r_accountToSEOStudioScans_accountEntryId"),
+			crawlHits, hostname, seoStudioScanId);
+
+		return null;
+	}
+
+	private String _getErrorMessage(Job job) {
+		if (job == null) {
+			return "Kubernetes job does not exist";
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		List<JobCondition> jobConditions = jobStatus.getConditions();
+
+		if (ListUtil.isEmpty(jobConditions)) {
+			return "Kubernetes job failed";
+		}
+
+		for (JobCondition jobCondition : jobConditions) {
+			if (!Objects.equals(jobCondition.getType(), "Failed") ||
+				!Objects.equals(jobCondition.getStatus(), "True")) {
+
+				continue;
+			}
+
+			String errorMessage = jobCondition.getMessage();
+
+			if (Validator.isNotNull(errorMessage)) {
+				return errorMessage;
+			}
+		}
+
+		return "Kubernetes job failed";
+	}
+
+	private String _getScanState(Job job) {
+		if (job == null) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		if (jobStatus == null) {
+			return null;
+		}
+
+		Integer active = jobStatus.getActive();
+
+		if ((active != null) && (active > 0)) {
+			return SEOStudioScanConstants.STATE_RUNNING;
+		}
+
+		Integer failed = jobStatus.getFailed();
+
+		if ((failed != null) && (failed > 0)) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		Integer succeeded = jobStatus.getSucceeded();
+
+		if ((succeeded != null) && (succeeded > 0)) {
+			return SEOStudioScanConstants.STATE_COMPLETED;
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerJobStatusService.class);
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private OrphanPagesDetectionCrawler _orphanPagesDetectionCrawler;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213   

## What

Adds the orphan-page detection and scan-status polling logic to the `liferay-seostudio-etc-crawler` client extension, under the parent effort LPD-86649 (detect orphan pages in the XML sitemap using the Elasticsearch Open Crawler).

  Three new classes:

  - **`BaseDetectionCrawler`** — abstract base for detection crawlers. Provides the shared pipeline: `ensurePages` (ensures a SEO Studio Page entry exists for each URL, creating the
  missing ones in batches and polling until they are readable), `writeInsights` (creates the insight type and writes its scan insights in batches), and the page/insight JSON builders.
  Subclasses implement `detect(...)`.
  - **`OrphanPagesDetectionCrawler`** — concrete crawler. From a domain's crawl hits it collects every page's canonical URL and every URL linked from another page, then flags any
  canonical URL that is neither the domain root nor linked from elsewhere as an orphan, writing those as `orphanPages` scan insights.
  - **`CrawlerJobStatusService`** — a Spring `@Scheduled` poller (60s) that fetches active scans, resolves each one's Kubernetes job by execution ID, derives the scan state from the
  job's pod counts, and updates the scan when the state changes. On completion it runs orphan detection; on failure it records the Kubernetes failure message.

  ## Why

  Completes the crawler-side pipeline that turns raw crawl results into actionable SEO Studio scan insights, and drives scans to a terminal state without manual intervention.

  ## Dependency

  Builds on **liferay-site-management/liferay-portal#3517**, which introduces `SEOStudioService`, `CrawlHit`, and `KubernetesJobService`. This branch does not compile against `master` on
  its own — it must be merged on top of / together with #3517. (This is why CI compilation and `pr-check` will fail in isolation.)