### PR TITLE
LPD-88837 Add Liferay Headless client and PageSpeed value classes

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -20,9 +20,11 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 dependencies {
+	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kiana Suetani
+ */
+public class Domain {
+
+	public Domain(JSONObject jsonObject) {
+		_domainHostname = jsonObject.optString("domainHostname", null);
+
+		JSONObject seoStudioInstanceJSONObject = jsonObject.optJSONObject(
+			"seoStudioInstance");
+
+		if (seoStudioInstanceJSONObject != null) {
+			_googlePageSpeedAPIKey = seoStudioInstanceJSONObject.optString(
+				"googlePageSpeedAPIKey", null);
+		}
+		else {
+			_googlePageSpeedAPIKey = null;
+		}
+	}
+
+	public String getDomainHostname() {
+		return _domainHostname;
+	}
+
+	public String getGooglePageSpeedAPIKey() {
+		return _googlePageSpeedAPIKey;
+	}
+
+	private final String _domainHostname;
+	private final String _googlePageSpeedAPIKey;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -1,0 +1,279 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.Domain;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class LiferayService extends BaseService {
+
+	public Domain getDomain(long domainId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/seo-studio/domains/" + domainId
+		).queryParam(
+			"nestedFields", "seoStudioInstance"
+		).build();
+
+		String responseJSON = get(
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				"liferay-seostudio-etc-pagespeed-oahs"),
+			uriComponents.toUri());
+
+		String message = "Unable to find domain " + domainId;
+
+		if (Validator.isNull(responseJSON)) {
+			throw new IllegalArgumentException(message);
+		}
+
+		try {
+			return new Domain(new JSONObject(responseJSON));
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(message, jsonException);
+			}
+
+			throw new IllegalArgumentException(message, jsonException);
+		}
+	}
+
+	public List<String> getSitemapPageURLs(String hostname, int limit) {
+		if ((limit <= 0) || Validator.isNull(hostname)) {
+			return Collections.emptyList();
+		}
+
+		String sitemapXML = _getSitemapXML(
+			"https://" + hostname + "/sitemap.xml");
+
+		if (Validator.isNull(sitemapXML)) {
+			return Collections.emptyList();
+		}
+
+		return _parseSitemapPageURLs(0, hostname, limit, sitemapXML);
+	}
+
+	private String _getSitemapXML(String url) {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+				).uri(
+					URI.create(url)
+				).timeout(
+					Duration.ofSeconds(10)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to fetch sitemap ", url, ", HTTP ",
+							httpResponse.statusCode()));
+				}
+
+				return null;
+			}
+
+			return httpResponse.body();
+		}
+		catch (IllegalArgumentException | IOException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to fetch sitemap " + url, exception);
+			}
+
+			return null;
+		}
+		catch (InterruptedException interruptedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to fetch sitemap " + url, interruptedException);
+			}
+
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			return null;
+		}
+	}
+
+	private boolean _isSameHost(String hostname, String urlString) {
+		try {
+			URI uri = URI.create(urlString);
+
+			String host = uri.getHost();
+
+			if (Validator.isNull(host)) {
+				return false;
+			}
+
+			String lowerCaseHost = StringUtil.toLowerCase(host);
+			String lowerCaseHostname = StringUtil.toLowerCase(hostname);
+
+			if (lowerCaseHost.equals(lowerCaseHostname) ||
+				lowerCaseHost.endsWith("." + lowerCaseHostname)) {
+
+				return true;
+			}
+
+			return false;
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to parse URL " + urlString,
+					illegalArgumentException);
+			}
+
+			return false;
+		}
+	}
+
+	private List<String> _parseSitemapPageURLs(
+		int depth, String hostname, int limit, String sitemapXML) {
+
+		if (limit <= 0) {
+			return Collections.emptyList();
+		}
+
+		if (depth > 3) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Maximum sitemap recursion depth exceeded");
+			}
+
+			return Collections.emptyList();
+		}
+
+		List<String> urls = new ArrayList<>();
+
+		JsonNode jsonNode = null;
+
+		try {
+			jsonNode = _xmlMapper.readTree(sitemapXML);
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to parse sitemap", ioException);
+			}
+
+			return urls;
+		}
+
+		if (jsonNode == null) {
+			return urls;
+		}
+
+		boolean sitemapIndex = jsonNode.has("sitemap");
+
+		JsonNode entriesJsonNode =
+			sitemapIndex ? jsonNode.path("sitemap") : jsonNode.path("url");
+
+		List<JsonNode> entryJsonNodes = new ArrayList<>();
+
+		if (entriesJsonNode.isArray()) {
+			entriesJsonNode.forEach(entryJsonNodes::add);
+		}
+		else if (!entriesJsonNode.isMissingNode()) {
+			entryJsonNodes.add(entriesJsonNode);
+		}
+
+		for (JsonNode entryJsonNode : entryJsonNodes) {
+			if (urls.size() >= limit) {
+				break;
+			}
+
+			JsonNode locJsonNode = entryJsonNode.path("loc");
+
+			String loc = locJsonNode.asText(null);
+
+			if (Validator.isNull(loc)) {
+				continue;
+			}
+
+			loc = loc.trim();
+
+			if (Validator.isNull(loc)) {
+				continue;
+			}
+
+			if (sitemapIndex) {
+				if (!_isSameHost(hostname, loc)) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("Ignoring cross host sitemap URL " + loc);
+					}
+
+					continue;
+				}
+
+				String childSitemapXML = _getSitemapXML(loc);
+
+				if (Validator.isNotNull(childSitemapXML)) {
+					urls.addAll(
+						_parseSitemapPageURLs(
+							depth + 1, hostname, limit - urls.size(),
+							childSitemapXML));
+				}
+			}
+			else {
+				urls.add(loc);
+			}
+		}
+
+		return urls;
+	}
+
+	private static final Log _log = LogFactory.getLog(LiferayService.class);
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).connectTimeout(
+		Duration.ofSeconds(5)
+	).followRedirects(
+		HttpClient.Redirect.NORMAL
+	).build();
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	private final XmlMapper _xmlMapper = new XmlMapper();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

Bootstrap the PageSpeed client extension utilities — a Liferay Headless client that fetches the SEO Studio Domain (with its Google PageSpeed API key) and a sitemap parser that discovers the URLs to scan. Later commits in the epic build on this base.

## How It Is Being Fixed

Add `Domain`, a JSON-backed value class exposing `domainHostname` and `googlePageSpeedAPIKey`, and `LiferayService`, which wraps the workspace CET's REST access. `getDomain(long)` reads the object entry via `/o/seo-studio/domains/{id}` with `nestedFields=seoStudioInstance` and unwraps the API key. `getSitemapPageURLs(String, int)` fetches the site's `sitemap.xml`, parses it with Jackson `XmlMapper`, follows sitemap-index recursion up to depth 3, and returns the leaf page URLs.

## Why Are There No Tests?

Workspace CETs cover behavior via end-to-end tests in the portal's main test suite; per team convention, no local unit tests are added to `workspaces/**/client-extensions/**`.

## PR Check

**pr-check: PASS** — tested on `8edaf0ae0d171d7aa0c619c695ea40d1956c2bd0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "8edaf0ae0d171d7aa0c619c695ea40d1956c2bd0"} -->
