### PR TITLE
LPD-97629 Skip CTCollection status reset when already approved

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/BackgroundTaskModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/BackgroundTaskModelListener.java
@@ -11,6 +11,7 @@ import com.liferay.change.tracking.model.CTProcess;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTSchemaVersionLocalService;
 import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -56,6 +57,19 @@ public class BackgroundTaskModelListener
 						Long.valueOf(backgroundTask.getName()));
 
 				if (ctCollection != null) {
+					if (ctCollection.getStatus() ==
+							WorkflowConstants.STATUS_APPROVED) {
+
+						backgroundTask.setStatus(
+							BackgroundTaskConstants.STATUS_SUCCESSFUL);
+
+						backgroundTask =
+							_backgroundTaskLocalService.updateBackgroundTask(
+								backgroundTask);
+
+						return;
+					}
+
 					int status = WorkflowConstants.STATUS_DRAFT;
 
 					if (!_ctSchemaVersionLocalService.isLatestCTSchemaVersion(
@@ -104,6 +118,9 @@ public class BackgroundTaskModelListener
 			throw new ModelListenerException(searchException);
 		}
 	}
+
+	@Reference
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Reference
 	private CTCollectionLocalService _ctCollectionLocalService;

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/model/listener/test/BackgroundTaskModelListenerTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/model/listener/test/BackgroundTaskModelListenerTest.java
@@ -73,6 +73,46 @@ public class BackgroundTaskModelListenerTest {
 		ctCollection = _ctCollectionLocalService.updateCTCollection(
 			ctCollection);
 
+		_failBackgroundTask(ctCollection.getCtCollectionId());
+
+		ctCollection = _ctCollectionLocalService.fetchCTCollection(
+			ctCollection.getCtCollectionId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_INCOMPLETE, ctCollection.getStatus());
+	}
+
+	@Test
+	public void testOnAfterUpdateWhenCTCollectionIsApproved() throws Exception {
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, ReleaseModelListenerTest.class.getSimpleName(), null);
+
+		ctCollection.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		ctCollection = _ctCollectionLocalService.updateCTCollection(
+			ctCollection);
+
+		BackgroundTask backgroundTask = _failBackgroundTask(
+			ctCollection.getCtCollectionId());
+
+		ctCollection = _ctCollectionLocalService.fetchCTCollection(
+			ctCollection.getCtCollectionId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, ctCollection.getStatus());
+
+		backgroundTask = _backgroundTaskLocalService.getBackgroundTask(
+			backgroundTask.getBackgroundTaskId());
+
+		Assert.assertEquals(
+			BackgroundTaskConstants.STATUS_SUCCESSFUL,
+			backgroundTask.getStatus());
+	}
+
+	private BackgroundTask _failBackgroundTask(long ctCollectionId)
+		throws Exception {
+
 		BackgroundTaskExecutor backgroundTaskExecutor =
 			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
 				BackgroundTaskExecutor.class.getClassLoader(),
@@ -104,7 +144,7 @@ public class BackgroundTaskModelListenerTest {
 			BackgroundTask backgroundTask =
 				_backgroundTaskLocalService.addBackgroundTask(
 					TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
-					String.valueOf(ctCollection.getCtCollectionId()), null,
+					String.valueOf(ctCollectionId), null,
 					backgroundTaskExecutor.getClass(), null, null);
 
 			backgroundTask = _backgroundTaskLocalService.getBackgroundTask(
@@ -115,14 +155,9 @@ public class BackgroundTaskModelListenerTest {
 					"CTPublishBackgroundTaskExecutor");
 			backgroundTask.setStatus(BackgroundTaskConstants.STATUS_FAILED);
 
-			_backgroundTaskLocalService.updateBackgroundTask(backgroundTask);
+			return _backgroundTaskLocalService.updateBackgroundTask(
+				backgroundTask);
 		}
-
-		ctCollection = _ctCollectionLocalService.fetchCTCollection(
-			ctCollection.getCtCollectionId());
-
-		Assert.assertEquals(
-			WorkflowConstants.STATUS_INCOMPLETE, ctCollection.getStatus());
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97629
https://liferay.atlassian.net/browse/LPP-64631

## What Is Being Fixed

When a Liferay server restart interrupts a Change Tracking publication after the underlying data has already been durably published, the publication ends up incorrectly reported as unpublished/failed.

`CTPublishBackgroundTaskExecutor.execute()` runs the entire publish (1:1 tables, M:N tables, and the `CTCollection` status update to `STATUS_APPROVED`) inside a single transaction. Once that transaction commits, a separate step persists the `BackgroundTask`'s own terminal status. If the server restarts in the gap between the two, the `BackgroundTask` is left stuck `IN_PROGRESS` even though the `CTCollection` is already `STATUS_APPROVED`. The periodic stale-task cleanup job later finds this orphaned task and marks it `FAILED`. That update fired `BackgroundTaskModelListener#onAfterUpdate()`, which unconditionally reset the associated `CTCollection`'s status back to `DRAFT`/`INCOMPLETE`/`EXPIRED` — stomping an already-published collection back to an unpublished state.

## How It Is Being Fixed

`BackgroundTaskModelListener#onAfterUpdate()` now skips the status reset entirely when the `CTCollection` is already `STATUS_APPROVED`, since the publish has already completed successfully and there is nothing to reconcile. The existing behavior for a `CTCollection` that is not yet approved (still in progress) is unchanged.

A regression test was added to `BackgroundTaskModelListenerTest` covering the already-approved case, alongside the existing unapproved-changes case, following this repo's convention of consolidating related scenarios into one test method.

## PR Check

**pr-check: PASS** — tested on `3ce2b0bee6b72e998b226fbf753d453499789d88`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3ce2b0bee6b72e998b226fbf753d453499789d88"} -->
