### PR TITLE
LPD-97016 Prevent deleteGroup from deleting colliding permissions

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -22,10 +22,17 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -44,6 +51,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
+import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
 import java.util.List;
 
@@ -244,6 +252,68 @@ public class GroupLocalServiceTest {
 				assetCategory.getCategoryId()));
 	}
 
+	@Test
+	public void testDeleteGroupPreservesCollidingLayoutPermission()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		long companyId = group.getCompanyId();
+		long groupId = group.getGroupId();
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+
+		String layoutClassName = Layout.class.getName();
+		String primKey = String.valueOf(groupId);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+			primKey, guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, layoutClassName, ResourceConstants.SCOPE_GROUP, primKey,
+			guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, DLConstants.RESOURCE_NAME,
+			ResourceConstants.SCOPE_INDIVIDUAL, primKey, guestRole.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+				primKey));
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, DLConstants.RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, primKey));
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+				primKey));
+		Assert.assertEquals(
+			0,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, layoutClassName, ResourceConstants.SCOPE_GROUP,
+				primKey));
+		Assert.assertEquals(
+			0,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, DLConstants.RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, primKey));
+
+		_resourcePermissionLocalService.deleteResourcePermissions(
+			companyId, layoutClassName, ResourceConstants.SCOPE_INDIVIDUAL,
+			primKey);
+	}
+
 	@FeatureFlag("LPD-82960")
 	@Test
 	public void testEnablingMaintenanceModeDeactivatesSite() throws Exception {
@@ -412,5 +482,11 @@ public class GroupLocalServiceTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1202,6 +1202,16 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				for (ResourcePermission resourcePermission :
 						resourcePermissions) {
 
+					String name = resourcePermission.getName();
+
+					if ((resourcePermission.getScope() !=
+							ResourceConstants.SCOPE_GROUP) &&
+						!Objects.equals(name, Group.class.getName()) &&
+						!ResourceActionsUtil.isRootModelResource(name)) {
+
+						continue;
+					}
+
 					_resourcePermissionLocalService.deleteResourcePermission(
 						resourcePermission);
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97016

## What Is Being Fixed

deleteGroup deleted every ResourcePermission that shared the group's numeric primary key. Because a group's groupId is minted from the global counter while a layout's plid is minted from a class scoped counter, the two can coincide, so deleting a group could wipe an unrelated layout's permissions and leave its pages inaccessible.

## How It Is Being Fixed

A matched permission is now deleted only when it belongs to the group being deleted: a group scoped permission, the group's own resource permission, or a root model resource permission, which keys its site level permissions by the group ID. Any other resource that matches shares the primary key only by coincidence and is left untouched, while the root model resource cleanup from LPS-197580 is preserved. An integration test reproduces the collision by forcing a layout's plid to equal a separate group's groupId and asserting the layout's permissions survive the group deletion.

## PR Check

**pr-check: PASS** — tested on `f312582cf64b7faae3b2aaf65a8edd90b820b16c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f312582cf64b7faae3b2aaf65a8edd90b820b16c"} -->
