### PR TITLE
LPD-91213 Add SEO Studio crawler client extension - Step 2

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.constants;
+
+/**
+ * @author Brooke Dalton
+ */
+public interface SEOStudioScanConstants {
+
+	public static final String STATE_FAILED = "failed";
+
+	public static final String STATE_RUNNING = "running";
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -6,9 +6,28 @@
 package com.liferay.seo.studio.controller;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.service.KubernetesJobService;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONObject;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,9 +43,172 @@ public class CrawlerRestController extends BaseRestController {
 
 	@PostMapping
 	public ResponseEntity<String> post(@RequestBody String json) {
-		return ResponseEntity.ok(
-			new JSONObject(
-			).toString());
+		if (_log.isDebugEnabled()) {
+			_log.debug(json);
+		}
+
+		JSONObject objectEntryJSONObject = new JSONObject(
+			json
+		).getJSONObject(
+			"objectEntry"
+		);
+
+		long seoStudioScanId = objectEntryJSONObject.getLong("objectEntryId");
+
+		try {
+			JSONObject valuesJSONObject = objectEntryJSONObject.getJSONObject(
+				"values");
+
+			long seoStudioDomainId = valuesJSONObject.getLong(
+				"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+			String domainJSON = _seoStudioService.fetchDomain(
+				seoStudioDomainId);
+
+			if (Validator.isNull(domainJSON)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to find a domain for SEO Studio domain ID " +
+							seoStudioDomainId);
+				}
+
+				return ResponseEntity.ok(
+					_seoStudioService.updateScan(
+						"Unable to find a domain for SEO Studio domain ID " +
+							seoStudioDomainId,
+						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+			}
+
+			String hostname = new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			);
+
+			String domainURL = SEOStudioService.toDomainURL(
+				SEOStudioService.toCrawlURI(hostname));
+
+			String canonicalDomainURL = _resolveCanonicalDomainURL(domainURL);
+
+			if (!canonicalDomainURL.equals(domainURL)) {
+				_seoStudioService.updateDomain(
+					new JSONObject(
+					).put(
+						"hostname", canonicalDomainURL
+					),
+					seoStudioDomainId);
+			}
+
+			String sitemapURL = canonicalDomainURL + "/sitemap.xml";
+
+			if (!_isSitemapReachable(sitemapURL)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to reach the sitemap at " + sitemapURL);
+				}
+
+				return ResponseEntity.ok(
+					_seoStudioService.updateScan(
+						"Unable to reach the sitemap at " + sitemapURL,
+						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+			}
+
+			_seoStudioService.updateScan(
+				null, seoStudioScanId, SEOStudioScanConstants.STATE_RUNNING);
+
+			JSONObject scopeConfigJSONObject = new JSONObject(
+				valuesJSONObject.getString("scopeConfig"));
+
+			Job job = _kubernetesJobService.createJob(
+				valuesJSONObject.getLong(
+					"r_accountToSEOStudioScans_accountEntryId"),
+				canonicalDomainURL,
+				scopeConfigJSONObject.getInt("maxCrawlDepth"),
+				scopeConfigJSONObject.getInt("maxDuration"),
+				SEOStudioService.toIndexName(seoStudioDomainId), sitemapURL);
+
+			ObjectMeta objectMeta = job.getMetadata();
+
+			JSONObject scanJSONObject = new JSONObject(
+			).put(
+				"executionId", objectMeta.getName()
+			);
+
+			_seoStudioService.updateScan(scanJSONObject, seoStudioScanId);
+
+			return ResponseEntity.ok(scanJSONObject.toString());
+		}
+		catch (Exception exception) {
+			_log.error("Unable to scan the domain", exception);
+
+			return ResponseEntity.ok(
+				_seoStudioService.updateScan(
+					"Unable to scan the domain " + exception.getMessage(),
+					seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
+		}
 	}
+
+	private boolean _isSitemapReachable(String sitemapURL) {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+					URI.create(sitemapURL)
+				).timeout(
+					Duration.ofSeconds(60)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+				return false;
+			}
+
+			return Validator.isNotNull(httpResponse.body());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to reach the sitemap at " + sitemapURL, exception);
+			}
+
+			return false;
+		}
+	}
+
+	private String _resolveCanonicalDomainURL(String domainURL)
+		throws Exception {
+
+		HttpResponse<Void> httpResponse = _httpClient.send(
+			HttpRequest.newBuilder(
+				URI.create(domainURL)
+			).timeout(
+				Duration.ofSeconds(60)
+			).GET(
+			).build(),
+			HttpResponse.BodyHandlers.discarding());
+
+		URI uri = httpResponse.uri();
+
+		if ((uri == null) || Validator.isNull(uri.getHost())) {
+			return domainURL;
+		}
+
+		return SEOStudioService.toDomainURL(uri);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerRestController.class);
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).followRedirects(
+		HttpClient.Redirect.NORMAL
+	).build();
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
 
 }

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/CrawlHit.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/CrawlHit.java
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Brooke Dalton
+ */
+public class CrawlHit {
+
+	public CrawlHit(JSONObject jsonObject) {
+		_canonicalURL = jsonObject.optString("canonicalUrl", null);
+
+		JSONArray linksJSONArray = jsonObject.optJSONArray("links");
+
+		if (linksJSONArray != null) {
+			for (Object linkObject : linksJSONArray) {
+				if (linkObject instanceof String) {
+					_links.add((String)linkObject);
+				}
+			}
+		}
+
+		_url = jsonObject.optString("url", null);
+	}
+
+	public String getCanonicalURL() {
+		return _canonicalURL;
+	}
+
+	public List<String> getLinks() {
+		return _links;
+	}
+
+	public String getURL() {
+		return _url;
+	}
+
+	private final String _canonicalURL;
+	private final List<String> _links = new ArrayList<>();
+	private final String _url;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -1,0 +1,231 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import java.net.URI;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class SEOStudioService extends BaseService {
+
+	public static URI toCrawlURI(String hostname) {
+		if (Validator.isNull(hostname)) {
+			throw new IllegalArgumentException("Hostname is required");
+		}
+
+		hostname = StringUtil.toLowerCase(hostname.trim());
+
+		if (!hostname.startsWith("http://") &&
+			!hostname.startsWith("https://")) {
+
+			hostname = "https://" + hostname;
+		}
+
+		URI uri = URI.create(hostname);
+
+		if (Validator.isNull(uri.getHost())) {
+			throw new IllegalArgumentException(
+				"Hostname \"" + hostname + "\" has no host component");
+		}
+
+		return uri;
+	}
+
+	public static String toDomainURL(URI uri) {
+		String host = StringUtil.toLowerCase(uri.getHost());
+		String scheme = StringUtil.toLowerCase(uri.getScheme());
+
+		if (uri.getPort() == -1) {
+			return scheme + "://" + host;
+		}
+
+		return StringBundler.concat(scheme, "://", host, ":", uri.getPort());
+	}
+
+	public static String toIndexName(long seoStudioDomainId) {
+		return "seo_studio_" + seoStudioDomainId;
+	}
+
+	public String fetchActiveScans() {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/scans"
+		).queryParam(
+			"filter", "state in ('queued','running')"
+		).queryParam(
+			"pageSize", 100
+		).build();
+
+		return get(_getAuthorization(), uriComponents.toUri());
+	}
+
+	public List<CrawlHit> fetchCrawlHits(long seoStudioDomainId) {
+		List<CrawlHit> crawlHits = new ArrayList<>();
+
+		String lastURL = null;
+
+		while (true) {
+			JSONObject hitsJSONObject = new JSONObject(
+				_fetchCrawlHits(lastURL, 2000, seoStudioDomainId));
+
+			JSONArray itemsJSONArray = hitsJSONObject.optJSONArray("items");
+
+			if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+				break;
+			}
+
+			String previousLastURL = lastURL;
+
+			for (Object object : itemsJSONArray) {
+				CrawlHit crawlHit = new CrawlHit((JSONObject)object);
+
+				crawlHits.add(crawlHit);
+
+				lastURL = crawlHit.getURL();
+			}
+
+			if (Objects.equals(previousLastURL, lastURL)) {
+				break;
+			}
+		}
+
+		return crawlHits;
+	}
+
+	public String fetchDomain(long seoStudioDomainId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/domains/" + seoStudioDomainId
+		).build();
+
+		return get(_getAuthorization(), uriComponents.toUri());
+	}
+
+	public String fetchPage(int page, int pageSize, long seoStudioScanId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/pages"
+		).queryParam(
+			"filter",
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId eq '" +
+				seoStudioScanId + "'"
+		).queryParam(
+			"page", page
+		).queryParam(
+			"pageSize", pageSize
+		).build();
+
+		return get(_getAuthorization(), uriComponents.toUri());
+	}
+
+	public String postInsightType(JSONObject jsonObject) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/insight-types"
+		).build();
+
+		return post(
+			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
+	}
+
+	public String postPagesBatch(JSONArray jsonArray) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/pages/batch"
+		).build();
+
+		return post(
+			_getAuthorization(), jsonArray.toString(), uriComponents.toUri());
+	}
+
+	public String postScanInsightsBatch(JSONArray jsonArray) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/scan-insights/batch"
+		).build();
+
+		return post(
+			_getAuthorization(), jsonArray.toString(), uriComponents.toUri());
+	}
+
+	public String updateDomain(JSONObject jsonObject, long seoStudioDomainId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/domains/" + seoStudioDomainId
+		).build();
+
+		return patch(
+			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
+	}
+
+	public String updateScan(JSONObject jsonObject, long seoStudioScanId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/scans/" + seoStudioScanId
+		).build();
+
+		return patch(
+			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
+	}
+
+	public String updateScan(
+		String errorMessage, long seoStudioScanId, String state) {
+
+		JSONObject jsonObject = new JSONObject();
+
+		if (Validator.isNotNull(errorMessage)) {
+			jsonObject.put("errorMessage", errorMessage);
+		}
+
+		jsonObject.put("state", state);
+
+		return updateScan(jsonObject, seoStudioScanId);
+	}
+
+	private String _fetchCrawlHits(
+		String lastURL, int pageSize, long seoStudioDomainId) {
+
+		UriComponentsBuilder uriComponentsBuilder =
+			UriComponentsBuilder.fromPath(
+				"/o/seo-studio/v1.0/seo-studio-domains/" + seoStudioDomainId +
+					"/crawl-hits"
+			).queryParam(
+				"pageSize", pageSize
+			);
+
+		if (Validator.isNotNull(lastURL)) {
+			uriComponentsBuilder.queryParam("lastURL", lastURL);
+		}
+
+		UriComponents uriComponents = uriComponentsBuilder.build();
+
+		uriComponents = uriComponents.encode();
+
+		return get(_getAuthorization(), uriComponents.toUri());
+	}
+
+	private String _getAuthorization() {
+		return _liferayOAuth2AccessTokenManager.getAuthorization(
+			"liferay-seostudio-etc-crawler-oahs");
+	}
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213

## What Is Being Fixed

SEO Studio needs to crawl a domain, index the crawled pages, and surface SEO insights (starting with orphan pages) back in the portal. There was no component that dispatched the crawl, tracked its progress, or turned crawl results into scan insights.

## How It Is Being Fixed

This adds the `liferay-seostudio-etc-crawler` client extension — a Spring Boot application that drives the end-to-end crawl. On a scan object action it dispatches a Kubernetes crawl Job, reading crawl depth and duration from the scan's `scopeConfig` and seeding the configured Elasticsearch index and sitemap. A scheduled poller watches the Job and, on completion, reads the crawl hits from the SEO Studio REST endpoint and runs orphan-page detection: pages that are crawled but referenced by no other page's links are written back as scan insights, with the required insight-type and scan-insight fields (category, name, severity, classification) populated. When a completed crawl yields no readable crawl hits, the scan is marked FAILED rather than silently reported as a clean zero result. The SEO Studio REST endpoint is added in https://github.com/liferay-site-management/liferay-portal/pull/3502.

## Note on the Split

To keep each change focused and reviewable, this work is being delivered in parts. The SEO Studio REST endpoint landed first in https://github.com/liferay-site-management/liferay-portal/pull/3502, this pull request is the second part and wires up the crawler client extension, and a third and final part will add the scheduled poller and orphan-page detection. Consequently, several of the public methods introduced on `SEOStudioService` — such as those that create insight types, batch scan insights, and page through crawl hits — do not yet have call sites within this pull request; their callers are added in the third part. Any method that appears unused when this change is read in isolation is consumed by that subsequent part.

## PR Check

**pr-check: PASS** — tested on `65c0a4f5495123d5d684fca7587293956ae6a96a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "65c0a4f5495123d5d684fca7587293956ae6a96a"} -->
