### PR TITLE
LPD-93368 Recompute the next scan date when a schedule changes - Step 1

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-domain-object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-domain-object-actions.json
@@ -2,6 +2,19 @@
 	"object-actions": [
 		{
 			"active": true,
+			"conditionExpression": "(oldValue('autoScanEnabled') != autoScanEnabled) || (oldValue('scanDayOfMonth') != scanDayOfMonth) || (oldValue('scanDayOfWeek') != scanDayOfWeek) || (oldValue('scanFrequency') != scanFrequency) || (oldValue('scanTime') != scanTime) || (oldValue('scanTimeZone') != scanTimeZone)",
+			"externalReferenceCode": "L_SEO_STUDIO_DOMAIN_COMPUTE_NEXT_SCAN_DATE",
+			"label": {
+				"en_US": "Compute Next Scan Date"
+			},
+			"name": "computeNextScanDate",
+			"objectActionExecutorKey": "compute-seo-studio-domain-next-scan-date",
+			"objectActionTriggerKey": "onAfterUpdate",
+			"parameters": {
+			}
+		},
+		{
+			"active": true,
 			"errorMessage": {
 				"en_US": "Unable to create the scans. Please try again later or contact support."
 			},

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@FeatureFlag("LPD-44511")
+@RunWith(Arquillian.class)
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.seo.studio.site.initializer");
+
+		siteInitializer.initialize(_group.getGroupId());
+
+		_seoStudioDomainObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
+		_seoStudioInstanceObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			_objectActionLocalService.deleteObjectAction(objectAction);
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_seoStudioDomainObjectEntry != null) {
+			for (ObjectEntry seoStudioScanObjectEntry :
+					_getSEOStudioScanObjectEntries(
+						_seoStudioDomainObjectEntry)) {
+
+				_objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanObjectEntry.getObjectEntryId());
+			}
+
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioDomainObjectEntry.getObjectEntryId());
+		}
+
+		if (_seoStudioInstanceObjectEntry != null) {
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioInstanceObjectEntry.getObjectEntryId());
+		}
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testExecute() throws Exception {
+		_addSEOStudioDomainObjectEntry();
+
+		_updateSEOStudioDomainObjectEntry(true);
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			_seoStudioDomainObjectEntry.getObjectEntryId());
+
+		Date nextScanDate = (Date)values.get("nextScanDate");
+
+		Assert.assertTrue(nextScanDate.after(new Date()));
+	}
+
+	@Test
+	public void testExecuteWithAutoScanDisabled() throws Exception {
+		_addSEOStudioDomainObjectEntry();
+
+		_updateSEOStudioDomainObjectEntry(false);
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			_seoStudioDomainObjectEntry.getObjectEntryId());
+
+		Assert.assertNull(values.get("nextScanDate"));
+	}
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		return _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _addSEOStudioDomainObjectEntry() throws Exception {
+		AccountEntry accountEntry = _addAccountEntry();
+
+		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
+			accountEntry);
+
+		_seoStudioDomainObjectEntry = _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				_seoStudioInstanceObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _updateSEOStudioDomainObjectEntry(boolean autoScanEnabled)
+		throws Exception {
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(),
+			_seoStudioDomainObjectEntry.getObjectEntryId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"autoScanEnabled", autoScanEnabled
+			).put(
+				"scanFrequency", "daily"
+			).put(
+				"scanTime", "09:00"
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private ObjectEntry _addSEOStudioInstanceObjectEntry(
+			AccountEntry accountEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioInstances_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+				"seoStudioDomainToSEOStudioScans");
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioDomainObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectActionLocalService _objectActionLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private ObjectDefinition _seoStudioDomainObjectDefinition;
+	private ObjectEntry _seoStudioDomainObjectEntry;
+	private ObjectDefinition _seoStudioInstanceObjectDefinition;
+	private ObjectEntry _seoStudioInstanceObjectEntry;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -7,6 +7,7 @@ package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -33,7 +34,7 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 
 	@Test
 	public void testExecute() throws Exception {
-		_addSEOStudioDomainObjectEntry();
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry();
 
 		_updateSEOStudioDomainObjectEntry(true);
 
@@ -47,7 +48,7 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 
 	@Test
 	public void testExecuteWithAutoScanDisabled() throws Exception {
-		_addSEOStudioDomainObjectEntry();
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry();
 
 		_updateSEOStudioDomainObjectEntry(false);
 
@@ -57,12 +58,9 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 		Assert.assertNull(values.get("nextScanDate"));
 	}
 
-	private void _addSEOStudioDomainObjectEntry() throws Exception {
-		seoStudioDomainObjectEntry = objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+	private ObjectEntry _addSEOStudioDomainObjectEntry() throws Exception {
+		return addObjectEntry(
+			seoStudioDomainObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"hostname", RandomTestUtil.randomString()
 			).put(
@@ -73,9 +71,7 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 			).put(
 				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
 				seoStudioInstanceObjectEntry.getObjectEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 	private void _updateSEOStudioDomainObjectEntry(boolean autoScanEnabled)

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -5,47 +5,21 @@
 
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
-import com.liferay.account.constants.AccountConstants;
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectAction;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectActionLocalService;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.initializer.SiteInitializer;
-import com.liferay.site.initializer.SiteInitializerRegistry;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,73 +28,8 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
-public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(
-				"com.liferay.seo.studio.site.initializer");
-
-		siteInitializer.initialize(_group.getGroupId());
-
-		_seoStudioDomainObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
-		_seoStudioInstanceObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
-
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
-
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
-
-			_objectActionLocalService.deleteObjectAction(objectAction);
-		}
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_seoStudioDomainObjectEntry != null) {
-			for (ObjectEntry seoStudioScanObjectEntry :
-					_getSEOStudioScanObjectEntries(
-						_seoStudioDomainObjectEntry)) {
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanObjectEntry.getObjectEntryId());
-			}
-
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioInstanceObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
-		ServiceContextThreadLocal.popServiceContext();
-	}
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
+	extends BaseSEOStudioTestCase {
 
 	@Test
 	public void testExecute() throws Exception {
@@ -128,8 +37,8 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
 
 		_updateSEOStudioDomainObjectEntry(true);
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			_seoStudioDomainObjectEntry.getObjectEntryId());
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
+			seoStudioDomainObjectEntry.getObjectEntryId());
 
 		Date nextScanDate = (Date)values.get("nextScanDate");
 
@@ -142,32 +51,16 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
 
 		_updateSEOStudioDomainObjectEntry(false);
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			_seoStudioDomainObjectEntry.getObjectEntryId());
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
+			seoStudioDomainObjectEntry.getObjectEntryId());
 
 		Assert.assertNull(values.get("nextScanDate"));
 	}
 
-	private AccountEntry _addAccountEntry() throws Exception {
-		return _accountEntryLocalService.addAccountEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
-			RandomTestUtil.randomString(), null, null,
-			RandomTestUtil.randomString() + "@liferay.com", null, null,
-			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
-			WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext());
-	}
-
 	private void _addSEOStudioDomainObjectEntry() throws Exception {
-		AccountEntry accountEntry = _addAccountEntry();
-
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
-			accountEntry);
-
-		_seoStudioDomainObjectEntry = _objectEntryLocalService.addObjectEntry(
+		seoStudioDomainObjectEntry = objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
@@ -179,18 +72,18 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
 				accountEntry.getAccountEntryId()
 			).put(
 				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				_seoStudioInstanceObjectEntry.getObjectEntryId()
+				seoStudioInstanceObjectEntry.getObjectEntryId()
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	private void _updateSEOStudioDomainObjectEntry(boolean autoScanEnabled)
 		throws Exception {
 
-		_objectEntryLocalService.partialUpdateObjectEntry(
+		objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(),
-			_seoStudioDomainObjectEntry.getObjectEntryId(),
+			seoStudioDomainObjectEntry.getObjectEntryId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			HashMapBuilder.<String, Serializable>put(
 				"autoScanEnabled", autoScanEnabled
@@ -200,69 +93,7 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest {
 				"scanTime", "09:00"
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
-
-	private ObjectEntry _addSEOStudioInstanceObjectEntry(
-			AccountEntry accountEntry)
-		throws Exception {
-
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioInstances_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScans");
-
-		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioDomainObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-	}
-
-	@Inject
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	private Group _group;
-
-	@Inject
-	private ObjectActionLocalService _objectActionLocalService;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	private ObjectDefinition _seoStudioDomainObjectDefinition;
-	private ObjectEntry _seoStudioDomainObjectEntry;
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectEntry _seoStudioInstanceObjectEntry;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
@@ -5,42 +5,22 @@
 
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
-import com.liferay.account.constants.AccountConstants;
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectAction;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectActionLocalService;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.initializer.SiteInitializer;
-import com.liferay.site.initializer.SiteInitializerRegistry;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -48,11 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -61,100 +37,18 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
-public class CreateSEOStudioScansObjectActionExecutorTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(
-				"com.liferay.seo.studio.site.initializer");
-
-		siteInitializer.initialize(_group.getGroupId());
-
-		_seoStudioDomainObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
-		_seoStudioInstanceObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
-		_seoStudioScanRunObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
-
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
-
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
-
-			_objectActionLocalService.deleteObjectAction(objectAction);
-		}
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_seoStudioDomainObjectEntry != null) {
-			ObjectEntry seoStudioScanRunObjectEntry =
-				_fetchSEOStudioScanRunObjectEntry(_seoStudioDomainObjectEntry);
-
-			if (seoStudioScanRunObjectEntry != null) {
-				for (ObjectEntry seoStudioScanObjectEntry :
-						_getSEOStudioScanObjectEntries(
-							seoStudioScanRunObjectEntry)) {
-
-					_objectEntryLocalService.deleteObjectEntry(
-						seoStudioScanObjectEntry.getObjectEntryId());
-				}
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanRunObjectEntry.getObjectEntryId());
-			}
-
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioInstanceObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
-		ServiceContextThreadLocal.popServiceContext();
-	}
+public class CreateSEOStudioScansObjectActionExecutorTest
+	extends BaseSEOStudioTestCase {
 
 	@Test
 	public void testExecute() throws Exception {
-		AccountEntry accountEntry = _addAccountEntry();
-
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
-			accountEntry);
-
 		String hostname = RandomTestUtil.randomString();
 		String includedPaths = RandomTestUtil.randomString();
 		int maxPagesPerScan = RandomTestUtil.randomInt();
 		String scope = RandomTestUtil.randomString();
 
-		_seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
-			accountEntry, hostname,
+		_addSEOStudioDomainObjectEntry(
+			hostname,
 			JSONUtil.put(
 				"engines",
 				JSONUtil.put(
@@ -175,16 +69,15 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 						"scope", scope
 					)
 				)
-			).toString(),
-			_seoStudioInstanceObjectEntry);
+			).toString());
 
-		_executeCreateScans(_seoStudioDomainObjectEntry);
+		_executeCreateScans();
 
 		ObjectEntry seoStudioScanRunObjectEntry =
-			_fetchSEOStudioScanRunObjectEntry(_seoStudioDomainObjectEntry);
+			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry);
 
 		Map<String, Serializable> scanRunValues =
-			_objectEntryLocalService.getValues(
+			objectEntryLocalService.getValues(
 				seoStudioScanRunObjectEntry.getObjectEntryId());
 
 		Assert.assertEquals(hostname, MapUtil.getString(scanRunValues, "name"));
@@ -201,7 +94,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 			MapUtil.getLong(scanRunValues, "triggeringUserId"));
 
 		List<ObjectEntry> seoStudioScanObjectEntries =
-			_getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
+			getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
 
 		Assert.assertEquals(
 			seoStudioScanObjectEntries.toString(), 3,
@@ -217,7 +110,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 		ObjectEntry seoStudioScanObjectEntry = seoStudioScanObjectEntryMap.get(
 			"pageSpeed");
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
 			seoStudioScanObjectEntry.getObjectEntryId());
 
 		Assert.assertEquals(
@@ -243,13 +136,8 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 
 	@Test
 	public void testExecuteWithNoEnabledEngines() throws Exception {
-		AccountEntry accountEntry = _addAccountEntry();
-
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
-			accountEntry);
-
-		_seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
-			accountEntry, RandomTestUtil.randomString(),
+		_addSEOStudioDomainObjectEntry(
+			RandomTestUtil.randomString(),
 			JSONUtil.put(
 				"engines",
 				JSONUtil.put(
@@ -261,34 +149,21 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 				).put(
 					"pageSpeed", JSONUtil.put("enabled", false)
 				)
-			).toString(),
-			_seoStudioInstanceObjectEntry);
+			).toString());
 
-		_executeCreateScans(_seoStudioDomainObjectEntry);
+		_executeCreateScans();
 
 		Assert.assertNull(
-			_fetchSEOStudioScanRunObjectEntry(_seoStudioDomainObjectEntry));
+			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
 	}
 
-	private AccountEntry _addAccountEntry() throws Exception {
-		return _accountEntryLocalService.addAccountEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
-			RandomTestUtil.randomString(), null, null,
-			RandomTestUtil.randomString() + "@liferay.com", null, null,
-			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
-			WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext());
-	}
-
-	private ObjectEntry _addSEOStudioDomainObjectEntry(
-			AccountEntry accountEntry, String hostname, String scanConfigJSON,
-			ObjectEntry seoStudioInstanceObjectEntry)
+	private void _addSEOStudioDomainObjectEntry(
+			String hostname, String scanConfigJSON)
 		throws Exception {
 
-		return _objectEntryLocalService.addObjectEntry(
+		seoStudioDomainObjectEntry = objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
@@ -305,36 +180,13 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 				"scanConfig", scanConfigJSON
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
-	private ObjectEntry _addSEOStudioInstanceObjectEntry(
-			AccountEntry accountEntry)
-		throws Exception {
-
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioInstances_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
-	private void _executeCreateScans(ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
+	private void _executeCreateScans() throws Exception {
 		_objectActionEngine.executeObjectAction(
 			"createScans", ObjectActionTriggerConstants.KEY_STANDALONE,
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
 			JSONUtil.put(
 				"classPK", seoStudioDomainObjectEntry.getObjectEntryId()
 			).put(
@@ -346,45 +198,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 				).build()
 			),
 			TestPropsValues.getUserId());
-	}
-
-	private ObjectEntry _fetchSEOStudioScanRunObjectEntry(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScanRuns");
-
-		List<ObjectEntry> seoStudioScanRunObjectEntries =
-			_objectEntryLocalService.getOneToManyObjectEntries(
-				seoStudioDomainObjectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null, true,
-				seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		if (ListUtil.isEmpty(seoStudioScanRunObjectEntries)) {
-			return null;
-		}
-
-		return seoStudioScanRunObjectEntries.get(0);
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioScanRunObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-				"seoStudioScanRunToSEOStudioScans");
-
-		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 	}
 
 	private Map<String, ObjectEntry> _getSEOStudioScanObjectEntryMap(
@@ -399,7 +212,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 
 			seoStudioScanObjectEntryMap.put(
 				MapUtil.getString(
-					_objectEntryLocalService.getValues(
+					objectEntryLocalService.getValues(
 						seoStudioScanObjectEntry.getObjectEntryId()),
 					"scanType"),
 				seoStudioScanObjectEntry);
@@ -409,32 +222,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest {
 	}
 
 	@Inject
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	private Group _group;
-
-	@Inject
 	private ObjectActionEngine _objectActionEngine;
-
-	@Inject
-	private ObjectActionLocalService _objectActionLocalService;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	private ObjectDefinition _seoStudioDomainObjectDefinition;
-	private ObjectEntry _seoStudioDomainObjectEntry;
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectEntry _seoStudioInstanceObjectEntry;
-	private ObjectDefinition _seoStudioScanRunObjectDefinition;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
@@ -8,13 +8,11 @@ package com.liferay.seo.studio.web.internal.object.action.executor.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -47,7 +45,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 		int maxPagesPerScan = RandomTestUtil.randomInt();
 		String scope = RandomTestUtil.randomString();
 
-		_addSEOStudioDomainObjectEntry(
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
 			hostname,
 			JSONUtil.put(
 				"engines",
@@ -136,7 +134,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 
 	@Test
 	public void testExecuteWithNoEnabledEngines() throws Exception {
-		_addSEOStudioDomainObjectEntry(
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
 			RandomTestUtil.randomString(),
 			JSONUtil.put(
 				"engines",
@@ -157,15 +155,12 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
 	}
 
-	private void _addSEOStudioDomainObjectEntry(
+	private ObjectEntry _addSEOStudioDomainObjectEntry(
 			String hostname, String scanConfigJSON)
 		throws Exception {
 
-		seoStudioDomainObjectEntry = objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		return addObjectEntry(
+			seoStudioDomainObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"hostname", hostname
 			).put(
@@ -178,9 +173,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 				seoStudioInstanceObjectEntry.getObjectEntryId()
 			).put(
 				"scanConfig", scanConfigJSON
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 	private void _executeCreateScans() throws Exception {

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -36,7 +37,9 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -101,33 +104,24 @@ public abstract class BaseSEOStudioTestCase {
 
 	@After
 	public void tearDown() throws Exception {
-		if (seoStudioDomainObjectEntry != null) {
-			ObjectEntry seoStudioScanRunObjectEntry =
-				fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry);
-
-			if (seoStudioScanRunObjectEntry != null) {
-				for (ObjectEntry seoStudioScanObjectEntry :
-						getSEOStudioScanObjectEntries(
-							seoStudioScanRunObjectEntry)) {
-
-					objectEntryLocalService.deleteObjectEntry(
-						seoStudioScanObjectEntry.getObjectEntryId());
-				}
-
-				objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanRunObjectEntry.getObjectEntryId());
-			}
-
-			objectEntryLocalService.deleteObjectEntry(
-				seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (seoStudioInstanceObjectEntry != null) {
-			objectEntryLocalService.deleteObjectEntry(
-				seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	protected ObjectEntry addObjectEntry(
+			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+		throws Exception {
+
+		ObjectEntry objectEntry = objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
+		_objectEntries.add(objectEntry);
+
+		return objectEntry;
 	}
 
 	protected ObjectEntry fetchSEOStudioScanRunObjectEntry(
@@ -191,11 +185,8 @@ public abstract class BaseSEOStudioTestCase {
 	}
 
 	private ObjectEntry _addSEOStudioInstanceObjectEntry() throws Exception {
-		return objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		return addObjectEntry(
+			_seoStudioInstanceObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"hostname", RandomTestUtil.randomString()
 			).put(
@@ -203,9 +194,7 @@ public abstract class BaseSEOStudioTestCase {
 			).put(
 				"r_accountToSEOStudioInstances_accountEntryId",
 				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 	@Inject
@@ -216,6 +205,9 @@ public abstract class BaseSEOStudioTestCase {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@DeleteAfterTestRun
+	private List<ObjectEntry> _objectEntries = new ArrayList<>();
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -85,17 +85,7 @@ public abstract class BaseSEOStudioTestCase {
 				getObjectDefinitionByExternalReferenceCode(
 					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
 
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
-
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
-
-			_objectActionLocalService.deleteObjectAction(objectAction);
-		}
+		_updateSEOStudioScanObjectActions(false);
 
 		accountEntry = _addAccountEntry();
 
@@ -104,6 +94,8 @@ public abstract class BaseSEOStudioTestCase {
 
 	@After
 	public void tearDown() throws Exception {
+		_updateSEOStudioScanObjectActions(true);
+
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
@@ -195,6 +187,24 @@ public abstract class BaseSEOStudioTestCase {
 				"r_accountToSEOStudioInstances_accountEntryId",
 				accountEntry.getAccountEntryId()
 			).build());
+	}
+
+	private void _updateSEOStudioScanObjectActions(boolean active)
+		throws Exception {
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			objectAction.setActive(active);
+
+			_objectActionLocalService.updateObjectAction(objectAction);
+		}
 	}
 
 	@Inject

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.Serializable;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+/**
+ * @author Jonathan McCann
+ */
+public abstract class BaseSEOStudioTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		group = GroupTestUtil.addGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.seo.studio.site.initializer");
+
+		siteInitializer.initialize(group.getGroupId());
+
+		seoStudioDomainObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
+		_seoStudioInstanceObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
+		_seoStudioScanRunObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			_objectActionLocalService.deleteObjectAction(objectAction);
+		}
+
+		accountEntry = _addAccountEntry();
+
+		seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (seoStudioDomainObjectEntry != null) {
+			ObjectEntry seoStudioScanRunObjectEntry =
+				fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry);
+
+			if (seoStudioScanRunObjectEntry != null) {
+				for (ObjectEntry seoStudioScanObjectEntry :
+						getSEOStudioScanObjectEntries(
+							seoStudioScanRunObjectEntry)) {
+
+					objectEntryLocalService.deleteObjectEntry(
+						seoStudioScanObjectEntry.getObjectEntryId());
+				}
+
+				objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanRunObjectEntry.getObjectEntryId());
+			}
+
+			objectEntryLocalService.deleteObjectEntry(
+				seoStudioDomainObjectEntry.getObjectEntryId());
+		}
+
+		if (seoStudioInstanceObjectEntry != null) {
+			objectEntryLocalService.deleteObjectEntry(
+				seoStudioInstanceObjectEntry.getObjectEntryId());
+		}
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	protected ObjectEntry fetchSEOStudioScanRunObjectEntry(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+				"seoStudioDomainToSEOStudioScanRuns");
+
+		List<ObjectEntry> seoStudioScanRunObjectEntries =
+			objectEntryLocalService.getOneToManyObjectEntries(
+				seoStudioDomainObjectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(), null, true,
+				seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (ListUtil.isEmpty(seoStudioScanRunObjectEntries)) {
+			return null;
+		}
+
+		return seoStudioScanRunObjectEntries.get(0);
+	}
+
+	protected List<ObjectEntry> getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioScanRunObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				"seoStudioScanRunToSEOStudioScans");
+
+		return objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioScanRunObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	protected AccountEntry accountEntry;
+	protected Group group;
+
+	@Inject
+	protected ObjectEntryLocalService objectEntryLocalService;
+
+	protected ObjectDefinition seoStudioDomainObjectDefinition;
+	protected ObjectEntry seoStudioDomainObjectEntry;
+	protected ObjectEntry seoStudioInstanceObjectEntry;
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		return _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addSEOStudioInstanceObjectEntry() throws Exception {
+		return objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioInstances_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private ObjectActionLocalService _objectActionLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private ObjectDefinition _seoStudioInstanceObjectDefinition;
+	private ObjectDefinition _seoStudioScanRunObjectDefinition;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -19,8 +19,11 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -31,7 +34,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
@@ -41,8 +43,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
@@ -53,13 +56,21 @@ public abstract class BaseSEOStudioTestCase {
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalName = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
 		group = GroupTestUtil.addGroup();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -86,17 +97,24 @@ public abstract class BaseSEOStudioTestCase {
 					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
 
 		_updateSEOStudioScanObjectActions(false);
-
-		accountEntry = _addAccountEntry();
-
-		seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry();
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterClass
+	public static void tearDownClass() throws Exception {
 		_updateSEOStudioScanObjectActions(true);
 
 		ServiceContextThreadLocal.popServiceContext();
+
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+
+		PrincipalThreadLocal.setName(_originalName);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		accountEntry = _addAccountEntry();
+
+		seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry();
 	}
 
 	protected ObjectEntry addObjectEntry(
@@ -155,15 +173,34 @@ public abstract class BaseSEOStudioTestCase {
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 	}
 
+	protected static Group group;
+	protected static ObjectDefinition seoStudioDomainObjectDefinition;
+
 	protected AccountEntry accountEntry;
-	protected Group group;
 
 	@Inject
 	protected ObjectEntryLocalService objectEntryLocalService;
 
-	protected ObjectDefinition seoStudioDomainObjectDefinition;
 	protected ObjectEntry seoStudioDomainObjectEntry;
 	protected ObjectEntry seoStudioInstanceObjectEntry;
+
+	private static void _updateSEOStudioScanObjectActions(boolean active)
+		throws Exception {
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			objectAction.setActive(active);
+
+			_objectActionLocalService.updateObjectAction(objectAction);
+		}
+	}
 
 	private AccountEntry _addAccountEntry() throws Exception {
 		return _accountEntryLocalService.addAccountEntry(
@@ -189,43 +226,27 @@ public abstract class BaseSEOStudioTestCase {
 			).build());
 	}
 
-	private void _updateSEOStudioScanObjectActions(boolean active)
-		throws Exception {
+	@Inject
+	private static ObjectActionLocalService _objectActionLocalService;
 
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
 
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+	private static String _originalName;
+	private static PermissionChecker _originalPermissionChecker;
+	private static ObjectDefinition _seoStudioInstanceObjectDefinition;
+	private static ObjectDefinition _seoStudioScanRunObjectDefinition;
 
-			objectAction.setActive(active);
-
-			_objectActionLocalService.updateObjectAction(objectAction);
-		}
-	}
+	@Inject
+	private static SiteInitializerRegistry _siteInitializerRegistry;
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Inject
-	private ObjectActionLocalService _objectActionLocalService;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@DeleteAfterTestRun
 	private List<ObjectEntry> _objectEntries = new ArrayList<>();
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectDefinition _seoStudioScanRunObjectDefinition;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor;
+
+import com.liferay.object.action.executor.BaseObjectActionExecutor;
+import com.liferay.object.action.executor.ObjectActionExecutor;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.scope.ObjectDefinitionScoped;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.seo.studio.web.internal.util.SEOStudioScanScheduleUtil;
+
+import java.io.Serializable;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = ObjectActionExecutor.class)
+public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorImpl
+	extends BaseObjectActionExecutor implements ObjectDefinitionScoped {
+
+	@Override
+	public List<String> getAllowedObjectDefinitionNames() {
+		return List.of("SEOStudioDomain");
+	}
+
+	@Override
+	public String getKey() {
+		return "compute-seo-studio-domain-next-scan-date";
+	}
+
+	@Override
+	protected void doExecute(
+			long companyId, long objectActionId,
+			UnicodeProperties parametersUnicodeProperties,
+			JSONObject payloadJSONObject, long userId)
+		throws Exception {
+
+		long seoStudioDomainId = payloadJSONObject.getLong("classPK");
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			seoStudioDomainId);
+
+		Date nextScanDate = null;
+
+		if (GetterUtil.getBoolean(values.get("autoScanEnabled"))) {
+			nextScanDate = SEOStudioScanScheduleUtil.getNextScanDate(
+				Instant.now(),
+				GetterUtil.getInteger(values.get("scanDayOfMonth")),
+				GetterUtil.getString(values.get("scanDayOfWeek")),
+				GetterUtil.getString(values.get("scanFrequency")),
+				GetterUtil.getString(values.get("scanTime")),
+				GetterUtil.getString(values.get("scanTimeZone")));
+		}
+
+		if (Objects.equals(nextScanDate, values.get("nextScanDate"))) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			userId, seoStudioDomainId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate", nextScanDate
+			).build(),
+			serviceContext);
+	}
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtil.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtil.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.time.DateTimeException;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+
+import java.util.Date;
+
+/**
+ * @author Jonathan McCann
+ */
+public class SEOStudioScanScheduleUtil {
+
+	public static Date getNextScanDate(
+		Instant instant, Integer scanDayOfMonth, String scanDayOfWeek,
+		String scanFrequency, String scanTime, String scanTimeZone) {
+
+		if (Validator.isNull(scanFrequency) || Validator.isNull(scanTime)) {
+			return null;
+		}
+
+		LocalTime localTime = _getLocalTime(scanTime);
+
+		if (localTime == null) {
+			return null;
+		}
+
+		ZoneId zoneId = _getZoneId(scanTimeZone);
+
+		ZonedDateTime currentZonedDateTime = instant.atZone(zoneId);
+
+		ZonedDateTime nextZonedDateTime = null;
+
+		if (scanFrequency.equals("daily")) {
+			LocalDate localDate = currentZonedDateTime.toLocalDate();
+
+			nextZonedDateTime = _getZonedDateTime(localDate, localTime, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localDate.plusDays(1), localTime, zoneId);
+			}
+		}
+		else if (scanFrequency.equals("monthly")) {
+			if ((scanDayOfMonth == null) || (scanDayOfMonth < 1)) {
+				return null;
+			}
+
+			YearMonth yearMonth = YearMonth.from(currentZonedDateTime);
+
+			nextZonedDateTime = _getZonedDateTime(
+				localTime, scanDayOfMonth, yearMonth, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localTime, scanDayOfMonth, yearMonth.plusMonths(1), zoneId);
+			}
+		}
+		else if (scanFrequency.equals("weekly")) {
+			DayOfWeek dayOfWeek = _getDayOfWeek(scanDayOfWeek);
+
+			if (dayOfWeek == null) {
+				return null;
+			}
+
+			LocalDate localDate = currentZonedDateTime.toLocalDate();
+
+			localDate = localDate.with(TemporalAdjusters.nextOrSame(dayOfWeek));
+
+			nextZonedDateTime = _getZonedDateTime(localDate, localTime, zoneId);
+
+			if (!nextZonedDateTime.isAfter(currentZonedDateTime)) {
+				nextZonedDateTime = _getZonedDateTime(
+					localDate.plusWeeks(1), localTime, zoneId);
+			}
+		}
+		else {
+			return null;
+		}
+
+		return Date.from(nextZonedDateTime.toInstant());
+	}
+
+	private static DayOfWeek _getDayOfWeek(String scanDayOfWeek) {
+		if (Validator.isNull(scanDayOfWeek)) {
+			return null;
+		}
+
+		if (scanDayOfWeek.equals("SU")) {
+			return DayOfWeek.SUNDAY;
+		}
+		else if (scanDayOfWeek.equals("MO")) {
+			return DayOfWeek.MONDAY;
+		}
+		else if (scanDayOfWeek.equals("TU")) {
+			return DayOfWeek.TUESDAY;
+		}
+		else if (scanDayOfWeek.equals("WE")) {
+			return DayOfWeek.WEDNESDAY;
+		}
+		else if (scanDayOfWeek.equals("TH")) {
+			return DayOfWeek.THURSDAY;
+		}
+		else if (scanDayOfWeek.equals("FR")) {
+			return DayOfWeek.FRIDAY;
+		}
+		else if (scanDayOfWeek.equals("SA")) {
+			return DayOfWeek.SATURDAY;
+		}
+
+		return null;
+	}
+
+	private static LocalTime _getLocalTime(String scanTime) {
+		try {
+			return LocalTime.parse(
+				scanTime, DateTimeFormatter.ofPattern("HH:mm"));
+		}
+		catch (DateTimeParseException dateTimeParseException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(dateTimeParseException);
+			}
+
+			return null;
+		}
+	}
+
+	private static ZonedDateTime _getZonedDateTime(
+		LocalDate localDate, LocalTime localTime, ZoneId zoneId) {
+
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			localDate, localTime, zoneId);
+
+		return zonedDateTime.withLaterOffsetAtOverlap();
+	}
+
+	private static ZonedDateTime _getZonedDateTime(
+		LocalTime localTime, int scanDayOfMonth, YearMonth yearMonth,
+		ZoneId zoneId) {
+
+		int dayOfMonth = Math.min(scanDayOfMonth, yearMonth.lengthOfMonth());
+
+		return _getZonedDateTime(
+			yearMonth.atDay(dayOfMonth), localTime, zoneId);
+	}
+
+	private static ZoneId _getZoneId(String scanTimeZone) {
+		if (Validator.isNull(scanTimeZone)) {
+			return ZoneId.of("UTC");
+		}
+
+		try {
+			return ZoneId.of(scanTimeZone);
+		}
+		catch (DateTimeException dateTimeException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(dateTimeException);
+			}
+
+			return ZoneId.of("UTC");
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SEOStudioScanScheduleUtil.class);
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/test/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtilTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/test/java/com/liferay/seo/studio/web/internal/util/SEOStudioScanScheduleUtilTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.util;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAdjusters;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jonathan McCann
+ */
+public class SEOStudioScanScheduleUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetNextScanDateDaily() {
+		LocalDate localDate = LocalDate.of(2026, Month.JANUARY, 1);
+
+		Assert.assertEquals(
+			_toDate(localDate, 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 8), null, null, "daily", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(localDate.plusDays(1), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 9), null, null, "daily", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(localDate.plusDays(1), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(localDate, 10), null, null, "daily", "09:00",
+				"UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringDST() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JULY, 2), 13),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JULY, 1), 20), null, null,
+				"daily", "09:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringFallBackOverlap() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.NOVEMBER, 1), 6),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.NOVEMBER, 1), 5, 30), null,
+				null, "daily", "01:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringNoDST() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 2), 14),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 1), 20), null,
+				null, "daily", "09:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateDailyDuringSpringForwardGap() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.MARCH, 9), 6),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.MARCH, 8), 12), null, null,
+				"daily", "02:00", "America/New_York"));
+	}
+
+	@Test
+	public void testGetNextScanDateMonthly() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.JANUARY, 15), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 1), 8), 15, null,
+				"monthly", "09:00", "UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateMonthlyWhenDayOfMonthExceedsMonthLength() {
+		Assert.assertEquals(
+			_toDate(LocalDate.of(2026, Month.FEBRUARY, 28), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(LocalDate.of(2026, Month.JANUARY, 31), 10), 31, null,
+				"monthly", "09:00", "UTC"));
+	}
+
+	@Test
+	public void testGetNextScanDateWeekly() {
+		LocalDate localDate = LocalDate.of(2026, Month.JANUARY, 1);
+
+		LocalDate wednesdayLocalDate = localDate.with(
+			TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
+
+		Instant instant = _toInstant(wednesdayLocalDate, 8);
+
+		Assert.assertEquals(
+			_toDate(
+				wednesdayLocalDate.with(
+					TemporalAdjusters.next(DayOfWeek.MONDAY)),
+				9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				instant, null, "MO", "weekly", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(wednesdayLocalDate, 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				instant, null, "WE", "weekly", "09:00", "UTC"));
+
+		Assert.assertEquals(
+			_toDate(wednesdayLocalDate.plusWeeks(1), 9),
+			SEOStudioScanScheduleUtil.getNextScanDate(
+				_toInstant(wednesdayLocalDate, 10), null, "WE", "weekly",
+				"09:00", "UTC"));
+	}
+
+	private Date _toDate(LocalDate localDate, int hour) {
+		return Date.from(_toInstant(localDate, hour));
+	}
+
+	private Instant _toInstant(LocalDate localDate, int hour) {
+		return _toInstant(localDate, hour, 0);
+	}
+
+	private Instant _toInstant(LocalDate localDate, int hour, int minute) {
+		LocalDateTime localDateTime = localDate.atTime(hour, minute);
+
+		return localDateTime.toInstant(ZoneOffset.UTC);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93368

## What Is Being Fixed

When an SEO Studio domain's scan schedule changed — frequency, time, time zone, day of week, or day of month — the domain's stored next scan date was not recomputed, so it could drift out of sync with the configured schedule and trigger scans at the wrong time.

## How It Is Being Fixed

A new SEOStudioScanScheduleUtil computes the next scan date from the schedule fields, handling daily, weekly, and monthly frequencies along with time zones and daylight saving time transitions (spring-forward gaps and fall-back overlaps). A new compute-seo-studio-domain-next-scan-date object action executor, wired through the site initializer as an onAfterUpdate action conditioned on the schedule fields, recomputes and persists the next scan date whenever a schedule change is saved, and clears it when auto scan is disabled.

The test changes extract the shared SEO Studio setup into BaseSEOStudioTestCase and harden cleanup so the suites no longer leak object entries: created entries are tracked with @DeleteAfterTestRun, the permission checker is held at class scope, and the scan object actions are disabled during tests rather than deleted.

## What Is Coming Next

This is the first step toward automated, schedule-driven scans. A later step adds the scheduled sweep that periodically finds domains whose next scan date is due, triggers their scans, and advances the next scan date for the following run.

## PR Check

**pr-check: PASS** — tested on `6f6a50209e95863e5351acb1556310756fcf7d3e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6f6a50209e95863e5351acb1556310756fcf7d3e"} -->
