### PR TITLE
LPD-88837 Add PageSpeed scanner with sitemap-based URL discovery

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -22,6 +22,7 @@ apply plugin: "org.springframework.boot"
 dependencies {
 	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
@@ -10,10 +10,12 @@ import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringB
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * @author Kiana Suetani
  */
+@EnableScheduling
 @Import(ClientExtensionUtilSpringBootComponentScan.class)
 @SpringBootApplication
 public class SEOStudioSpringBootApplication {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.constants;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedConstants {
+
+	public static final String STATE_COMPLETED = "completed";
+
+	public static final String STATE_FAILED = "failed";
+
+	public static final String STATE_QUEUED = "queued";
+
+	public static final String STATE_RUNNING = "running";
+
+	public static final String STRATEGY_DESKTOP = "DESKTOP";
+
+	public static final String STRATEGY_MOBILE = "MOBILE";
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScanResult {
+
+	public PageSpeedScanResult(
+		PageSpeedReport averagePageSpeedReport, int pagesErrored,
+		int pagesScanned, int pagesTotal, String strategy) {
+
+		_averagePageSpeedReport = averagePageSpeedReport;
+		_pagesErrored = pagesErrored;
+		_pagesScanned = pagesScanned;
+		_pagesTotal = pagesTotal;
+		_strategy = strategy;
+	}
+
+	public PageSpeedReport getAveragePageSpeedReport() {
+		return _averagePageSpeedReport;
+	}
+
+	public int getPagesErrored() {
+		return _pagesErrored;
+	}
+
+	public int getPagesScanned() {
+		return _pagesScanned;
+	}
+
+	public int getPagesTotal() {
+		return _pagesTotal;
+	}
+
+	public String getStrategy() {
+		return _strategy;
+	}
+
+	private final PageSpeedReport _averagePageSpeedReport;
+	private final int _pagesErrored;
+	private final int _pagesScanned;
+	private final int _pagesTotal;
+	private final String _strategy;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -13,7 +13,10 @@ import com.liferay.client.extension.util.spring.boot3.service.BaseService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.PageSpeedConstants;
 import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.PageSpeedReport;
+import com.liferay.seo.studio.model.PageSpeedScanResult;
 
 import java.io.IOException;
 
@@ -32,6 +35,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -53,10 +57,7 @@ public class LiferayService extends BaseService {
 			"nestedFields", "seoStudioInstance"
 		).build();
 
-		String responseJSON = get(
-			_liferayOAuth2AccessTokenManager.getAuthorization(
-				"liferay-seostudio-etc-pagespeed-oahs"),
-			uriComponents.toUri());
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
 
 		String message = "Unable to find domain " + domainId;
 
@@ -76,19 +77,143 @@ public class LiferayService extends BaseService {
 		}
 	}
 
+	public JSONArray getQueuedSEOStudioScansJSONArray() {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscans"
+		).queryParam(
+			"filter", "state eq '" + PageSpeedConstants.STATE_QUEUED + "'"
+		).queryParam(
+			"pageSize", 20
+		).build();
+
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
+
+		if (Validator.isNull(responseJSON)) {
+			return new JSONArray();
+		}
+
+		JSONArray itemsJSONArray = new JSONObject(
+			responseJSON
+		).optJSONArray(
+			"items"
+		);
+
+		if (itemsJSONArray == null) {
+			return new JSONArray();
+		}
+
+		return itemsJSONArray;
+	}
+
+	public JSONObject getSEOStudioScanRunJSONObject(long seoStudioScanRunId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscanruns/" + seoStudioScanRunId
+		).build();
+
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
+
+		String message =
+			"Unable to find SEO Studio scan run " + seoStudioScanRunId;
+
+		if (Validator.isNull(responseJSON)) {
+			throw new IllegalArgumentException(message);
+		}
+
+		try {
+			return new JSONObject(responseJSON);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(message, jsonException);
+			}
+
+			throw new IllegalArgumentException(message, jsonException);
+		}
+	}
+
 	public List<String> getSitemapPageURLs(String hostname, int limit) {
-		if ((limit <= 0) || Validator.isNull(hostname)) {
-			return Collections.emptyList();
+		if (Validator.isNull(hostname)) {
+			throw new IllegalArgumentException(
+				"Unable to fetch a sitemap without a hostname");
+		}
+
+		if (limit <= 0) {
+			throw new IllegalArgumentException(
+				"Unable to fetch a sitemap without a positive limit");
 		}
 
 		String sitemapXML = _getSitemapXML(
 			"https://" + hostname + "/sitemap.xml");
 
 		if (Validator.isNull(sitemapXML)) {
-			return Collections.emptyList();
+			throw new IllegalStateException(
+				"Unable to fetch a sitemap for " + hostname);
 		}
 
 		return _parseSitemapPageURLs(0, hostname, limit, sitemapXML);
+	}
+
+	public void patchSEOStudioScanState(
+		String errorMessage, long seoStudioScanId, String state) {
+
+		JSONObject bodyJSONObject = new JSONObject(
+		).put(
+			"state", state
+		);
+
+		if (Validator.isNotNull(errorMessage)) {
+			bodyJSONObject.put("errorMessage", errorMessage);
+		}
+
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscans/" + seoStudioScanId
+		).build();
+
+		patch(
+			_getAuthorization(), bodyJSONObject.toString(),
+			uriComponents.toUri());
+	}
+
+	public void postSEOStudioPageSpeedResult(
+		PageSpeedScanResult pageSpeedScanResult, long seoStudioScanId) {
+
+		PageSpeedReport averagePageSpeedReport =
+			pageSpeedScanResult.getAveragePageSpeedReport();
+
+		JSONObject bodyJSONObject = new JSONObject(
+		).put(
+			"accessibilityScore", averagePageSpeedReport.getAccessibility()
+		).put(
+			"bestPracticesScore", averagePageSpeedReport.getBestPractices()
+		).put(
+			"pagesErrored", pageSpeedScanResult.getPagesErrored()
+		).put(
+			"pagesScanned", pageSpeedScanResult.getPagesScanned()
+		).put(
+			"pagesTotal", pageSpeedScanResult.getPagesTotal()
+		).put(
+			"performanceScore", averagePageSpeedReport.getPerformance()
+		).put(
+			"r_seoStudioScanToSEOStudioPageSpeedResults_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"seoScore", averagePageSpeedReport.getSEO()
+		).put(
+			"strategy", pageSpeedScanResult.getStrategy()
+		);
+
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudiopagespeedresults"
+		).build();
+
+		post(
+			_getAuthorization(), bodyJSONObject.toString(),
+			uriComponents.toUri());
+	}
+
+	private String _getAuthorization() {
+		return _liferayOAuth2AccessTokenManager.getAuthorization(
+			"liferay-seostudio-etc-pagespeed-oahs");
 	}
 
 	private String _getSitemapXML(String url) {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.PageSpeedConstants;
+import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.PageSpeedReport;
+import com.liferay.seo.studio.model.PageSpeedScanResult;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class PageSpeedScanService {
+
+	@Scheduled(fixedDelay = 30000)
+	public void processQueuedScans() {
+		JSONArray scansJSONArray =
+			_liferayService.getQueuedSEOStudioScansJSONArray();
+
+		for (Object object : scansJSONArray) {
+			JSONObject scanJSONObject = (JSONObject)object;
+
+			long seoStudioScanId = scanJSONObject.optLong("id");
+
+			try {
+				_runScan(scanJSONObject, seoStudioScanId);
+			}
+			catch (Exception exception1) {
+				_log.error(
+					"Unable to run PageSpeed scan " + seoStudioScanId,
+					exception1);
+
+				try {
+					_liferayService.patchSEOStudioScanState(
+						exception1.getMessage(), seoStudioScanId,
+						PageSpeedConstants.STATE_FAILED);
+				}
+				catch (Exception exception2) {
+					_log.error(
+						"Unable to mark the scan " + seoStudioScanId +
+							" as failed",
+						exception2);
+				}
+			}
+		}
+	}
+
+	private PageSpeedReport _getPageSpeedReport(
+		String apiKey, String strategy, String url) {
+
+		try {
+			return _pageSpeedReportService.getPageSpeedReport(
+				apiKey, strategy, url);
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to complete PageSpeed scan " + url,
+					interruptedException);
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get PageSpeed scores " + url, ioException);
+			}
+
+			return null;
+		}
+	}
+
+	private void _runScan(JSONObject scanJSONObject, long seoStudioScanId) {
+		_liferayService.patchSEOStudioScanState(
+			null, seoStudioScanId, PageSpeedConstants.STATE_RUNNING);
+
+		long seoStudioScanRunId = scanJSONObject.optLong(
+			"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId");
+
+		JSONObject scanRunJSONObject =
+			_liferayService.getSEOStudioScanRunJSONObject(seoStudioScanRunId);
+
+		long domainId = scanRunJSONObject.optLong(
+			"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId");
+
+		Domain domain = _liferayService.getDomain(domainId);
+
+		String apiKey = domain.getGooglePageSpeedAPIKey();
+
+		if (Validator.isNull(apiKey)) {
+			_liferayService.patchSEOStudioScanState(
+				"Unable to find a Google PageSpeed API key for SEO Studio " +
+					"domain ID " + domainId,
+				seoStudioScanId, PageSpeedConstants.STATE_FAILED);
+
+			return;
+		}
+
+		JSONObject scopeConfigJSONObject = new JSONObject(
+			scanJSONObject.optString("scopeConfig"));
+
+		int maxPagesPerScan = scopeConfigJSONObject.optInt(
+			"maxPagesPerScan", 100);
+
+		List<String> urls = _liferayService.getSitemapPageURLs(
+			domain.getDomainHostname(), maxPagesPerScan);
+
+		_liferayService.postSEOStudioPageSpeedResult(
+			_scanURLs(apiKey, PageSpeedConstants.STRATEGY_DESKTOP, urls),
+			seoStudioScanId);
+		_liferayService.postSEOStudioPageSpeedResult(
+			_scanURLs(apiKey, PageSpeedConstants.STRATEGY_MOBILE, urls),
+			seoStudioScanId);
+
+		_liferayService.patchSEOStudioScanState(
+			null, seoStudioScanId, PageSpeedConstants.STATE_COMPLETED);
+	}
+
+	private PageSpeedScanResult _scanURLs(
+		String apiKey, String strategy, List<String> urls) {
+
+		List<CompletableFuture<PageSpeedReport>> completableFutures =
+			TransformUtil.transform(
+				urls,
+				url -> CompletableFuture.supplyAsync(
+					() -> _getPageSpeedReport(apiKey, strategy, url)));
+
+		int pagesErrored = 0;
+
+		List<PageSpeedReport> pageSpeedReports = new ArrayList<>();
+
+		for (CompletableFuture<PageSpeedReport> completableFuture :
+				completableFutures) {
+
+			try {
+				PageSpeedReport pageSpeedReport = completableFuture.join();
+
+				if (pageSpeedReport == null) {
+					pagesErrored++;
+				}
+				else {
+					pageSpeedReports.add(pageSpeedReport);
+				}
+			}
+			catch (Exception exception) {
+				pagesErrored++;
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Unable to add PageSpeed scores", exception);
+				}
+			}
+		}
+
+		int pagesScanned = pageSpeedReports.size();
+
+		if (pagesScanned == 0) {
+			return new PageSpeedScanResult(
+				new PageSpeedReport(0, 0, 0, 0), pagesErrored, pagesScanned,
+				urls.size(), strategy);
+		}
+
+		int totalAccessibility = 0;
+		int totalBestPractices = 0;
+		int totalPerformance = 0;
+		int totalSEO = 0;
+
+		for (PageSpeedReport pageSpeedReport : pageSpeedReports) {
+			totalAccessibility += pageSpeedReport.getAccessibility();
+			totalBestPractices += pageSpeedReport.getBestPractices();
+			totalPerformance += pageSpeedReport.getPerformance();
+			totalSEO += pageSpeedReport.getSEO();
+		}
+
+		PageSpeedReport averagePageSpeedReport = new PageSpeedReport(
+			Math.round((float)totalAccessibility / pagesScanned),
+			Math.round((float)totalBestPractices / pagesScanned),
+			Math.round((float)totalPerformance / pagesScanned),
+			Math.round((float)totalSEO / pagesScanned));
+
+		return new PageSpeedScanResult(
+			averagePageSpeedReport, pagesErrored, pagesScanned, urls.size(),
+			strategy);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		PageSpeedScanService.class);
+
+	@Autowired
+	private LiferayService _liferayService;
+
+	@Autowired
+	private PageSpeedReportService _pageSpeedReportService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

SEO Studio needs an automated PageSpeed scanner that processes queued scans against a domain's pages, aggregates scores across desktop and mobile strategies, and reports results back through the SEO Studio REST APIs.

## How It Is Being Fixed

Adds a `PageSpeedScanService` scheduled poller that pulls queued `SEOStudioScan` entries and delegates to Google's PageSpeed Insights API for each page discovered by fetching and parsing the domain's `sitemap.xml`. Sitemap parsing supports both sitemap indexes and URL sets, walks nested sitemaps up to a bounded recursion depth, and rejects cross-host references to close the SSRF vector introduced by hostname-configurable domains. Per-strategy averages (accessibility, best practices, performance, SEO) are POSTed as `SEOStudioPageSpeedResult` entries, and scan state transitions (running, failed, completed) are PATCHed on the scan itself.

The `LiferayService` layer wraps every REST call through Spring's `UriComponentsBuilder` for URI construction and reuses a single `_getAuthorization()` helper for OAuth headers. A `Domain` value class wraps the Liferay Headless response so callers see typed accessors (`getDomainHostname`, `getGooglePageSpeedAPIKey`) instead of raw JSON.

## Why Are There No Tests?

Behavior is covered end-to-end by SEO Studio integration tests in the portal's main test suite. Per team convention, client-extension microservices in `workspaces/` do not carry local unit tests — Brian has rejected CET-local tests on prior reviews.

## PR Check

**pr-check: PASS** — tested on `57df312fbca180148a6e3604ebdc2ac1a98972da`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "57df312fbca180148a6e3604ebdc2ac1a98972da"} -->
