### PR TITLE
LPD-97016 Prevent deleteGroup from deleting colliding permissions

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -22,10 +22,18 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -201,7 +209,7 @@ public class GroupLocalServiceTest {
 	@FeatureFlag("LPD-86291")
 	@Test
 	public void testDeleteGroup() throws Exception {
-		Group group = GroupTestUtil.addGroup();
+		Group group1 = GroupTestUtil.addGroup();
 
 		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
 			new AssetVocabularySettingsHelper();
@@ -211,7 +219,7 @@ public class GroupLocalServiceTest {
 
 		AssetVocabulary assetVocabulary =
 			_assetVocabularyLocalService.addVocabulary(
-				null, TestPropsValues.getUserId(), group.getGroupId(),
+				null, TestPropsValues.getUserId(), group1.getGroupId(),
 				RandomTestUtil.randomString(), null,
 				HashMapBuilder.put(
 					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
@@ -219,10 +227,10 @@ public class GroupLocalServiceTest {
 				null, assetVocabularySettingsHelper.toString(),
 				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), TestPropsValues.getUserId()));
+					group1.getGroupId(), TestPropsValues.getUserId()));
 
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
-			null, TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group1.getGroupId(),
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			HashMapBuilder.put(
 				LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
@@ -232,9 +240,33 @@ public class GroupLocalServiceTest {
 			).build(),
 			assetVocabulary.getVocabularyId(), true, null,
 			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+				group1.getGroupId(), TestPropsValues.getUserId()));
 
-		_groupLocalService.deleteGroup(group);
+		Layout layout = _layoutLocalService.createLayout(group1.getGroupId());
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		layout.setGroupId(group2.getGroupId());
+		layout.setCompanyId(group2.getCompanyId());
+
+		layout.setLayoutId(RandomTestUtil.nextLong());
+
+		_layoutLocalService.addLayout(layout);
+
+		Role role = _roleLocalService.getRole(
+			group1.getCompanyId(), RoleConstants.GUEST);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			group1.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(group1.getGroupId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+		_resourcePermissionLocalService.setResourcePermissions(
+			group1.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(group1.getGroupId()), role.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+
+		_groupLocalService.deleteGroup(group1);
 
 		Assert.assertNull(
 			_assetVocabularyLocalService.fetchAssetVocabulary(
@@ -242,6 +274,18 @@ public class GroupLocalServiceTest {
 		Assert.assertNull(
 			_assetCategoryLocalService.fetchAssetCategory(
 				assetCategory.getCategoryId()));
+		Assert.assertEquals(
+			0,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				group1.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_GROUP,
+				String.valueOf(group1.getGroupId())));
+		Assert.assertEquals(
+			1,
+			_resourcePermissionLocalService.getResourcePermissionsCount(
+				group1.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(group1.getGroupId())));
 	}
 
 	@FeatureFlag("LPD-82960")
@@ -412,5 +456,14 @@ public class GroupLocalServiceTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -76,6 +76,7 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -111,6 +112,7 @@ import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.MembershipRequestLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -170,6 +172,7 @@ import com.liferay.portal.kernel.util.comparator.GroupNameComparator;
 import com.liferay.portal.model.impl.GroupModelImpl;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.service.base.GroupLocalServiceBaseImpl;
 import com.liferay.portal.service.http.ClassNameServiceHttp;
 import com.liferay.portal.service.http.GroupServiceHttp;
@@ -1201,6 +1204,27 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 				for (ResourcePermission resourcePermission :
 						resourcePermissions) {
+
+					String name = resourcePermission.getName();
+
+					if ((resourcePermission.getScope() ==
+							ResourceConstants.SCOPE_INDIVIDUAL) &&
+						!name.equals(Group.class.getName())) {
+
+						PersistedModelLocalService persistedModelLocalService =
+							PersistedModelLocalServiceRegistryUtil.
+								getPersistedModelLocalService(name);
+
+						if (persistedModelLocalService != null) {
+							PersistedModel persistedModel =
+								persistedModelLocalService.fetchPersistedModel(
+									group.getGroupId());
+
+							if (persistedModel != null) {
+								continue;
+							}
+						}
+					}
 
 					_resourcePermissionLocalService.deleteResourcePermission(
 						resourcePermission);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97016

## What Is Being Fixed

`GroupLocalService.deleteGroup` deleted every `ResourcePermission` whose primary key matched the group's `groupId`. A group's `groupId` is minted from the global counter while a layout's `plid` is minted from a class-scoped counter, so the two can coincide. When they did, deleting a group wiped an unrelated colliding layout's resource permissions, leaving that layout's pages inaccessible.

## How It Is Being Fixed

An individual-scope permission is now kept when a persisted model still exists at that primary key, meaning another entity — such as the colliding layout — actually owns it. Probing the persisted-model registry for a backing entity covers any model whose primary key happens to collide, not just layouts. Everything else that matches is still deleted: group-scoped permissions, the group's own resource permission, and the site-level permissions on non-model resources that have no entity behind the shared key, so the site cleanup introduced by LPS-197580 stays intact.

## PR Check

**pr-check: PASS** — tested on `ce0c3520a886c7aeef5e8fd708f8454efd442ec8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "ce0c3520a886c7aeef5e8fd708f8454efd442ec8"} -->
