### PR TITLE
LPD-97013 Provision the AI Hub Cell connection on SEO Studio enablement

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-test/build.gradle
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/build.gradle
@@ -1,6 +1,12 @@
 dependencies {
 	testIntegrationImplementation project(":apps:account:account-api")
+	testIntegrationImplementation project(":apps:ai-hub-cell:ai-hub-cell-api")
+	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-api")
 	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-service-access-policy-api")
+	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/feature/flag/test/SEOStudioFeatureFlagListenerTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/feature/flag/test/SEOStudioFeatureFlagListenerTest.java
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.feature.flag.test;
+
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author David Truong
+ */
+@RunWith(Arquillian.class)
+public class SEOStudioFeatureFlagListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_configurationProvider.deleteCompanyConfiguration(
+			AIHubCellConfiguration.class, _company.getCompanyId());
+	}
+
+	@Test
+	public void testOnValue() throws Exception {
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					FeatureFlagConstants.getKey("LPD-62272"),
+					Boolean.TRUE.toString())) {
+
+			FeatureFlagTestUtil.invokeFeatureFlagListeners(
+				_company.getCompanyId(), true, "LPD-44511");
+
+			OAuth2Application oAuth2Application =
+				_oAuth2ApplicationLocalService.
+					fetchOAuth2ApplicationByExternalReferenceCode(
+						"SEO-STUDIO-AI-HUB-CELL-CLIENT",
+						_company.getCompanyId());
+
+			Assert.assertNotNull(oAuth2Application);
+
+			Assert.assertEquals(
+				Arrays.asList(GrantType.CLIENT_CREDENTIALS),
+				oAuth2Application.getAllowedGrantTypesList());
+
+			User user = _userLocalService.getUserById(
+				oAuth2Application.getClientCredentialUserId());
+
+			Assert.assertEquals(
+				"seo-studio-ai-hub-cell-service-account", user.getScreenName());
+			Assert.assertEquals(
+				UserConstants.TYPE_SERVICE_ACCOUNT, user.getType());
+
+			AIHubCellConfiguration aiHubCellConfiguration =
+				IdempotentRetryAssert.retryAssert(
+					10, TimeUnit.SECONDS, 1, TimeUnit.SECONDS,
+					() -> {
+						AIHubCellConfiguration currentAIHubCellConfiguration =
+							_configurationProvider.getCompanyConfiguration(
+								AIHubCellConfiguration.class,
+								_company.getCompanyId());
+
+						Assert.assertEquals(
+							oAuth2Application.getClientId(),
+							currentAIHubCellConfiguration.clientId());
+
+						return currentAIHubCellConfiguration;
+					});
+
+			Assert.assertEquals(
+				oAuth2Application.getClientSecret(),
+				aiHubCellConfiguration.clientSecret());
+			Assert.assertEquals(
+				_company.getPortalURL(0), aiHubCellConfiguration.serviceURL());
+
+			Assert.assertNotNull(
+				_oAuth2ApplicationLocalService.
+					fetchOAuth2ApplicationByExternalReferenceCode(
+						"AI-HUB-CELL", _company.getCompanyId()));
+			Assert.assertNotNull(
+				_sapEntryLocalService.fetchSAPEntry(
+					_company.getCompanyId(), "AI_HUB_CELL_TOKEN"));
+
+			FeatureFlagTestUtil.invokeFeatureFlagListeners(
+				_company.getCompanyId(), true, "LPD-44511");
+
+			IdempotentRetryAssert.retryAssert(
+				10, TimeUnit.SECONDS, 1, TimeUnit.SECONDS,
+				() -> {
+					AIHubCellConfiguration currentAIHubCellConfiguration =
+						_configurationProvider.getCompanyConfiguration(
+							AIHubCellConfiguration.class,
+							_company.getCompanyId());
+
+					Assert.assertEquals(
+						oAuth2Application.getClientId(),
+						currentAIHubCellConfiguration.clientId());
+
+					return currentAIHubCellConfiguration;
+				});
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private ConfigurationProvider _configurationProvider;
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Inject
+	private SAPEntryLocalService _sapEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/build.gradle
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	compileOnly group: "jakarta.servlet.jsp", name: "jakarta.servlet.jsp-api", version: "3.1.1"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:account:account-api")
+	compileOnly project(":apps:ai-hub-cell:ai-hub-cell-api")
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
@@ -16,8 +18,10 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:list-type:list-type-api")
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
+	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:site:site-api")

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/constants/SEOStudioWebConstants.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/constants/SEOStudioWebConstants.java
@@ -13,4 +13,7 @@ public class SEOStudioWebConstants {
 	public static final String BUNDLE_SYMBOLIC_NAME =
 		"com.liferay.seo.studio.web";
 
+	public static final String SCREEN_NAME_AI_HUB_CELL_SERVICE_ACCOUNT =
+		"seo-studio-ai-hub-cell-service-account";
+
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
@@ -5,22 +5,41 @@
 
 package com.liferay.seo.studio.web.internal.feature.flag;
 
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.oauth2.provider.constants.ClientProfile;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.seo.studio.web.internal.constants.SEOStudioWebConstants;
 import com.liferay.seo.studio.web.internal.util.SiteInitializerUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
+import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -44,6 +63,8 @@ public class SEOStudioFeatureFlagListener implements FeatureFlagListener {
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			_addAIHubCellConfiguration(companyId);
 
 			Group group = _groupLocalService.fetchGroup(
 				companyId, GroupConstants.SEO_STUDIO);
@@ -75,11 +96,112 @@ public class SEOStudioFeatureFlagListener implements FeatureFlagListener {
 		}
 	}
 
+	private void _addAIHubCellConfiguration(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-62272")) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Skipping the AI Hub Cell connection for company ",
+						companyId,
+						" because feature flag LPD-62272 is disabled"));
+			}
+
+			return;
+		}
+
+		try {
+			Company company = _companyLocalService.getCompany(companyId);
+
+			OAuth2Application oAuth2Application = _addOAuth2Application(
+				company);
+
+			_configurationProvider.saveCompanyConfiguration(
+				AIHubCellConfiguration.class, companyId,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"clientId", oAuth2Application.getClientId()
+				).put(
+					"clientSecret", oAuth2Application.getClientSecret()
+				).put(
+					"serviceURL", company.getPortalURL(0)
+				).build());
+		}
+		catch (PortalException portalException) {
+			_log.error(
+				"Unable to add the AI Hub Cell configuration for company " +
+					companyId,
+				portalException);
+		}
+	}
+
+	private OAuth2Application _addOAuth2Application(Company company)
+		throws PortalException {
+
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					_EXTERNAL_REFERENCE_CODE, company.getCompanyId());
+
+		if (oAuth2Application != null) {
+			return oAuth2Application;
+		}
+
+		User user = _addServiceAccountUser(company);
+
+		return _oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
+			_EXTERNAL_REFERENCE_CODE, user.getUserId(), user.getScreenName(),
+			Arrays.asList(GrantType.CLIENT_CREDENTIALS), "client_secret_post",
+			user.getUserId(), OAuth2SecureRandomGenerator.generateClientId(),
+			ClientProfile.HEADLESS_SERVER.id(),
+			OAuth2SecureRandomGenerator.generateClientSecret(), null, null,
+			company.getPortalURL(0), 0, null, "SEO Studio AI Hub Cell Client",
+			null, Arrays.asList(), false,
+			Arrays.asList(
+				"Liferay.AI.Hub.REST.everything",
+				"Liferay.AI.Hub.REST.everything.read",
+				"Liferay.AI.Hub.REST.everything.write"),
+			false, new ServiceContext());
+	}
+
+	private User _addServiceAccountUser(Company company)
+		throws PortalException {
+
+		String screenName =
+			SEOStudioWebConstants.SCREEN_NAME_AI_HUB_CELL_SERVICE_ACCOUNT;
+
+		User user = _userLocalService.fetchUserByScreenName(
+			company.getCompanyId(), screenName);
+
+		if (user != null) {
+			return user;
+		}
+
+		return _userLocalService.addUser(
+			UserConstants.USER_ID_DEFAULT, company.getCompanyId(), true, null,
+			null, false, screenName,
+			screenName + StringPool.AT + company.getMx(),
+			LocaleUtil.getDefault(), screenName, StringPool.BLANK,
+			"Service Account", 0, 0, true, Calendar.JANUARY, 1, 1970,
+			StringPool.BLANK, UserConstants.TYPE_SERVICE_ACCOUNT, null, null,
+			null, null, false, new ServiceContext());
+	}
+
+	private static final String _EXTERNAL_REFERENCE_CODE =
+		"SEO-STUDIO-AI-HUB-CELL-CLIENT";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SEOStudioFeatureFlagListener.class);
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference(
 		target = "(site.initializer.key=com.liferay.seo.studio.site.initializer)"

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/fragment/renderer/ViewOnPageInsightDetailsFragmentRenderer.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/fragment/renderer/ViewOnPageInsightDetailsFragmentRenderer.java
@@ -5,11 +5,20 @@
 
 package com.liferay.seo.studio.web.internal.fragment.renderer;
 
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.seo.studio.web.internal.constants.SEOStudioFDSNames;
+import com.liferay.seo.studio.web.internal.constants.SEOStudioWebConstants;
 import com.liferay.seo.studio.web.internal.display.context.ViewOnPageInsightDetailsDisplayContext;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +26,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Noor Najjar
@@ -43,6 +53,11 @@ public class ViewOnPageInsightDetailsFragmentRenderer
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		_ensureAIHubAccountMembership(
+			themeDisplay.getCompanyId(), themeDisplay.getUserId());
+
+		_ensureAIHubCellClientAccountMembership(themeDisplay.getCompanyId());
+
 		JSONArray viewsJSONArray = fdsSerializer.serializeViews(
 			SEOStudioFDSNames.AFFECTED_PAGES_SECTION, httpServletRequest);
 
@@ -54,5 +69,57 @@ public class ViewOnPageInsightDetailsFragmentRenderer
 	protected String getJSPPath() {
 		return "/on_page_insight_details_view.jsp";
 	}
+
+	private void _ensureAccountMembership(
+		long companyId, long userId, String accountEntryExternalReferenceCode) {
+
+		AccountEntry accountEntry =
+			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
+				accountEntryExternalReferenceCode, companyId);
+
+		if ((accountEntry == null) ||
+			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+				accountEntry.getAccountEntryId(), userId)) {
+
+			return;
+		}
+
+		try {
+			_accountEntryUserRelLocalService.addAccountEntryUserRel(
+				accountEntry.getAccountEntryId(), userId);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private void _ensureAIHubAccountMembership(long companyId, long userId) {
+		_ensureAccountMembership(companyId, userId, "L_AI_HUB");
+		_ensureAccountMembership(companyId, userId, "L_SEO_STUDIO");
+	}
+
+	private void _ensureAIHubCellClientAccountMembership(long companyId) {
+		User user = _userLocalService.fetchUserByScreenName(
+			companyId,
+			SEOStudioWebConstants.SCREEN_NAME_AI_HUB_CELL_SERVICE_ACCOUNT);
+
+		if (user == null) {
+			return;
+		}
+
+		_ensureAIHubAccountMembership(companyId, user.getUserId());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ViewOnPageInsightDetailsFragmentRenderer.class);
+
+	@Reference
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Reference
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97013

## What Is Being Fixed

Enabling the SEO Studio feature flag left Auto Fix non-functional until an administrator manually created a client-credentials OAuth2 application and a company-scoped AIHubCellConfiguration through the Groovy console, so a co-located AI Hub Cell could not be used out of the box.

## How It Is Being Fixed

SEOStudioFeatureFlagListener now provisions both pieces when the feature flag is enabled for a company: a SEO-Studio-owned client-credentials OAuth2 application (external reference code SEO-STUDIO-AI-HUB-CELL-CLIENT, display name "SEO Studio AI Hub Cell Client"), owned by a dedicated seo-studio-ai-hub-cell-service-account service account, and the company-scoped AIHubCellConfiguration pointing at it. The dedicated account (screen name shared via the new SEOStudioWebConstants.SCREEN_NAME_AI_HUB_CELL_SERVICE_ACCOUNT, created via the same fetch-or-create shape ai-hub-rest-impl's ProvisioningRequestManagerImpl uses, no extra Role needed) replaces the shared UserConstants.SCREEN_NAME_DEFAULT_SERVICE_ACCOUNT, which is also used by Analytics Cloud, Kaleo Designer, and the headless server OAuth2 config; reusing it would have leaked SEO-Studio-scoped account membership onto those unrelated features. Saving the configuration triggers the existing AIHubCellConfigurationModelListener, which creates the companion application and service access policy, so no new listener logic is needed there. ViewOnPageInsightDetailsFragmentRenderer._ensureAIHubCellClientAccountMembership grants account membership directly to the dedicated service account by screen name, rather than resolving whatever OAuth2 application AIHubCellConfiguration happens to point at: SEO Studio is a SaaS application and the sole consumer of AI Hub Cell for a given instance, so there is no other configuration to account for. For the same reason, _addOAuth2Application no longer guards against an already-populated AIHubCellConfiguration.clientId() from some other source; it's already idempotent on its own (it fetches by external reference code before creating), and the only scenario the guard additionally protected against can't occur under that single-consumer assumption.

SEOStudioFeatureFlagListenerTest follows the same shape as every other *FeatureFlagListenerTest in the codebase (DSR, PIM, Segments, CommerceOrderAttachment, AttachmentObjectFieldDownloadAction): it triggers the listener via FeatureFlagTestUtil.invokeFeatureFlagListeners instead of injecting the specific listener bean by OSGi filter and calling onValue() directly, and fakes the internally-checked LPD-62272 flag with a scoped PropsTemporarySwapper. It waits for the asynchronously-saved configuration via IdempotentRetryAssert.retryAssert (the established polling convention used at 39 call sites codebase-wide, including AI Hub's own test module) instead of a hand-rolled retry loop that would silently return a stale value on timeout.

## PR Check

**pr-check: PASS** — tested on `4427dd0acc58c4e2e2f4777a89c271190de54d2f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4427dd0acc58c4e2e2f4777a89c271190de54d2f"} -->
