### PR TITLE
LPD-96037 Calculate metrics when a scan run completes

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-scan-object-actions.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-actions/seo-studio-scan-object-actions.json
@@ -2,6 +2,22 @@
 	"object-actions": [
 		{
 			"active": true,
+			"conditionExpression": "state == 'cancelled' || state == 'completed' || state == 'failed'",
+			"errorMessage": {
+				"en_US": "Scan metrics calculation failed. Please try again later or contact support."
+			},
+			"externalReferenceCode": "L_SEO_STUDIO_SCAN_CALCULATE_SCAN_METRICS",
+			"label": {
+				"en_US": "Calculate Scan Metrics"
+			},
+			"name": "calculateScanMetrics",
+			"objectActionExecutorKey": "calculate-seo-studio-scan-metrics",
+			"objectActionTriggerKey": "onAfterUpdate",
+			"parameters": {
+			}
+		},
+		{
+			"active": true,
 			"conditionExpression": "scanType == 'crawler'",
 			"errorMessage": {
 				"en_US": "Crawler scan failed. Please try again later or contact support."

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/BaseObjectActionExecutorTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/BaseObjectActionExecutorTestCase.java
@@ -126,6 +126,27 @@ public abstract class BaseObjectActionExecutorTestCase {
 		return objectEntry;
 	}
 
+	protected ObjectEntry addSEOStudioDomainObjectEntry(
+			String hostname, String scanConfigJSON)
+		throws Exception {
+
+		return addObjectEntry(
+			seoStudioDomainObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", hostname
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				seoStudioInstanceObjectEntry.getObjectEntryId()
+			).put(
+				"scanConfig", scanConfigJSON
+			).build());
+	}
+
 	protected static Group group;
 	protected static ObjectDefinition seoStudioDomainObjectDefinition;
 

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
@@ -1,0 +1,477 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.action.engine.ObjectActionEngine;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Noor Najjar
+ */
+@FeatureFlag("LPD-44511")
+@RunWith(Arquillian.class)
+public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		SiteInitializer siteInitializer =
+			_siteInitializerRegistry.getSiteInitializer(
+				"com.liferay.seo.studio.site.initializer");
+
+		siteInitializer.initialize(_group.getGroupId());
+
+		_seoStudioDomainObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
+		_seoStudioInstanceObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
+		_seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", TestPropsValues.getCompanyId());
+		_seoStudioScanRunObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
+
+		for (ObjectAction objectAction :
+				_objectActionLocalService.getObjectActions(
+					_seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+
+			if (!Objects.equals(
+					objectAction.getName(), "calculateScanMetrics")) {
+
+				_objectActionLocalService.deleteObjectAction(objectAction);
+			}
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_seoStudioScanRunObjectEntry != null) {
+			for (ObjectEntry seoStudioScanMetricObjectEntry :
+					_getSEOStudioScanMetricObjectEntries(
+						_seoStudioScanRunObjectEntry)) {
+
+				_objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanMetricObjectEntry.getObjectEntryId());
+			}
+
+			for (ObjectEntry seoStudioScanObjectEntry :
+					_getSEOStudioScanObjectEntries(
+						_seoStudioScanRunObjectEntry)) {
+
+				_objectEntryLocalService.deleteObjectEntry(
+					seoStudioScanObjectEntry.getObjectEntryId());
+			}
+
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioScanRunObjectEntry.getObjectEntryId());
+		}
+
+		if (_seoStudioDomainObjectEntry != null) {
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioDomainObjectEntry.getObjectEntryId());
+		}
+
+		if (_seoStudioInstanceObjectEntry != null) {
+			_objectEntryLocalService.deleteObjectEntry(
+				_seoStudioInstanceObjectEntry.getObjectEntryId());
+		}
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testDoesNotFinalizeWhenScanStillRunning() throws Exception {
+		_seedScanRun();
+
+		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"crawler", "completed");
+
+		_addSEOStudioScanObjectEntry("pageSpeed", "running");
+
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+
+		Assert.assertEquals("running", _getState(_seoStudioScanRunObjectEntry));
+		Assert.assertTrue(
+			_getSEOStudioScanMetricObjectEntries(
+				_seoStudioScanRunObjectEntry
+			).isEmpty());
+	}
+
+	@Test
+	public void testFinalizesWhenAllScansCompleted() throws Exception {
+		_seedScanRun();
+
+		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"crawler", "completed");
+
+		_addSEOStudioScanObjectEntry("pageSpeed", "completed");
+
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+
+		Assert.assertEquals(
+			"completed", _getState(_seoStudioScanRunObjectEntry));
+
+		List<ObjectEntry> seoStudioScanMetricObjectEntries =
+			_getSEOStudioScanMetricObjectEntries(_seoStudioScanRunObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanMetricObjectEntries.toString(), 1,
+			seoStudioScanMetricObjectEntries.size());
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			seoStudioScanMetricObjectEntries.get(
+				0
+			).getObjectEntryId());
+
+		Assert.assertEquals("onPage", MapUtil.getString(values, "scope"));
+		Assert.assertEquals(0, MapUtil.getInteger(values, "totalInsights"));
+		Assert.assertEquals(0, MapUtil.getInteger(values, "criticalInsights"));
+		Assert.assertEquals(
+			0, MapUtil.getInteger(values, "affectedPagesCount"));
+	}
+
+	@Test
+	public void testIsIdempotent() throws Exception {
+		_seedScanRun();
+
+		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"crawler", "completed");
+
+		_addSEOStudioScanObjectEntry("pageSpeed", "completed");
+
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+
+		Assert.assertEquals(
+			"completed", _getState(_seoStudioScanRunObjectEntry));
+
+		List<ObjectEntry> seoStudioScanMetricObjectEntries =
+			_getSEOStudioScanMetricObjectEntries(_seoStudioScanRunObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanMetricObjectEntries.toString(), 1,
+			seoStudioScanMetricObjectEntries.size());
+	}
+
+	@Test
+	public void testSetsScanRunToFailedWhenScanCancelled() throws Exception {
+		_seedScanRun();
+
+		_addSEOStudioScanObjectEntry("crawler", "completed");
+
+		ObjectEntry cancelledScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"pageSpeed", "cancelled");
+
+		_executeCalculateScanMetrics(cancelledScanObjectEntry);
+
+		Assert.assertEquals("failed", _getState(_seoStudioScanRunObjectEntry));
+		Assert.assertTrue(
+			_getSEOStudioScanMetricObjectEntries(
+				_seoStudioScanRunObjectEntry
+			).isEmpty());
+	}
+
+	@Test
+	public void testSetsScanRunToFailedWhenScanFailed() throws Exception {
+		_seedScanRun();
+
+		_addSEOStudioScanObjectEntry("crawler", "completed");
+
+		ObjectEntry failedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"pageSpeed", "failed");
+
+		_executeCalculateScanMetrics(failedScanObjectEntry);
+
+		Assert.assertEquals("failed", _getState(_seoStudioScanRunObjectEntry));
+		Assert.assertTrue(
+			_getSEOStudioScanMetricObjectEntries(
+				_seoStudioScanRunObjectEntry
+			).isEmpty());
+	}
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		return _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addSEOStudioDomainObjectEntry(
+			AccountEntry accountEntry, ObjectEntry seoStudioInstanceObjectEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				seoStudioInstanceObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private ObjectEntry _addSEOStudioInstanceObjectEntry(
+			AccountEntry accountEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioInstances_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private ObjectEntry _addSEOStudioScanObjectEntry(
+			String scanType, String state)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioScanObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"r_accountToSEOStudioScans_accountEntryId",
+				_accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
+				_seoStudioScanRunObjectEntry.getObjectEntryId()
+			).put(
+				"scanRange", "full"
+			).put(
+				"scanScope", "entireDomain"
+			).put(
+				"scanType", scanType
+			).put(
+				"state", state
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private ObjectEntry _addSEOStudioScanRunObjectEntry(
+			AccountEntry accountEntry, ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioScanRuns_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId",
+				seoStudioDomainObjectEntry.getObjectEntryId()
+			).put(
+				"requestDate", new Date()
+			).put(
+				"state", "running"
+			).put(
+				"triggeredBy", "manual"
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _executeCalculateScanMetrics(
+			ObjectEntry seoStudioScanObjectEntry)
+		throws Exception {
+
+		_objectActionEngine.executeObjectAction(
+			"calculateScanMetrics",
+			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
+			_seoStudioScanObjectDefinition.getObjectDefinitionId(),
+			JSONUtil.put(
+				"classPK", seoStudioScanObjectEntry.getObjectEntryId()
+			).put(
+				"objectEntry",
+				HashMapBuilder.<String, Object>putAll(
+					seoStudioScanObjectEntry.getModelAttributes()
+				).put(
+					"values", seoStudioScanObjectEntry.getValues()
+				).build()
+			),
+			TestPropsValues.getUserId());
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanMetricObjectEntries(
+			ObjectEntry seoStudioScanRunObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				"seoStudioScanRunToSEOStudioScanMetrics");
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioScanRunObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioScanRunObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				"seoStudioScanRunToSEOStudioScans");
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioScanRunObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private String _getState(ObjectEntry objectEntry) throws Exception {
+		return MapUtil.getString(
+			_objectEntryLocalService.getValues(objectEntry.getObjectEntryId()),
+			"state");
+	}
+
+	private void _seedScanRun() throws Exception {
+		_accountEntry = _addAccountEntry();
+
+		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
+			_accountEntry);
+
+		_seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
+			_accountEntry, _seoStudioInstanceObjectEntry);
+
+		_seoStudioScanRunObjectEntry = _addSEOStudioScanRunObjectEntry(
+			_accountEntry, _seoStudioDomainObjectEntry);
+	}
+
+	private AccountEntry _accountEntry;
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectActionEngine _objectActionEngine;
+
+	@Inject
+	private ObjectActionLocalService _objectActionLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private ObjectDefinition _seoStudioDomainObjectDefinition;
+	private ObjectEntry _seoStudioDomainObjectEntry;
+	private ObjectDefinition _seoStudioInstanceObjectDefinition;
+	private ObjectEntry _seoStudioInstanceObjectEntry;
+	private ObjectDefinition _seoStudioScanObjectDefinition;
+	private ObjectDefinition _seoStudioScanRunObjectDefinition;
+	private ObjectEntry _seoStudioScanRunObjectEntry;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
@@ -5,52 +5,36 @@
 
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
-import com.liferay.account.constants.AccountConstants;
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.initializer.SiteInitializer;
-import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.io.Serializable;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,37 +43,14 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
-public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+public class CalculateSEOStudioScanMetricsObjectActionExecutorTest
+	extends BaseObjectActionExecutorTestCase {
 
 	@Before
+	@Override
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		super.setUp();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-
-		SiteInitializer siteInitializer =
-			_siteInitializerRegistry.getSiteInitializer(
-				"com.liferay.seo.studio.site.initializer");
-
-		siteInitializer.initialize(_group.getGroupId());
-
-		_seoStudioDomainObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_DOMAIN", TestPropsValues.getCompanyId());
-		_seoStudioInstanceObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_INSTANCE", TestPropsValues.getCompanyId());
 		_seoStudioScanObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
@@ -99,75 +60,145 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 				getObjectDefinitionByExternalReferenceCode(
 					"L_SEO_STUDIO_SCAN_RUN", TestPropsValues.getCompanyId());
 
-		for (ObjectAction objectAction :
-				_objectActionLocalService.getObjectActions(
-					_seoStudioScanObjectDefinition.getObjectDefinitionId())) {
+		ObjectAction objectAction = _objectActionLocalService.fetchObjectAction(
+			_seoStudioScanObjectDefinition.getObjectDefinitionId(),
+			"calculateScanMetrics");
 
-			if (!Objects.equals(
-					objectAction.getName(), "calculateScanMetrics")) {
+		objectAction.setActive(true);
 
-				_objectActionLocalService.deleteObjectAction(objectAction);
-			}
-		}
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_seoStudioScanRunObjectEntry != null) {
-			for (ObjectEntry seoStudioScanMetricObjectEntry :
-					_getSEOStudioScanMetricObjectEntries(
-						_seoStudioScanRunObjectEntry)) {
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanMetricObjectEntry.getObjectEntryId());
-			}
-
-			for (ObjectEntry seoStudioScanObjectEntry :
-					_getSEOStudioScanObjectEntries(
-						_seoStudioScanRunObjectEntry)) {
-
-				_objectEntryLocalService.deleteObjectEntry(
-					seoStudioScanObjectEntry.getObjectEntryId());
-			}
-
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioScanRunObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioDomainObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioDomainObjectEntry.getObjectEntryId());
-		}
-
-		if (_seoStudioInstanceObjectEntry != null) {
-			_objectEntryLocalService.deleteObjectEntry(
-				_seoStudioInstanceObjectEntry.getObjectEntryId());
-		}
-
-		ServiceContextThreadLocal.popServiceContext();
+		_objectActionLocalService.updateObjectAction(objectAction);
 	}
 
 	@Test
-	public void testDoesNotFinalizeWhenScanStillRunning() throws Exception {
-		_seedScanRun();
+	public void testExecute() throws Exception {
+		_addSEOStudioScanRunObjectEntry();
 
 		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
 			"crawler", "completed");
 
-		_addSEOStudioScanObjectEntry("pageSpeed", "running");
+		ObjectEntry aeoReadinessHighInsightTypeObjectEntry =
+			_addSEOStudioInsightTypeObjectEntry(
+				"aeoReadiness", completedScanObjectEntry, "3");
+		ObjectEntry contentStructureMediumInsightTypeObjectEntry =
+			_addSEOStudioInsightTypeObjectEntry(
+				"contentStructure", completedScanObjectEntry, "2");
+		ObjectEntry imagesHighInsightTypeObjectEntry =
+			_addSEOStudioInsightTypeObjectEntry(
+				"images", completedScanObjectEntry, "3");
+		ObjectEntry metadataHighInsightTypeObjectEntry =
+			_addSEOStudioInsightTypeObjectEntry(
+				"metadata", completedScanObjectEntry, "3");
+		ObjectEntry metadataLowInsightTypeObjectEntry =
+			_addSEOStudioInsightTypeObjectEntry(
+				"metadata", completedScanObjectEntry, "1");
+
+		ObjectEntry pageObjectEntry1 = _addSEOStudioPageObjectEntry(
+			completedScanObjectEntry);
+		ObjectEntry pageObjectEntry2 = _addSEOStudioPageObjectEntry(
+			completedScanObjectEntry);
+		ObjectEntry pageObjectEntry3 = _addSEOStudioPageObjectEntry(
+			completedScanObjectEntry);
+
+		_addSEOStudioScanInsightObjectEntry(
+			aeoReadinessHighInsightTypeObjectEntry, pageObjectEntry1,
+			completedScanObjectEntry);
+		_addSEOStudioScanInsightObjectEntry(
+			contentStructureMediumInsightTypeObjectEntry, pageObjectEntry3,
+			completedScanObjectEntry);
+		_addSEOStudioScanInsightObjectEntry(
+			imagesHighInsightTypeObjectEntry, pageObjectEntry1,
+			completedScanObjectEntry);
+		_addSEOStudioScanInsightObjectEntry(
+			metadataHighInsightTypeObjectEntry, pageObjectEntry1,
+			completedScanObjectEntry);
+		_addSEOStudioScanInsightObjectEntry(
+			metadataHighInsightTypeObjectEntry, pageObjectEntry2,
+			completedScanObjectEntry);
+		_addSEOStudioScanInsightObjectEntry(
+			metadataLowInsightTypeObjectEntry, pageObjectEntry1,
+			completedScanObjectEntry);
 
 		_executeCalculateScanMetrics(completedScanObjectEntry);
 
-		Assert.assertEquals("running", _getState(_seoStudioScanRunObjectEntry));
-		Assert.assertTrue(
-			_getSEOStudioScanMetricObjectEntries(
-				_seoStudioScanRunObjectEntry
-			).isEmpty());
+		List<ObjectEntry> seoStudioScanMetricObjectEntries =
+			_getSEOStudioScanMetricObjectEntries(_seoStudioScanRunObjectEntry);
+
+		ObjectEntry seoStudioScanMetricObjectEntry =
+			seoStudioScanMetricObjectEntries.get(0);
+
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
+			seoStudioScanMetricObjectEntry.getObjectEntryId());
+
+		Assert.assertEquals(
+			3, MapUtil.getInteger(values, "affectedPagesCount"));
+		Assert.assertEquals(
+			5.0 / 3.0,
+			MapUtil.getDouble(values, "averageInsightsPerAffectedPage"), 0.001);
+		Assert.assertEquals(3, MapUtil.getInteger(values, "criticalInsights"));
+		Assert.assertEquals(5, MapUtil.getInteger(values, "totalInsights"));
+
+		JSONObject categoryBreakdownJSONObject =
+			JSONFactoryUtil.createJSONObject(
+				MapUtil.getString(values, "categoryBreakdown"));
+
+		Assert.assertFalse(categoryBreakdownJSONObject.has("aeoReadiness"));
+		Assert.assertEquals(
+			1, categoryBreakdownJSONObject.getInt("contentStructure"));
+		Assert.assertEquals(1, categoryBreakdownJSONObject.getInt("images"));
+		Assert.assertEquals(3, categoryBreakdownJSONObject.getInt("metadata"));
+
+		JSONObject impactMixJSONObject = JSONFactoryUtil.createJSONObject(
+			MapUtil.getString(values, "impactMix"));
+
+		JSONObject contentStructureImpactMixJSONObject =
+			impactMixJSONObject.getJSONObject("contentStructure");
+
+		Assert.assertEquals(1, contentStructureImpactMixJSONObject.getInt("2"));
+
+		JSONObject imagesImpactMixJSONObject =
+			impactMixJSONObject.getJSONObject("images");
+
+		Assert.assertEquals(1, imagesImpactMixJSONObject.getInt("3"));
+
+		JSONObject metadataImpactMixJSONObject =
+			impactMixJSONObject.getJSONObject("metadata");
+
+		Assert.assertEquals(1, metadataImpactMixJSONObject.getInt("1"));
+		Assert.assertEquals(2, metadataImpactMixJSONObject.getInt("3"));
 	}
 
 	@Test
-	public void testFinalizesWhenAllScansCompleted() throws Exception {
-		_seedScanRun();
+	public void testExecuteWithExistingScanMetric() throws Exception {
+		_addSEOStudioScanRunObjectEntry();
+
+		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"crawler", "completed");
+
+		_addSEOStudioScanObjectEntry("pageSpeed", "completed");
+
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+
+		Assert.assertEquals(
+			"completed", _getState(_seoStudioScanRunObjectEntry));
+
+		List<ObjectEntry> seoStudioScanMetricObjectEntries =
+			_getSEOStudioScanMetricObjectEntries(_seoStudioScanRunObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanMetricObjectEntries.toString(), 1,
+			seoStudioScanMetricObjectEntries.size());
+	}
+
+	@Test
+	public void testExecuteWithFailedScan() throws Exception {
+		_testExecuteWithoutMetrics("failed", "cancelled");
+		_testExecuteWithoutMetrics("failed", "failed");
+	}
+
+	@Test
+	public void testExecuteWithNoScanInsights() throws Exception {
+		_addSEOStudioScanRunObjectEntry();
 
 		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
 			"crawler", "completed");
@@ -186,145 +217,109 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 			seoStudioScanMetricObjectEntries.toString(), 1,
 			seoStudioScanMetricObjectEntries.size());
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			seoStudioScanMetricObjectEntries.get(
-				0
-			).getObjectEntryId());
+		ObjectEntry seoStudioScanMetricObjectEntry =
+			seoStudioScanMetricObjectEntries.get(0);
 
-		Assert.assertEquals("onPage", MapUtil.getString(values, "scope"));
-		Assert.assertEquals(0, MapUtil.getInteger(values, "totalInsights"));
-		Assert.assertEquals(0, MapUtil.getInteger(values, "criticalInsights"));
+		Map<String, Serializable> values = objectEntryLocalService.getValues(
+			seoStudioScanMetricObjectEntry.getObjectEntryId());
+
 		Assert.assertEquals(
 			0, MapUtil.getInteger(values, "affectedPagesCount"));
+		Assert.assertEquals(0, MapUtil.getInteger(values, "criticalInsights"));
+		Assert.assertEquals("onPage", MapUtil.getString(values, "scope"));
+		Assert.assertEquals(0, MapUtil.getInteger(values, "totalInsights"));
 	}
 
 	@Test
-	public void testIsIdempotent() throws Exception {
-		_seedScanRun();
-
-		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
-			"crawler", "completed");
-
-		_addSEOStudioScanObjectEntry("pageSpeed", "completed");
-
-		_executeCalculateScanMetrics(completedScanObjectEntry);
-		_executeCalculateScanMetrics(completedScanObjectEntry);
-
-		Assert.assertEquals(
-			"completed", _getState(_seoStudioScanRunObjectEntry));
-
-		List<ObjectEntry> seoStudioScanMetricObjectEntries =
-			_getSEOStudioScanMetricObjectEntries(_seoStudioScanRunObjectEntry);
-
-		Assert.assertEquals(
-			seoStudioScanMetricObjectEntries.toString(), 1,
-			seoStudioScanMetricObjectEntries.size());
+	public void testExecuteWithRunningScan() throws Exception {
+		_testExecuteWithoutMetrics("running", "running");
 	}
 
-	@Test
-	public void testSetsScanRunToFailedWhenScanCancelled() throws Exception {
-		_seedScanRun();
-
-		_addSEOStudioScanObjectEntry("crawler", "completed");
-
-		ObjectEntry cancelledScanObjectEntry = _addSEOStudioScanObjectEntry(
-			"pageSpeed", "cancelled");
-
-		_executeCalculateScanMetrics(cancelledScanObjectEntry);
-
-		Assert.assertEquals("failed", _getState(_seoStudioScanRunObjectEntry));
-		Assert.assertTrue(
-			_getSEOStudioScanMetricObjectEntries(
-				_seoStudioScanRunObjectEntry
-			).isEmpty());
-	}
-
-	@Test
-	public void testSetsScanRunToFailedWhenScanFailed() throws Exception {
-		_seedScanRun();
-
-		_addSEOStudioScanObjectEntry("crawler", "completed");
-
-		ObjectEntry failedScanObjectEntry = _addSEOStudioScanObjectEntry(
-			"pageSpeed", "failed");
-
-		_executeCalculateScanMetrics(failedScanObjectEntry);
-
-		Assert.assertEquals("failed", _getState(_seoStudioScanRunObjectEntry));
-		Assert.assertTrue(
-			_getSEOStudioScanMetricObjectEntries(
-				_seoStudioScanRunObjectEntry
-			).isEmpty());
-	}
-
-	private AccountEntry _addAccountEntry() throws Exception {
-		return _accountEntryLocalService.addAccountEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT,
-			RandomTestUtil.randomString(), null, null,
-			RandomTestUtil.randomString() + "@liferay.com", null, null,
-			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
-			WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext());
-	}
-
-	private ObjectEntry _addSEOStudioDomainObjectEntry(
-			AccountEntry accountEntry, ObjectEntry seoStudioInstanceObjectEntry)
+	private ObjectEntry _addSEOStudioInsightTypeObjectEntry(
+			String category, ObjectEntry seoStudioScanObjectEntry,
+			String severity)
 		throws Exception {
 
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		return addObjectEntry(
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_INSIGHT_TYPE",
+					TestPropsValues.getCompanyId()),
 			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
+				"category", category
 			).put(
-				"name", RandomTestUtil.randomString()
+				"name", "orphanPages"
 			).put(
-				"r_accountToSEOStudioDomains_accountEntryId",
+				"r_accountToSEOStudioInsightTypes_accountEntryId",
 				accountEntry.getAccountEntryId()
 			).put(
-				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				seoStudioInstanceObjectEntry.getObjectEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+				seoStudioScanObjectEntry.getObjectEntryId()
+			).put(
+				"severity", severity
+			).build());
 	}
 
-	private ObjectEntry _addSEOStudioInstanceObjectEntry(
-			AccountEntry accountEntry)
+	private ObjectEntry _addSEOStudioPageObjectEntry(
+			ObjectEntry seoStudioScanObjectEntry)
 		throws Exception {
 
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioInstanceObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		return addObjectEntry(
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_PAGE", TestPropsValues.getCompanyId()),
 			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
+				"pageURL", RandomTestUtil.randomString()
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioInstances_accountEntryId",
+				"r_accountToSEOStudioPages_accountEntryId",
 				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+			).put(
+				"r_seoStudioScanToSEOStudioPages_seoStudioScanId",
+				seoStudioScanObjectEntry.getObjectEntryId()
+			).build());
+	}
+
+	private ObjectEntry _addSEOStudioScanInsightObjectEntry(
+			ObjectEntry seoStudioInsightTypeObjectEntry,
+			ObjectEntry seoStudioPageObjectEntry,
+			ObjectEntry seoStudioScanObjectEntry)
+		throws Exception {
+
+		return addObjectEntry(
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_INSIGHT",
+					TestPropsValues.getCompanyId()),
+			HashMapBuilder.<String, Serializable>put(
+				"classification", "problem"
+			).put(
+				"detectedDate", new Date()
+			).put(
+				"r_accountToSEOStudioScanInsights_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInsightTypeToScanInsights_seoStudioInsightTypeId",
+				seoStudioInsightTypeObjectEntry.getObjectEntryId()
+			).put(
+				"r_seoStudioPageToSEOStudioScanInsights_seoStudioPageId",
+				seoStudioPageObjectEntry.getObjectEntryId()
+			).put(
+				"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+				seoStudioScanObjectEntry.getObjectEntryId()
+			).put(
+				"state", RandomTestUtil.randomInt()
+			).build());
 	}
 
 	private ObjectEntry _addSEOStudioScanObjectEntry(
 			String scanType, String state)
 		throws Exception {
 
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioScanObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		return addObjectEntry(
+			_seoStudioScanObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"r_accountToSEOStudioScans_accountEntryId",
-				_accountEntry.getAccountEntryId()
+				accountEntry.getAccountEntryId()
 			).put(
 				"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
 				_seoStudioScanRunObjectEntry.getObjectEntryId()
@@ -336,20 +331,15 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 				"scanType", scanType
 			).put(
 				"state", state
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
-	private ObjectEntry _addSEOStudioScanRunObjectEntry(
-			AccountEntry accountEntry, ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
+	private void _addSEOStudioScanRunObjectEntry() throws Exception {
+		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
+			RandomTestUtil.randomString(), null);
 
-		return _objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
+		_seoStudioScanRunObjectEntry = addObjectEntry(
+			_seoStudioScanRunObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
 				"name", RandomTestUtil.randomString()
 			).put(
@@ -364,9 +354,7 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 				"state", "running"
 			).put(
 				"triggeredBy", "manual"
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 	private void _executeCalculateScanMetrics(
@@ -399,23 +387,7 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
 				"seoStudioScanRunToSEOStudioScanMetrics");
 
-		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioScanRunObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-				"seoStudioScanRunToSEOStudioScans");
-
-		return _objectEntryLocalService.getOneToManyObjectEntries(
+		return objectEntryLocalService.getOneToManyObjectEntries(
 			seoStudioScanRunObjectEntry.getGroupId(),
 			objectRelationship.getObjectRelationshipId(), null, true,
 			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
@@ -424,29 +396,30 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 
 	private String _getState(ObjectEntry objectEntry) throws Exception {
 		return MapUtil.getString(
-			_objectEntryLocalService.getValues(objectEntry.getObjectEntryId()),
+			objectEntryLocalService.getValues(objectEntry.getObjectEntryId()),
 			"state");
 	}
 
-	private void _seedScanRun() throws Exception {
-		_accountEntry = _addAccountEntry();
+	private void _testExecuteWithoutMetrics(
+			String expectedState, String scanState)
+		throws Exception {
 
-		_seoStudioInstanceObjectEntry = _addSEOStudioInstanceObjectEntry(
-			_accountEntry);
+		_addSEOStudioScanRunObjectEntry();
 
-		_seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
-			_accountEntry, _seoStudioInstanceObjectEntry);
+		ObjectEntry completedScanObjectEntry = _addSEOStudioScanObjectEntry(
+			"crawler", "completed");
 
-		_seoStudioScanRunObjectEntry = _addSEOStudioScanRunObjectEntry(
-			_accountEntry, _seoStudioDomainObjectEntry);
+		_addSEOStudioScanObjectEntry("pageSpeed", scanState);
+
+		_executeCalculateScanMetrics(completedScanObjectEntry);
+
+		Assert.assertEquals(
+			expectedState, _getState(_seoStudioScanRunObjectEntry));
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				_getSEOStudioScanMetricObjectEntries(
+					_seoStudioScanRunObjectEntry)));
 	}
-
-	private AccountEntry _accountEntry;
-
-	@Inject
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	private Group _group;
 
 	@Inject
 	private ObjectActionEngine _objectActionEngine;
@@ -458,20 +431,10 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest {
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
-	private ObjectDefinition _seoStudioDomainObjectDefinition;
-	private ObjectEntry _seoStudioDomainObjectEntry;
-	private ObjectDefinition _seoStudioInstanceObjectDefinition;
-	private ObjectEntry _seoStudioInstanceObjectEntry;
 	private ObjectDefinition _seoStudioScanObjectDefinition;
 	private ObjectDefinition _seoStudioScanRunObjectDefinition;
 	private ObjectEntry _seoStudioScanRunObjectEntry;
-
-	@Inject
-	private SiteInitializerRegistry _siteInitializerRegistry;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
@@ -48,7 +48,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 		int maxPagesPerScan = RandomTestUtil.randomInt();
 		String scope = RandomTestUtil.randomString();
 
-		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
+		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
 			hostname,
 			JSONUtil.put(
 				"engines",
@@ -137,7 +137,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 
 	@Test
 	public void testExecuteWithNoEnabledEngines() throws Exception {
-		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
+		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
 			RandomTestUtil.randomString(),
 			JSONUtil.put(
 				"engines",
@@ -156,27 +156,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 
 		Assert.assertNull(
 			_fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
-	}
-
-	private ObjectEntry _addSEOStudioDomainObjectEntry(
-			String hostname, String scanConfigJSON)
-		throws Exception {
-
-		return addObjectEntry(
-			seoStudioDomainObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", hostname
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioDomains_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).put(
-				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				seoStudioInstanceObjectEntry.getObjectEntryId()
-			).put(
-				"scanConfig", scanConfigJSON
-			).build());
 	}
 
 	private void _executeCreateScans() throws Exception {

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CalculateSEOStudioScanMetricsObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CalculateSEOStudioScanMetricsObjectActionExecutorImpl.java
@@ -16,6 +16,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -27,8 +28,11 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import java.io.Serializable;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -90,10 +94,11 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 			return;
 		}
 
-		List<ObjectEntry> seoStudioScanObjectEntries =
-			_getSEOStudioScanRunRelatedObjectEntries(
-				companyId, seoStudioScanRunObjectEntry,
-				"seoStudioScanRunToSEOStudioScans");
+		List<ObjectEntry> seoStudioScanObjectEntries = _getRelatedObjectEntries(
+			seoStudioScanRunObjectEntry,
+			_fetchObjectRelationship(
+				companyId, "L_SEO_STUDIO_SCAN_RUN",
+				"seoStudioScanRunToSEOStudioScans"));
 
 		if (ListUtil.isEmpty(seoStudioScanObjectEntries)) {
 			return;
@@ -103,8 +108,7 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 				seoStudioScanObjectEntries) {
 
 			Map<String, Serializable> values =
-				_objectEntryLocalService.getValues(
-					seoStudioScanObjectEntry.getObjectEntryId());
+				seoStudioScanObjectEntry.getValues();
 
 			String seoStudioScanState = GetterUtil.getString(
 				values.get("state"));
@@ -126,25 +130,69 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 		}
 
 		List<ObjectEntry> seoStudioScanMetricObjectEntries =
-			_getSEOStudioScanRunRelatedObjectEntries(
-				companyId, seoStudioScanRunObjectEntry,
-				"seoStudioScanRunToSEOStudioScanMetrics");
+			_getRelatedObjectEntries(
+				seoStudioScanRunObjectEntry,
+				_fetchObjectRelationship(
+					companyId, "L_SEO_STUDIO_SCAN_RUN",
+					"seoStudioScanRunToSEOStudioScanMetrics"));
 
-		if (seoStudioScanMetricObjectEntries.isEmpty()) {
-			_addOnPageSEOStudioScanMetric(
-				companyId, userId, seoStudioScanRunObjectEntry,
-				seoStudioScanRunValues);
+		if (ListUtil.isEmpty(seoStudioScanMetricObjectEntries)) {
+			_addSEOStudioScanMetrics(
+				companyId, seoStudioScanObjectEntries,
+				seoStudioScanRunObjectEntry, seoStudioScanRunValues, userId);
 		}
 
 		_partialUpdateSEOStudioScanRunState(
 			seoStudioScanRunObjectEntry, "completed", userId);
 	}
 
-	private void _addOnPageSEOStudioScanMetric(
-			long companyId, long userId,
+	private void _addSEOStudioScanMetric(
+			Set<Long> affectedPageIds, long companyId,
+			Map<String, Map<String, Integer>> impactMixMap, String scope,
 			ObjectEntry seoStudioScanRunObjectEntry,
-			Map<String, Serializable> seoStudioScanRunValues)
+			Map<String, Serializable> seoStudioScanRunValues, long userId)
 		throws Exception {
+
+		JSONObject categoryBreakdownJSONObject =
+			_jsonFactory.createJSONObject();
+		JSONObject impactMixJSONObject = _jsonFactory.createJSONObject();
+
+		int criticalInsights = 0;
+		int totalInsights = 0;
+
+		for (Map.Entry<String, Map<String, Integer>> entry :
+				impactMixMap.entrySet()) {
+
+			String category = entry.getKey();
+			Map<String, Integer> categoryImpactMixMap = entry.getValue();
+
+			JSONObject categoryImpactMixJSONObject =
+				_jsonFactory.createJSONObject();
+
+			int categoryTotalInsights = 0;
+
+			for (Map.Entry<String, Integer> impactCountEntry :
+					categoryImpactMixMap.entrySet()) {
+
+				categoryImpactMixJSONObject.put(
+					impactCountEntry.getKey(), impactCountEntry.getValue());
+
+				categoryTotalInsights += impactCountEntry.getValue();
+			}
+
+			criticalInsights += categoryImpactMixMap.getOrDefault("3", 0);
+			totalInsights += categoryTotalInsights;
+
+			categoryBreakdownJSONObject.put(category, categoryTotalInsights);
+			impactMixJSONObject.put(category, categoryImpactMixJSONObject);
+		}
+
+		double averageInsightsPerAffectedPage = 0.0;
+
+		if (!affectedPageIds.isEmpty()) {
+			averageInsightsPerAffectedPage =
+				(double)totalInsights / affectedPageIds.size();
+		}
 
 		ObjectDefinition seoStudioScanMetricObjectDefinition =
 			_objectDefinitionLocalService.
@@ -162,17 +210,17 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
-				"affectedPagesCount", 0
+				"affectedPagesCount", affectedPageIds.size()
 			).put(
-				"averageInsightsPerAffectedPage", 0.0D
+				"averageInsightsPerAffectedPage", averageInsightsPerAffectedPage
 			).put(
-				"categoryBreakdown", "{}"
+				"categoryBreakdown", categoryBreakdownJSONObject.toString()
 			).put(
 				"computedDate", new Date()
 			).put(
-				"criticalInsights", 0
+				"criticalInsights", criticalInsights
 			).put(
-				"impactMix", "{}"
+				"impactMix", impactMixJSONObject.toString()
 			).put(
 				"r_accountToSEOStudioScanMetrics_accountEntryId",
 				GetterUtil.getLong(
@@ -182,33 +230,139 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 				"r_seoStudioScanRunToSEOStudioScanMetrics_seoStudioScanRunId",
 				seoStudioScanRunObjectEntry.getObjectEntryId()
 			).put(
-				"scope", "onPage"
+				"scope", scope
 			).put(
-				"totalInsights", 0
+				"totalInsights", totalInsights
 			).build(),
 			serviceContext);
 	}
 
-	private List<ObjectEntry> _getSEOStudioScanRunRelatedObjectEntries(
-			long companyId, ObjectEntry seoStudioScanRunObjectEntry,
+	private void _addSEOStudioScanMetrics(
+			long companyId, List<ObjectEntry> seoStudioScanObjectEntries,
+			ObjectEntry seoStudioScanRunObjectEntry,
+			Map<String, Serializable> seoStudioScanRunValues, long userId)
+		throws Exception {
+
+		Map<String, Set<Long>> affectedPageIdsMapByScope = new HashMap<>();
+		Map<String, Map<String, Map<String, Integer>>> impactMixMapByScope =
+			new HashMap<>();
+
+		for (String scope : _categoriesMapByScope.keySet()) {
+			affectedPageIdsMapByScope.put(scope, new HashSet<>());
+			impactMixMapByScope.put(scope, new HashMap<>());
+		}
+
+		ObjectRelationship objectRelationship = _fetchObjectRelationship(
+			companyId, "L_SEO_STUDIO_SCAN",
+			"seoStudioScanToSEOStudioScanInsights");
+
+		Map<Long, Map<String, Serializable>> seoStudioInsightTypeValuesMap =
+			new HashMap<>();
+
+		for (ObjectEntry seoStudioScanObjectEntry :
+				seoStudioScanObjectEntries) {
+
+			for (ObjectEntry seoStudioScanInsightObjectEntry :
+					_getRelatedObjectEntries(
+						seoStudioScanObjectEntry, objectRelationship)) {
+
+				Map<String, Serializable> seoStudioScanInsightValues =
+					seoStudioScanInsightObjectEntry.getValues();
+
+				long seoStudioInsightTypeId = GetterUtil.getLong(
+					seoStudioScanInsightValues.get(
+						"r_seoStudioInsightTypeToScanInsights_" +
+							"seoStudioInsightTypeId"));
+
+				Map<String, Serializable> seoStudioInsightTypeValues =
+					seoStudioInsightTypeValuesMap.get(seoStudioInsightTypeId);
+
+				if (seoStudioInsightTypeValues == null) {
+					seoStudioInsightTypeValues =
+						_objectEntryLocalService.getValues(
+							seoStudioInsightTypeId);
+
+					seoStudioInsightTypeValuesMap.put(
+						seoStudioInsightTypeId, seoStudioInsightTypeValues);
+				}
+
+				String category = GetterUtil.getString(
+					seoStudioInsightTypeValues.get("category"));
+
+				String scope = _getScope(category);
+
+				if (scope == null) {
+					continue;
+				}
+
+				Map<String, Map<String, Integer>> impactMixMap =
+					impactMixMapByScope.get(scope);
+
+				Map<String, Integer> categoryImpactMixMap =
+					impactMixMap.computeIfAbsent(
+						category, categoryKey -> new HashMap<>());
+
+				categoryImpactMixMap.merge(
+					GetterUtil.getString(
+						seoStudioInsightTypeValues.get("severity")),
+					1, Integer::sum);
+
+				Set<Long> affectedPageIds = affectedPageIdsMapByScope.get(
+					scope);
+
+				affectedPageIds.add(
+					GetterUtil.getLong(
+						seoStudioScanInsightValues.get(
+							"r_seoStudioPageToSEOStudioScanInsights_" +
+								"seoStudioPageId")));
+			}
+		}
+
+		for (String scope : _categoriesMapByScope.keySet()) {
+			_addSEOStudioScanMetric(
+				affectedPageIdsMapByScope.get(scope), companyId,
+				impactMixMapByScope.get(scope), scope,
+				seoStudioScanRunObjectEntry, seoStudioScanRunValues, userId);
+		}
+	}
+
+	private ObjectRelationship _fetchObjectRelationship(
+			long companyId, String objectDefinitionExternalReferenceCode,
 			String relationshipName)
 		throws Exception {
 
-		ObjectDefinition seoStudioScanRunObjectDefinition =
+		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN_RUN", companyId);
+					objectDefinitionExternalReferenceCode, companyId);
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-				relationshipName);
+		return _objectRelationshipLocalService.fetchObjectRelationship(
+			objectDefinition.getObjectDefinitionId(), relationshipName);
+	}
+
+	private List<ObjectEntry> _getRelatedObjectEntries(
+			ObjectEntry objectEntry, ObjectRelationship objectRelationship)
+		throws Exception {
 
 		return _objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
+			objectEntry.getGroupId(),
 			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+			objectEntry.getObjectEntryId(), true, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	private String _getScope(String category) {
+		for (Map.Entry<String, Set<String>> entry :
+				_categoriesMapByScope.entrySet()) {
+
+			Set<String> categories = entry.getValue();
+
+			if (categories.contains(category)) {
+				return entry.getKey();
+			}
+		}
+
+		return null;
 	}
 
 	private void _partialUpdateSEOStudioScanRunState(
@@ -228,6 +382,12 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
 			).build(),
 			serviceContext);
 	}
+
+	private static final Map<String, Set<String>> _categoriesMapByScope =
+		Map.of("onPage", Set.of("contentStructure", "images", "metadata"));
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CalculateSEOStudioScanMetricsObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CalculateSEOStudioScanMetricsObjectActionExecutorImpl.java
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.object.action.executor;
+
+import com.liferay.object.action.executor.BaseObjectActionExecutor;
+import com.liferay.object.action.executor.ObjectActionExecutor;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.scope.ObjectDefinitionScoped;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Noor Najjar
+ */
+@Component(service = ObjectActionExecutor.class)
+public class CalculateSEOStudioScanMetricsObjectActionExecutorImpl
+	extends BaseObjectActionExecutor implements ObjectDefinitionScoped {
+
+	@Override
+	public List<String> getAllowedObjectDefinitionNames() {
+		return List.of("SEOStudioScan");
+	}
+
+	@Override
+	public String getKey() {
+		return "calculate-seo-studio-scan-metrics";
+	}
+
+	@Override
+	protected void doExecute(
+			long companyId, long objectActionId,
+			UnicodeProperties parametersUnicodeProperties,
+			JSONObject payloadJSONObject, long userId)
+		throws Exception {
+
+		long seoStudioScanId = payloadJSONObject.getLong("classPK");
+
+		Map<String, Serializable> seoStudioScanValues =
+			_objectEntryLocalService.getValues(seoStudioScanId);
+
+		long seoStudioScanRunId = GetterUtil.getLong(
+			seoStudioScanValues.get(
+				"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId"));
+
+		if (seoStudioScanRunId <= 0) {
+			return;
+		}
+
+		ObjectEntry seoStudioScanRunObjectEntry =
+			_objectEntryLocalService.fetchObjectEntry(seoStudioScanRunId);
+
+		if (seoStudioScanRunObjectEntry == null) {
+			return;
+		}
+
+		Map<String, Serializable> seoStudioScanRunValues =
+			seoStudioScanRunObjectEntry.getValues();
+
+		String seoStudioScanRunState = GetterUtil.getString(
+			seoStudioScanRunValues.get("state"));
+
+		if (ArrayUtil.contains(
+				new String[] {"cancelled", "completed", "failed"},
+				seoStudioScanRunState)) {
+
+			return;
+		}
+
+		List<ObjectEntry> seoStudioScanObjectEntries =
+			_getSEOStudioScanRunRelatedObjectEntries(
+				companyId, seoStudioScanRunObjectEntry,
+				"seoStudioScanRunToSEOStudioScans");
+
+		if (ListUtil.isEmpty(seoStudioScanObjectEntries)) {
+			return;
+		}
+
+		for (ObjectEntry seoStudioScanObjectEntry :
+				seoStudioScanObjectEntries) {
+
+			Map<String, Serializable> values =
+				_objectEntryLocalService.getValues(
+					seoStudioScanObjectEntry.getObjectEntryId());
+
+			String seoStudioScanState = GetterUtil.getString(
+				values.get("state"));
+
+			if (ArrayUtil.contains(
+					new String[] {"queued", "running"}, seoStudioScanState)) {
+
+				return;
+			}
+
+			if (ArrayUtil.contains(
+					new String[] {"cancelled", "failed"}, seoStudioScanState)) {
+
+				_partialUpdateSEOStudioScanRunState(
+					seoStudioScanRunObjectEntry, "failed", userId);
+
+				return;
+			}
+		}
+
+		List<ObjectEntry> seoStudioScanMetricObjectEntries =
+			_getSEOStudioScanRunRelatedObjectEntries(
+				companyId, seoStudioScanRunObjectEntry,
+				"seoStudioScanRunToSEOStudioScanMetrics");
+
+		if (seoStudioScanMetricObjectEntries.isEmpty()) {
+			_addOnPageSEOStudioScanMetric(
+				companyId, userId, seoStudioScanRunObjectEntry,
+				seoStudioScanRunValues);
+		}
+
+		_partialUpdateSEOStudioScanRunState(
+			seoStudioScanRunObjectEntry, "completed", userId);
+	}
+
+	private void _addOnPageSEOStudioScanMetric(
+			long companyId, long userId,
+			ObjectEntry seoStudioScanRunObjectEntry,
+			Map<String, Serializable> seoStudioScanRunValues)
+		throws Exception {
+
+		ObjectDefinition seoStudioScanMetricObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_METRIC", companyId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.addObjectEntry(
+			0, userId,
+			seoStudioScanMetricObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"affectedPagesCount", 0
+			).put(
+				"averageInsightsPerAffectedPage", 0.0D
+			).put(
+				"categoryBreakdown", "{}"
+			).put(
+				"computedDate", new Date()
+			).put(
+				"criticalInsights", 0
+			).put(
+				"impactMix", "{}"
+			).put(
+				"r_accountToSEOStudioScanMetrics_accountEntryId",
+				GetterUtil.getLong(
+					seoStudioScanRunValues.get(
+						"r_accountToSEOStudioScanRuns_accountEntryId"))
+			).put(
+				"r_seoStudioScanRunToSEOStudioScanMetrics_seoStudioScanRunId",
+				seoStudioScanRunObjectEntry.getObjectEntryId()
+			).put(
+				"scope", "onPage"
+			).put(
+				"totalInsights", 0
+			).build(),
+			serviceContext);
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanRunRelatedObjectEntries(
+			long companyId, ObjectEntry seoStudioScanRunObjectEntry,
+			String relationshipName)
+		throws Exception {
+
+		ObjectDefinition seoStudioScanRunObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_RUN", companyId);
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				relationshipName);
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioScanRunObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private void _partialUpdateSEOStudioScanRunState(
+			ObjectEntry seoStudioScanRunObjectEntry, String state, long userId)
+		throws Exception {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(seoStudioScanRunObjectEntry.getCompanyId());
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			userId, seoStudioScanRunObjectEntry.getObjectEntryId(),
+			seoStudioScanRunObjectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"state", state
+			).build(),
+			serviceContext);
+	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96037

## What Is Being Fixed

The On-Page Insights Dashboard (LPD-92215) needs precomputed On-Page metrics for each scan run, but nothing computed or persisted them when a run's scans finished. The dashboard's distinct "affected pages" count and related aggregates cannot be derived live across the union of a run's per-engine scans, so without a precomputed row the dashboard has nothing to read.

## How It Is Being Fixed

An onAfterUpdate object action on SEOStudioScan is backed by a new ObjectActionExecutor (calculate-seo-studio-scan-metrics) in seo-studio-web. When a scan reaches a terminal state, the executor inspects the sibling scans of the parent SEOStudioScanRun: if any sibling is still queued or running it returns without doing anything; if any failed or was cancelled it marks the run failed and skips metrics; once every sibling has completed it computes the On-Page metrics, writes a single SEOStudioScanMetric row with scope onPage, and marks the run completed.

The metrics are computed over SEOStudioScanInsight occurrences joined to their SEOStudioInsightType, filtered to the On-Page categories (metadata, contentStructure, images): totalInsights, criticalInsights (severity 3), a nested category-to-impact impactMix, a categoryBreakdown, the distinct affectedPagesCount, and averageInsightsPerAffectedPage. The aggregation is routed per scope so the technical and AEO scopes can be added later by extending a single mapping. Finalization is idempotent, guarded by the run state and a check for an existing metric row.

## PR Check

**pr-check: PASS** — tested on `0c278c78022763f3a383961f3e7a815f9f4126b2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit | PASS |

<!-- pr-check {"result": "success", "sha": "0c278c78022763f3a383961f3e7a815f9f4126b2"} -->
