### PR TITLE
LPD-86527 LPD-97399 Preserve Page Review context on back navigation

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -280,7 +280,7 @@ public class ViewChangesDisplayContext {
 					_renderResponse
 				).setMVCRenderCommandName(
 					"/change_tracking/view_change"
-				).setRedirect(
+				).setBackURL(
 					_themeDisplay.getURLCurrent()
 				).setParameter(
 					"ctCollectionId", "{ctCollectionId}"

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -544,6 +544,8 @@ public class ViewChangesDisplayContext {
 				_renderResponse
 			).setMVCRenderCommandName(
 				"/change_tracking/view_change"
+			).setBackURL(
+				_themeDisplay.getURLCurrent()
 			).setParameter(
 				"ctCollectionId", _ctCollection.getCtCollectionId()
 			).buildString()

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingLayoutChangesSidePanel.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingLayoutChangesSidePanel.js
@@ -9,7 +9,7 @@ import {SidePanel} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayPanel from '@clayui/panel';
-import {fetch} from 'frontend-js-web';
+import {createPortletURL, fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const DELTA = 20;
@@ -121,39 +121,50 @@ export default function ChangeTrackingLayoutChangesSidePanel({
 							{Liferay.Language.get('collapse-all')}
 						</ClayButton>
 					</ClayButton.Group>
-					{panels.map((panel) => (
-						<ClayPanel
-							collapsable
-							displayTitle={
-								<ClayPanel.Title className="panel-title text-secondary">
-									{panel.title}
-								</ClayPanel.Title>
+					{panels.map((panel) => {
+						const viewChangeURL = createPortletURL(
+							panel.viewChangeURL,
+							{
+								backURL:
+									window.location.pathname +
+									window.location.search,
 							}
-							displayType="unstyled"
-							expanded={panel.expanded}
-							key={panel.ctEntryId}
-							onExpandedChange={() => {
-								handleExpanded(panel.ctEntryId);
-							}}
-							showCollapseIcon={true}
-						>
-							<ClayPanel.Body>
-								<div
-									className="mb-4 mt-3 taglib-diff-html"
-									dangerouslySetInnerHTML={{
-										__html: panel.preview,
-									}}
-								/>
+						).toString();
 
-								<a
-									className="btn btn-secondary btn-xs"
-									href={panel.viewChangeURL}
-								>
-									{Liferay.Language.get('view-details')}
-								</a>
-							</ClayPanel.Body>
-						</ClayPanel>
-					))}
+						return (
+							<ClayPanel
+								collapsable
+								displayTitle={
+									<ClayPanel.Title className="panel-title text-secondary">
+										{panel.title}
+									</ClayPanel.Title>
+								}
+								displayType="unstyled"
+								expanded={panel.expanded}
+								key={panel.ctEntryId}
+								onExpandedChange={() => {
+									handleExpanded(panel.ctEntryId);
+								}}
+								showCollapseIcon={true}
+							>
+								<ClayPanel.Body>
+									<div
+										className="mb-4 mt-3 taglib-diff-html"
+										dangerouslySetInnerHTML={{
+											__html: panel.preview,
+										}}
+									/>
+
+									<a
+										className="btn btn-secondary btn-xs"
+										href={viewChangeURL}
+									>
+										{Liferay.Language.get('view-details')}
+									</a>
+								</ClayPanel.Body>
+							</ClayPanel>
+						);
+					})}
 					{panels.length < total ? (
 						<div className="align-items-center d-flex justify-content-center">
 							<ClayButton

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_change.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_change.jsp
@@ -10,7 +10,8 @@
 <%
 ViewChangesDisplayContext viewChangesDisplayContext = (ViewChangesDisplayContext)request.getAttribute(CTWebKeys.VIEW_CHANGES_DISPLAY_CONTEXT);
 
-portletDisplay.setURLBack(
+String backURL = ParamUtil.getString(
+	request, "backURL",
 	PortletURLBuilder.createRenderURL(
 		renderResponse
 	).setMVCRenderCommandName(
@@ -18,6 +19,8 @@ portletDisplay.setURLBack(
 	).setParameter(
 		"ctCollectionId", viewChangesDisplayContext.getCtCollectionId()
 	).buildString());
+
+portletDisplay.setURLBack(backURL);
 
 portletDisplay.setShowBackIcon(true);
 

--- a/modules/test/playwright/tests/change-tracking-web/main/layoutContentChangesSidePanel.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/layoutContentChangesSidePanel.spec.ts
@@ -223,7 +223,7 @@ test('LPD-82049 Changes are limited to 20 panels and can be expanded to view mor
 	await expect(viewMoreButton).not.toBeVisible();
 });
 
-test('LPD-82049 Can redirect to fragment entry link change view', async ({
+test('LPD-82049, LPD-86527 Can redirect to fragment entry link change view and back', async ({
 	changeTrackingPage,
 	ctCollection,
 	page,
@@ -247,21 +247,23 @@ test('LPD-82049 Can redirect to fragment entry link change view', async ({
 		type: 'Page',
 	});
 
-	await expect(
-		page
-			.getByLabel('Layout Changes Side Panel')
-			.filter({hasText: 'Content Changes'})
-	).toBeVisible();
+	const sidePanelLocator = page
+		.getByLabel('Layout Changes Side Panel')
+		.filter({hasText: 'Content Changes'});
 
-	const viewDetailsButton = page.getByRole('link', {name: 'View Details'});
+	await expect(sidePanelLocator).toBeVisible();
 
 	const fragmentTitle = await page
 		.locator('button.panel-header-link')
 		.innerText();
 
-	await viewDetailsButton.click();
+	await page.getByRole('link', {name: 'View Details'}).click();
 
 	await expect(page.locator('h2')).toContainText(fragmentTitle, {
 		ignoreCase: true,
 	});
+
+	await page.getByRole('link', {exact: true, name: 'Back'}).click();
+
+	await expect(sidePanelLocator).toBeVisible();
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86527
https://liferay.atlassian.net/browse/LPD-97399

## What Is Being Fixed

The Publications Page Review screen has two flows that reach a change-detail screen where the in-app back button then returns the user to the top-level Review Changes table instead of the Page Review screen they came from.

The first (LPD-86527) is the Content Changes side panel: when the LPD-75671 feature flag is enabled, clicking "View Details" inside a side panel entry opens the detail screen; clicking Back loses the side-panel context. The second (LPD-97399) is Parents/Children navigation: on the Page Review screen, clicking the Parents or Children tab and then clicking a row to jump to a related entry produces the same broken back-button behavior. Both flows share the same root cause — the URL that navigates to `view_change.jsp` never carries a back-URL parameter, and the JSP's back button is hardcoded to the Review Changes table.

## How It Is Being Fixed

`view_change.jsp` now reads the `backURL` request parameter (via the same `ParamUtil.getString(request, name, default)` idiom sibling `view_discard.jsp` uses) and falls back to the previous hardcoded URL when the parameter is absent. Each URL builder in `ViewChangesDisplayContext.java` that navigates to `view_change.jsp` — the FDS row action and the `changeURL` used by the React view for Parents/Children navigation — now calls `.setBackURL(_themeDisplay.getURLCurrent())`, matching the same builder's `setBackURL` usage in the discard flow at line 598. `ChangeTrackingLayoutChangesSidePanel.js` wraps each side-panel "View Details" URL with `createPortletURL(url, {backURL: window.location.pathname + window.location.search})`, matching the pattern in the module's sibling `ChangeTrackingIndicator.js`. A Playwright test extends the existing `LPD-82049` case with a back-button assertion covering the side panel flow; the prove-it check confirms it fails on the un-fixed code and passes on the fixed code.

## PR Check

**pr-check: PASS** — tested on `9edfaf2c437f5176f17656fcd790b8bc4fbfc648`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS (NO-SOURCE) |
| JavaScript Unit Tests | N/A (module has no jest suite) |
| Java Unit Tests | N/A (no counterpart test) |

<!-- pr-check {"result": "success", "sha": "9edfaf2c437f5176f17656fcd790b8bc4fbfc648"} -->
