### PR TITLE
LPD-97016 Prevent deleteGroup from deleting colliding permissions

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -280,7 +280,7 @@ public class ViewChangesDisplayContext {
 					_renderResponse
 				).setMVCRenderCommandName(
 					"/change_tracking/view_change"
-				).setRedirect(
+				).setBackURL(
 					_themeDisplay.getURLCurrent()
 				).setParameter(
 					"ctCollectionId", "{ctCollectionId}"

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -544,6 +544,8 @@ public class ViewChangesDisplayContext {
 				_renderResponse
 			).setMVCRenderCommandName(
 				"/change_tracking/view_change"
+			).setBackURL(
+				_themeDisplay.getURLCurrent()
 			).setParameter(
 				"ctCollectionId", _ctCollection.getCtCollectionId()
 			).buildString()

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingLayoutChangesSidePanel.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingLayoutChangesSidePanel.js
@@ -9,7 +9,7 @@ import {SidePanel} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayPanel from '@clayui/panel';
-import {fetch} from 'frontend-js-web';
+import {createPortletURL, fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const DELTA = 20;
@@ -121,39 +121,50 @@ export default function ChangeTrackingLayoutChangesSidePanel({
 							{Liferay.Language.get('collapse-all')}
 						</ClayButton>
 					</ClayButton.Group>
-					{panels.map((panel) => (
-						<ClayPanel
-							collapsable
-							displayTitle={
-								<ClayPanel.Title className="panel-title text-secondary">
-									{panel.title}
-								</ClayPanel.Title>
+					{panels.map((panel) => {
+						const viewChangeURL = createPortletURL(
+							panel.viewChangeURL,
+							{
+								backURL:
+									window.location.pathname +
+									window.location.search,
 							}
-							displayType="unstyled"
-							expanded={panel.expanded}
-							key={panel.ctEntryId}
-							onExpandedChange={() => {
-								handleExpanded(panel.ctEntryId);
-							}}
-							showCollapseIcon={true}
-						>
-							<ClayPanel.Body>
-								<div
-									className="mb-4 mt-3 taglib-diff-html"
-									dangerouslySetInnerHTML={{
-										__html: panel.preview,
-									}}
-								/>
+						).toString();
 
-								<a
-									className="btn btn-secondary btn-xs"
-									href={panel.viewChangeURL}
-								>
-									{Liferay.Language.get('view-details')}
-								</a>
-							</ClayPanel.Body>
-						</ClayPanel>
-					))}
+						return (
+							<ClayPanel
+								collapsable
+								displayTitle={
+									<ClayPanel.Title className="panel-title text-secondary">
+										{panel.title}
+									</ClayPanel.Title>
+								}
+								displayType="unstyled"
+								expanded={panel.expanded}
+								key={panel.ctEntryId}
+								onExpandedChange={() => {
+									handleExpanded(panel.ctEntryId);
+								}}
+								showCollapseIcon={true}
+							>
+								<ClayPanel.Body>
+									<div
+										className="mb-4 mt-3 taglib-diff-html"
+										dangerouslySetInnerHTML={{
+											__html: panel.preview,
+										}}
+									/>
+
+									<a
+										className="btn btn-secondary btn-xs"
+										href={viewChangeURL}
+									>
+										{Liferay.Language.get('view-details')}
+									</a>
+								</ClayPanel.Body>
+							</ClayPanel>
+						);
+					})}
 					{panels.length < total ? (
 						<div className="align-items-center d-flex justify-content-center">
 							<ClayButton

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_change.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_change.jsp
@@ -10,7 +10,8 @@
 <%
 ViewChangesDisplayContext viewChangesDisplayContext = (ViewChangesDisplayContext)request.getAttribute(CTWebKeys.VIEW_CHANGES_DISPLAY_CONTEXT);
 
-portletDisplay.setURLBack(
+String backURL = ParamUtil.getString(
+	request, "backURL",
 	PortletURLBuilder.createRenderURL(
 		renderResponse
 	).setMVCRenderCommandName(
@@ -18,6 +19,8 @@ portletDisplay.setURLBack(
 	).setParameter(
 		"ctCollectionId", viewChangesDisplayContext.getCtCollectionId()
 	).buildString());
+
+portletDisplay.setURLBack(backURL);
 
 portletDisplay.setShowBackIcon(true);
 

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 125.2.0
+Bundle-Version: 126.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
@@ -146,6 +146,9 @@ public class ObjectDefinitionTreeUtil {
 			}
 		}
 		else {
+			_addAllowStandaloneObjectEntrySetting(
+				objectDefinition2, objectDefinitionSettingLocalService);
+
 			if (ArrayUtil.isNotEmpty(
 					getRootObjectDefinitionIds(
 						objectDefinition2.getObjectDefinitionId(),

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 11.3.0
+version 11.4.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 35.4.0
+version 35.5.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -9,7 +9,6 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
-import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -1847,6 +1846,12 @@ public class ObjectDefinitionLocalServiceImpl
 				objectDefinitionSetting.getValue());
 		}
 
+		if (!_hasEdgeObjectRelationship(objectDefinition)) {
+			objectDefinitionSettingsValuesMap.remove(
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+		}
+
 		_validateObjectDefinitionSettings(
 			objectDefinition, objectDefinitionSettingsValuesMap);
 
@@ -1898,6 +1903,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 			if (!objectDefinitionSettingsValuesMap.containsKey(
 					oldObjectDefinitionSetting.getName())) {
+
+				if (StringUtil.equals(
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
+						oldObjectDefinitionSetting.getName())) {
+
+					continue;
+				}
 
 				_objectDefinitionSettingLocalService.
 					deleteObjectDefinitionSetting(oldObjectDefinitionSetting);
@@ -2475,6 +2488,19 @@ public class ObjectDefinitionLocalServiceImpl
 		ObjectDefinitionValidationThreadLocal.addValidationError(
 			ObjectDefinition.class.getName(), exception, propertyName,
 			propertyValue);
+	}
+
+	private boolean _hasEdgeObjectRelationship(
+		ObjectDefinition objectDefinition) {
+
+		int count = _objectRelationshipPersistence.countByODI2_E(
+			objectDefinition.getObjectDefinitionId(), true);
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasObjectField(
@@ -3600,21 +3626,6 @@ public class ObjectDefinitionLocalServiceImpl
 			Map<String, String> objectDefinitionSettingsValuesMap)
 		throws PortalException {
 
-		if (!BatchEngineThreadLocal.isBatchImportInProcess() &&
-			objectDefinition.isRootDescendantNode() &&
-			!objectDefinitionSettingsValuesMap.containsKey(
-				ObjectDefinitionSettingConstants.
-					NAME_ALLOW_STANDALONE_OBJECT_ENTRY)) {
-
-			_handleException(
-				new ObjectDefinitionSettingNameException.RequiredNames(
-					objectDefinition.getShortName(),
-					Set.of(
-						ObjectDefinitionSettingConstants.
-							NAME_ALLOW_STANDALONE_OBJECT_ENTRY)),
-				"objectDefinitionSettings", null);
-		}
-
 		if (objectDefinitionSettingsValuesMap.isEmpty()) {
 			return;
 		}
@@ -3645,19 +3656,6 @@ public class ObjectDefinitionLocalServiceImpl
 					ObjectDefinitionSettingConstants.
 						NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
 					objectDefinitionSettingsValue.getKey())) {
-
-				if (!BatchEngineThreadLocal.isBatchImportInProcess() &&
-					!objectDefinition.isRootDescendantNode()) {
-
-					_handleException(
-						new ObjectDefinitionSettingNameException.
-							NotAllowedNames(
-								objectDefinition.getShortName(),
-								Set.of(
-									ObjectDefinitionSettingConstants.
-										NAME_ALLOW_STANDALONE_OBJECT_ENTRY)),
-						"objectDefinitionSettings", null);
-				}
 
 				String allowStandaloneObjectEntry =
 					objectDefinitionSettingsValue.getValue();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
@@ -19,12 +20,14 @@ import com.liferay.object.exception.ObjectRelationshipEdgeException;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -589,6 +592,48 @@ public class ObjectDefinitionTreeUtilTest {
 			).build(),
 			_objectDefinitionTreeFactory.create(rootNodeB.getPrimaryKey()),
 			_objectDefinitionLocalService);
+	}
+
+	@Test
+	public void testBindObjectDefinitionsWithAllowStandaloneObjectEntrySetting()
+		throws Exception {
+
+		// Bind a draft object definition to a published object definition
+
+		ObjectDefinition objectDefinitionA =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition("A");
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition("AA");
+
+		TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_assertAllowStandaloneObjectEntrySetting(
+			objectDefinitionAA, StringPool.TRUE);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// Bind a published object definition to a draft object definition
+
+		objectDefinitionA = _addAndPublishCustomObjectDefinition("A");
+		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
+			"AA");
+
+		TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_assertAllowStandaloneObjectEntrySetting(
+			objectDefinitionAA, StringPool.TRUE);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
+			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
 	@Test
@@ -2531,6 +2576,21 @@ public class ObjectDefinitionTreeUtilTest {
 			null, values, ServiceContextTestUtil.getServiceContext());
 	}
 
+	private void _assertAllowStandaloneObjectEntrySetting(
+		ObjectDefinition objectDefinition,
+		String expectedAllowStandaloneObjectEntrySetting) {
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(
+			expectedAllowStandaloneObjectEntrySetting,
+			objectDefinitionSetting.getValue());
+	}
+
 	private void _assertRootObjectEntryIds(Map<ObjectEntry, Long> expectedMap)
 		throws Exception {
 
@@ -2743,6 +2803,10 @@ public class ObjectDefinitionTreeUtilTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	private ObjectDefinitionTreeFactory _objectDefinitionTreeFactory;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -3841,6 +3841,243 @@ public class ObjectDefinitionLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdateObjectDefinitionWithAllowStandaloneObjectEntry()
+		throws Exception {
+
+		// Invalid value
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition finalChildObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		String value = RandomTestUtil.randomString();
+
+		AssertUtils.assertFailure(
+			ObjectDefinitionSettingValueException.InvalidValue.class,
+			StringBundler.concat(
+				"The value ", value, " of setting \"",
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
+				"\" is invalid for object definition \"",
+				finalChildObjectDefinition.getShortName(), "\""),
+			() -> _updateCustomObjectDefinition(
+				finalChildObjectDefinition.getClassName(),
+				finalChildObjectDefinition,
+				Collections.singletonList(
+					new ObjectDefinitionSettingBuilder(
+					).name(
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+					).value(
+						value
+					).build())));
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				finalChildObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// The object definition can be updated after any publish ordering
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// The setting is not persisted when the object definition is not a
+		// root descendant
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		objectDefinition = _updateCustomObjectDefinition(
+			objectDefinition.getClassName(), objectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					StringPool.FALSE
+				).build()));
+
+		Assert.assertNull(
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+
+		// The setting is persisted when the object definition is a root
+		// descendant
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		_updateCustomObjectDefinition(
+			childObjectDefinition.getClassName(), childObjectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					StringPool.FALSE
+				).build()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		_updateCustomObjectDefinition(
+			childObjectDefinition.getClassName(), childObjectDefinition,
+			Collections.emptyList());
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				childObjectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(
+			StringPool.FALSE, objectDefinitionSetting.getValue());
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
+	@Test
 	public void testUpdateObjectFolderId() throws Exception {
 		ObjectDefinition objectDefinition = _addCustomObjectDefinition(
 			ObjectDefinitionTestUtil.getRandomName());
@@ -5196,6 +5433,35 @@ public class ObjectDefinitionLocalServiceTest {
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				objectDefinition2);
 		}
+	}
+
+	private void _testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		String value = String.valueOf(RandomTestUtil.randomBoolean());
+
+		_updateCustomObjectDefinition(
+			objectDefinition.getClassName(), objectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					value
+				).build()));
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(value, objectDefinitionSetting.getValue());
 	}
 
 	private void

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
@@ -9,8 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.BaseExportImportTestCase;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -29,6 +31,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -128,6 +131,80 @@ public class BoundObjectDefinitionsExportImportTest
 				)
 			).toString(),
 			getExportJSON("TestObjectDefinition1"), JSONCompareMode.LENIENT);
+
+		_deleteObjectDefinition("TESTOBJECTDEFINITION1", "objectRelationship1");
+		_deleteObjectDefinition("TESTOBJECTDEFINITION2", null);
+	}
+
+	@Test
+	public void testImportBoundObjectDefinitionsWithChildBeforeParent()
+		throws Exception {
+
+		JSONObject statusJSONObject = JSONUtil.put(
+			"code", 0
+		).put(
+			"label", "approved"
+		).put(
+			"label_i18n", "Approved"
+		);
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			jsonFactory.createJSONObject(
+				defaultObjectDefinitionJSON
+			).put(
+				"externalReferenceCode", "TESTOBJECTDEFINITION2"
+			).put(
+				"name", "TestObjectDefinition2"
+			).put(
+				"objectDefinitionSettings",
+				JSONUtil.put(
+					JSONUtil.put(
+						"name",
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+					).put(
+						"value", "true"
+					))
+			).put(
+				"scope", ObjectDefinitionConstants.SCOPE_COMPANY
+			).put(
+				"status", statusJSONObject
+			),
+			jsonFactory.createJSONObject(
+				defaultObjectDefinitionJSON
+			).put(
+				"externalReferenceCode", "TESTOBJECTDEFINITION1"
+			).put(
+				"name", "TestObjectDefinition1"
+			).put(
+				"objectRelationships",
+				JSONUtil.put(
+					createOneToManyObjectRelationship(
+						"TESTOBJECTDEFINITION1", "TESTOBJECTDEFINITION2",
+						"TestObjectDefinition2",
+						ObjectDefinitionConstants.SCOPE_COMPANY,
+						"objectRelationship1"))
+			).put(
+				"scope", ObjectDefinitionConstants.SCOPE_COMPANY
+			).put(
+				"status", statusJSONObject
+			));
+
+		importJSON(
+			"TESTOBJECTDEFINITION2", jsonArray.toString(),
+			"TestObjectDefinition2");
+
+		com.liferay.object.model.ObjectDefinition childObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"TESTOBJECTDEFINITION2", TestPropsValues.getCompanyId());
+
+		Assert.assertTrue(childObjectDefinition.isRootDescendantNode());
+		Assert.assertNotNull(
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				childObjectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY));
 
 		_deleteObjectDefinition("TESTOBJECTDEFINITION1", "objectRelationship1");
 		_deleteObjectDefinition("TESTOBJECTDEFINITION2", null);
@@ -404,6 +481,10 @@ public class BoundObjectDefinitionsExportImportTest
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -22,10 +22,18 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -244,6 +252,52 @@ public class GroupLocalServiceTest {
 				assetCategory.getCategoryId()));
 	}
 
+	@Test
+	public void testDeleteGroupPreservesResourcePermissionOfPersistedModel()
+		throws Exception {
+
+		Group group1 = GroupTestUtil.addGroup();
+
+		Layout layout = _layoutLocalService.createLayout(group1.getGroupId());
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		layout.setGroupId(group2.getGroupId());
+		layout.setCompanyId(group2.getCompanyId());
+
+		layout.setLayoutId(RandomTestUtil.nextLong());
+
+		_layoutLocalService.addLayout(layout);
+
+		Role role = _roleLocalService.getRole(
+			group1.getCompanyId(), RoleConstants.GUEST);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			group1.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(group1.getGroupId()), role.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+		_resourcePermissionLocalService.setResourcePermissions(
+			group1.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(group1.getGroupId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		_groupLocalService.deleteGroup(group1);
+
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				group1.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(group1.getGroupId())));
+		Assert.assertEquals(
+			0,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				group1.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_GROUP,
+				String.valueOf(group1.getGroupId())));
+	}
+
 	@FeatureFlag("LPD-82960")
 	@Test
 	public void testEnablingMaintenanceModeDeactivatesSite() throws Exception {
@@ -412,5 +466,14 @@ public class GroupLocalServiceTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/test/playwright/tests/change-tracking-web/main/layoutContentChangesSidePanel.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/layoutContentChangesSidePanel.spec.ts
@@ -223,7 +223,7 @@ test('LPD-82049 Changes are limited to 20 panels and can be expanded to view mor
 	await expect(viewMoreButton).not.toBeVisible();
 });
 
-test('LPD-82049 Can redirect to fragment entry link change view', async ({
+test('LPD-82049, LPD-86527 Can redirect to fragment entry link change view and back', async ({
 	changeTrackingPage,
 	ctCollection,
 	page,
@@ -247,21 +247,23 @@ test('LPD-82049 Can redirect to fragment entry link change view', async ({
 		type: 'Page',
 	});
 
-	await expect(
-		page
-			.getByLabel('Layout Changes Side Panel')
-			.filter({hasText: 'Content Changes'})
-	).toBeVisible();
+	const sidePanelLocator = page
+		.getByLabel('Layout Changes Side Panel')
+		.filter({hasText: 'Content Changes'});
 
-	const viewDetailsButton = page.getByRole('link', {name: 'View Details'});
+	await expect(sidePanelLocator).toBeVisible();
 
 	const fragmentTitle = await page
 		.locator('button.panel-header-link')
 		.innerText();
 
-	await viewDetailsButton.click();
+	await page.getByRole('link', {name: 'View Details'}).click();
 
 	await expect(page.locator('h2')).toContainText(fragmentTitle, {
 		ignoreCase: true,
 	});
+
+	await page.getByRole('link', {exact: true, name: 'Back'}).click();
+
+	await expect(sidePanelLocator).toBeVisible();
 });

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -76,6 +76,7 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -111,6 +112,7 @@ import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.MembershipRequestLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -170,6 +172,7 @@ import com.liferay.portal.kernel.util.comparator.GroupNameComparator;
 import com.liferay.portal.model.impl.GroupModelImpl;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.service.base.GroupLocalServiceBaseImpl;
 import com.liferay.portal.service.http.ClassNameServiceHttp;
 import com.liferay.portal.service.http.GroupServiceHttp;
@@ -1201,6 +1204,27 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 				for (ResourcePermission resourcePermission :
 						resourcePermissions) {
+
+					String name = resourcePermission.getName();
+
+					if ((resourcePermission.getScope() ==
+							ResourceConstants.SCOPE_INDIVIDUAL) &&
+						!name.equals(Group.class.getName())) {
+
+						PersistedModelLocalService persistedModelLocalService =
+							PersistedModelLocalServiceRegistryUtil.
+								getPersistedModelLocalService(name);
+
+						if (persistedModelLocalService != null) {
+							PersistedModel persistedModel =
+								persistedModelLocalService.fetchPersistedModel(
+									group.getGroupId());
+
+							if (persistedModel != null) {
+								continue;
+							}
+						}
+					}
 
 					_resourcePermissionLocalService.deleteResourcePermission(
 						resourcePermission);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97016

## What Is Being Fixed

`deleteGroup` deleted every `ResourcePermission` that shared the group's numeric primary key. A group's `groupId` is minted from the global counter while a layout's `plid` is minted from a class-scoped counter, so the two can coincide. When they did, deleting a group wiped an unrelated layout's resource permissions and left its pages inaccessible, taking the site down.

## How It Is Being Fixed

An individual-scope permission is now preserved only when a persisted model still exists at that primary key, which means another entity, such as the colliding layout, actually owns it. Probing for the backing entity through `PersistedModelLocalServiceRegistryUtil`, instead of enumerating known resource names, covers any model whose primary key happens to collide, not just layouts. Everything else that matched before is still deleted — group-scoped permissions, the group's own resource permission, and the site-level permissions on non-model resources that have no entity behind the shared key — so the site cleanup introduced by LPS-197580 stays intact.

## PR Check

**pr-check: PASS** — tested on `a09321bcadbad4d4b70d1f4b408d34d96ab3f672`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "a09321bcadbad4d4b70d1f4b408d34d96ab3f672"} -->
