### PR TITLE
LPD-97016 Prevent deleteGroup from deleting colliding layout permissions

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -16,10 +16,18 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -191,6 +199,58 @@ public class GroupLocalServiceTest {
 		}
 	}
 
+	@Test
+	public void testDeleteGroupPreservesCollidingLayoutPermission()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		long companyId = group.getCompanyId();
+		long groupId = group.getGroupId();
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+
+		String layoutClassName = Layout.class.getName();
+		String primKey = String.valueOf(groupId);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+			primKey, guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, layoutClassName, ResourceConstants.SCOPE_GROUP, primKey,
+			guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+				primKey));
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+				primKey));
+		Assert.assertEquals(
+			0,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_GROUP,
+				primKey));
+
+		for (ResourcePermission resourcePermission :
+				_resourcePermissionLocalService.getResourcePermissions(
+					companyId, layoutClassName,
+					ResourceConstants.SCOPE_INDIVIDUAL, primKey)) {
+
+			_resourcePermissionLocalService.deleteResourcePermission(
+				resourcePermission);
+		}
+	}
+
 	@FeatureFlag("LPD-82960")
 	@Test
 	public void testEnablingMaintenanceModeDeactivatesSite() throws Exception {
@@ -353,5 +413,11 @@ public class GroupLocalServiceTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1199,11 +1199,18 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 						group.getCompanyId(),
 						String.valueOf(group.getGroupId()));
 
+				String groupClassName = Group.class.getName();
+
 				for (ResourcePermission resourcePermission :
 						resourcePermissions) {
 
-					_resourcePermissionLocalService.deleteResourcePermission(
-						resourcePermission);
+					if ((resourcePermission.getScope() ==
+							ResourceConstants.SCOPE_GROUP) ||
+						groupClassName.equals(resourcePermission.getName())) {
+
+						_resourcePermissionLocalService.
+							deleteResourcePermission(resourcePermission);
+					}
 				}
 
 				// Indexer


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-64650
https://liferay.atlassian.net/browse/LPD-97016

## What Is Being Fixed

GroupLocalServiceImpl.deleteGroup deletes ResourcePermission rows by companyId and primKey with no filter on the resource name or scope. A Group's groupId is minted from the global counter while a Layout's plid is minted from a class-scoped counter, so the two can hold the same value (common on large or migrated databases). When a group whose groupId equals a Layout's plid is deleted, that Layout's ResourcePermission rows are removed, leaving the page inaccessible with "Someone may be trying to circumvent the permission checker" errors across the site. Deleting a user is only one of the many deleteGroup callers that can trigger this.

## How It Is Being Fixed

The deletion in the non-site branch is restricted to the group's own permission rows: a row is deleted only when it is group-scoped (scope == ResourceConstants.SCOPE_GROUP) or belongs to the Group resource (name == Group.class.getName()). This preserves the existing group-scoped and Group-own cleanup for every deleteGroup caller while leaving an unrelated resource's individual-scope permission untouched. A new integration test seeds a colliding Layout individual-scope permission alongside a legitimate group-scoped permission, deletes the group, and asserts the colliding permission survives while the group-scoped one is removed.

## PR Check

**pr-check: PASS** — tested on `b058e53a791cf82cdcf035eb9143ebacae41b3d1`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b058e53a791cf82cdcf035eb9143ebacae41b3d1"} -->
