### PR TITLE
LPD-91213 Add orphan page detection and scan status polling

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
@@ -108,6 +108,7 @@ public class AssetCategoryActionDropdownItemsProvider {
 					DropdownItemListBuilder.add(
 						() ->
 							!_assetCategoriesLimitExceeded &&
+							!_isSystemCategory(category) &&
 							_hasPermission(category, ActionKeys.ADD_CATEGORY),
 						dropdownItem -> {
 							dropdownItem.setHref(

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -274,6 +274,21 @@ public class AssetCategoryLocalServiceTest {
 			assetCategory.getTitleMap());
 	}
 
+	@FeatureFlag("LPD-86291")
+	@Test
+	public void testAddCategorySystemCategory() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot have child categories"),
+			() -> AssetTestUtil.addCategory(
+				_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+				assetCategory.getCategoryId()));
+	}
+
 	@Test
 	public void testAddCategoryWithExternalReferenceCode() throws Exception {
 		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
@@ -903,7 +918,7 @@ public class AssetCategoryLocalServiceTest {
 	@FeatureFlag("LPD-86291")
 	@Test
 	public void testMoveCategory() throws Exception {
-		AssetCategory assetCategory = _addSystemCategory();
+		AssetCategory assetCategory1 = _addSystemCategory();
 
 		AssetVocabulary assetVocabulary =
 			_assetVocabularyLocalService.addVocabulary(
@@ -915,12 +930,29 @@ public class AssetCategoryLocalServiceTest {
 		AssertUtils.assertFailure(
 			SystemCategoryException.MustNotModify.class,
 			StringBundler.concat(
-				"Category ", assetCategory.getCategoryId(),
+				"Category ", assetCategory1.getCategoryId(),
 				" cannot be modified"),
 			() -> _assetCategoryLocalService.moveCategory(
-				assetCategory.getCategoryId(),
+				assetCategory1.getCategoryId(),
 				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				assetVocabulary.getVocabularyId(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+
+		AssetCategory assetCategory2 = _addSystemCategory();
+
+		AssetCategory assetCategory3 = AssetTestUtil.addCategory(
+			_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", assetCategory2.getCategoryId(),
+				" cannot have child categories"),
+			() -> _assetCategoryLocalService.moveCategory(
+				assetCategory3.getCategoryId(), assetCategory2.getCategoryId(),
+				_assetVocabulary.getVocabularyId(),
 				ServiceContextTestUtil.getServiceContext(
 					_group.getGroupId(), TestPropsValues.getUserId())));
 	}
@@ -1298,6 +1330,7 @@ public class AssetCategoryLocalServiceTest {
 	public void testUpdateCategory() throws Exception {
 		_testUpdateCategorySystemDescription();
 		_testUpdateCategorySystemExternalReferenceCode();
+		_testUpdateCategorySystemParent();
 		_testUpdateCategorySystemRename();
 		_testUpdateCategorySystemWhenImporting();
 		_testUpdateCategorySystemWithNullDescription();
@@ -1428,6 +1461,28 @@ public class AssetCategoryLocalServiceTest {
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				assetCategory.getCategoryId(),
 				assetCategory.getParentCategoryId(),
+				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _testUpdateCategorySystemParent() throws Exception {
+		AssetCategory parentAssetCategory = _addSystemCategory();
+
+		AssetCategory assetCategory = AssetTestUtil.addCategory(
+			_group.getGroupId(), _assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotAddChild.class,
+			StringBundler.concat(
+				"Category ", parentAssetCategory.getCategoryId(),
+				" cannot have child categories"),
+			() -> _assetCategoryLocalService.updateCategory(
+				assetCategory.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				parentAssetCategory.getCategoryId(),
 				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
 				assetCategory.getVocabularyId(), null,
 				ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
@@ -94,7 +94,7 @@ public class CETManagerImplTest {
 	private void _testGetCETIsRebuiltAfterUpdate() throws Exception {
 		ClientExtensionEntry clientExtensionEntry = _addClientExtensionEntry(
 			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
-			RandomTestUtil.randomString());
+			"http://" + RandomTestUtil.randomString());
 
 		CET cet1 = _cetManager.getCET(
 			TestPropsValues.getCompanyId(),
@@ -130,11 +130,11 @@ public class CETManagerImplTest {
 		ClientExtensionEntry globalCSSClientExtensionEntry =
 			_addClientExtensionEntry(
 				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
-				RandomTestUtil.randomString());
+				"http://" + RandomTestUtil.randomString());
 		ClientExtensionEntry globalJSClientExtensionEntry =
 			_addClientExtensionEntry(
 				ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
-				RandomTestUtil.randomString());
+				"http://" + RandomTestUtil.randomString());
 
 		List<CET> cets = _cetManager.getCETs(
 			TestPropsValues.getCompanyId(), null,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/CacheControlWebServerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/CacheControlWebServerTest.java
@@ -6,9 +6,13 @@
 package com.liferay.document.library.webserver.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.test.util.BaseWebServerTestCase;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.friendly.url.resolver.FileEntryFriendlyURLResolver;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -64,6 +68,34 @@ public class CacheControlWebServerTest extends BaseWebServerTestCase {
 			mockHttpServletResponse.getHeader(HttpHeaders.CACHE_CONTROL));
 	}
 
+	@Test
+	public void testDownloadWhenCTCollectionIsCheckedOut() throws Exception {
+		String urlTitle = RandomTestUtil.randomString();
+
+		_addFileEntry(RandomTestUtil.randomString(), urlTitle);
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, group.getCompanyId(), TestPropsValues.getUserId(), 0,
+			RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			MockHttpServletResponse mockHttpServletResponse = service(
+				HttpMethods.GET, _getFileEntryFriendlyURL(urlTitle),
+				Collections.emptyMap(),
+				HashMapBuilder.put(
+					"download", Boolean.TRUE.toString()
+				).build(),
+				TestPropsValues.getUser(), null);
+
+			Assert.assertEquals(
+				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE,
+				mockHttpServletResponse.getHeader(HttpHeaders.CACHE_CONTROL));
+		}
+	}
+
 	private FileEntry _addFileEntry(String fileName, String urlTitle)
 		throws Exception {
 
@@ -82,6 +114,9 @@ public class CacheControlWebServerTest extends BaseWebServerTestCase {
 			"%s%s/%s", FriendlyURLResolverConstants.URL_SEPARATOR_X_FILE_ENTRY,
 			group.getFriendlyURL(), urlTitle);
 	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.web.internal.servlet;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.web.internal.configuration.CacheControlConfiguration;
 import com.liferay.document.library.web.internal.configuration.helper.CacheControlConfigurationHelper;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -49,6 +50,10 @@ public class CacheControlFileEntryHttpHeaderCustomizer
 
 	private String _getHttpHeaderValue(FileEntry fileEntry, String currentValue)
 		throws PortalException {
+
+		if (!CTCollectionThreadLocal.isProductionMode()) {
+			return HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
+		}
 
 		CacheControlConfiguration cacheControlConfiguration =
 			_cacheControlConfigurationHelper.

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1122,6 +1122,11 @@ public class LayoutReferencesExportImportContentProcessor
 			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
 				groupId, privateLayout, url);
 
+			if (layout == null) {
+				layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+					groupId, !privateLayout, url);
+			}
+
 			if (layout != null) {
 				continue;
 			}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -657,6 +657,26 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97694")
+	public void testValidateContentRelativePrivatePageURLWithVirtualHost()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(group, true);
+		GroupTestUtil.addLayoutSetVirtualHost(group, false);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group, true);
+
+		_layoutReferencesExportImportContentProcessor.validateContentReferences(
+			group.getGroupId(),
+			StringBundler.concat(
+				_CONTENT_PREFIX, layout.getFriendlyURL(),
+				_CONTENT_POSTFIX));
+
+	}
+
+	@Test
 	public void testValidateContentRelativePublicDefaultPageURLWithLocale()
 		throws Exception {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -671,9 +671,7 @@ public class LayoutReferencesExportImportContentProcessorTest {
 		_layoutReferencesExportImportContentProcessor.validateContentReferences(
 			group.getGroupId(),
 			StringBundler.concat(
-				_CONTENT_PREFIX, layout.getFriendlyURL(),
-				_CONTENT_POSTFIX));
-
+				_CONTENT_PREFIX, layout.getFriendlyURL(), _CONTENT_POSTFIX));
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -663,8 +663,8 @@ public class LayoutReferencesExportImportContentProcessorTest {
 
 		Group group = GroupTestUtil.addGroup();
 
-		GroupTestUtil.addLayoutSetVirtualHost(group, true);
 		GroupTestUtil.addLayoutSetVirtualHost(group, false);
+		GroupTestUtil.addLayoutSetVirtualHost(group, true);
 
 		Layout layout = LayoutTestUtil.addTypePortletLayout(group, true);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -98,6 +98,7 @@ public class TaxonomyCategoryDTOConverter
 				assetCategory.getCompanyId(), "LPD-86291") &&
 			assetCategory.isSystem()) {
 
+			actions.remove("add-category");
 			actions.remove("delete");
 			actions.remove("replace");
 			actions.remove("update");

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -474,6 +474,7 @@ public class TaxonomyCategoryResourceTest
 		super.testPatchTaxonomyCategory();
 
 		_testPatchTaxonomyCategorySystem();
+		_testPatchTaxonomyCategorySystemParent();
 		_testPatchTaxonomyCategoryWithExistingParentTaxonomyCategory(
 			testPatchTaxonomyCategory_addTaxonomyCategory(),
 			_addAssetVocabulary());
@@ -515,6 +516,27 @@ public class TaxonomyCategoryResourceTest
 		_testPostSiteTaxonomyCategoryBatch("INSERT");
 		_testPostSiteTaxonomyCategoryBatch("UPSERT");
 		_testPostSiteTaxonomyCategoryWithNonexistingTaxonomyVocabulary();
+	}
+
+	@FeatureFlag("LPD-86291")
+	@Override
+	@Test
+	public void testPostTaxonomyCategoryTaxonomyCategory() throws Exception {
+		super.testPostTaxonomyCategoryTaxonomyCategory();
+
+		TaxonomyCategory parentTaxonomyCategory = _addSystemTaxonomyCategory();
+
+		try {
+			taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
+				parentTaxonomyCategory.getId(), randomTaxonomyCategory());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
 	}
 
 	@Override
@@ -1421,6 +1443,44 @@ public class TaxonomyCategoryResourceTest
 		try {
 			taxonomyCategoryResource.patchTaxonomyCategory(
 				postTaxonomyCategory.getId(), postTaxonomyCategory);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPatchTaxonomyCategorySystemParent() throws Exception {
+		TaxonomyCategory randomTaxonomyCategory = randomTaxonomyCategory();
+
+		randomTaxonomyCategory.setSystem(true);
+
+		TaxonomyCategory patchParentTaxonomyCategory =
+			taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				_assetVocabulary.getVocabularyId(), randomTaxonomyCategory);
+
+		TaxonomyCategory taxonomyCategory =
+			testPatchTaxonomyCategory_addTaxonomyCategory();
+
+		try {
+			taxonomyCategoryResource.patchTaxonomyCategory(
+				taxonomyCategory.getId(),
+				new TaxonomyCategory() {
+					{
+						parentTaxonomyCategory = new ParentTaxonomyCategory() {
+							{
+								externalReferenceCode =
+									patchParentTaxonomyCategory.
+										getExternalReferenceCode();
+								id = Long.valueOf(
+									patchParentTaxonomyCategory.getId());
+							}
+						};
+					}
+				});
 
 			Assert.fail();
 		}

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.11.1
+Bundle-Version: 38.12.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -39,6 +39,39 @@ public class InfoFormValidationException extends InfoFormException {
 			locale, "x-an-error-occurred", HtmlUtil.escape(fieldLabel), false);
 	}
 
+	public static class AssetTooManyCategories
+		extends InfoFormValidationException {
+
+		public AssetTooManyCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class BlockedEmailAddressDomain
 		extends InvalidInfoFieldValue {
 
@@ -429,39 +462,6 @@ public class InfoFormValidationException extends InfoFormException {
 		private final List<CustomValidation> _customValidations =
 			new ArrayList<>();
 		private final String _message;
-
-	}
-
-	public static class TooManyAssetCategories
-		extends InfoFormValidationException {
-
-		public TooManyAssetCategories(
-			AssetCategoryException assetCategoryException,
-			AssetVocabulary assetVocabulary) {
-
-			_assetCategoryException = assetCategoryException;
-			_assetVocabulary = assetVocabulary;
-		}
-
-		public AssetCategoryException getAssetCategoryException() {
-			return _assetCategoryException;
-		}
-
-		public AssetVocabulary getAssetVocabulary() {
-			return _assetVocabulary;
-		}
-
-		@Override
-		public String getLocalizedMessage(Locale locale) {
-			return LanguageUtil.format(
-				locale, "you-cannot-select-more-than-one-category-for-x",
-				(_assetVocabulary != null) ?
-					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
-						StringPool.BLANK);
-		}
-
-		private final AssetCategoryException _assetCategoryException;
-		private final AssetVocabulary _assetVocabulary;
 
 	}
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -432,6 +432,39 @@ public class InfoFormValidationException extends InfoFormException {
 
 	}
 
+	public static class TooManyAssetCategories
+		extends InfoFormValidationException {
+
+		public TooManyAssetCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class UniqueValueConstraintViolation
 		extends InfoFormValidationException {
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.6.0
+version 6.7.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -55,7 +55,7 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 			else if (assetCategoryException.getType() ==
 						AssetCategoryException.TOO_MANY_CATEGORIES) {
 
-				throw new InfoFormValidationException.TooManyAssetCategories(
+				throw new InfoFormValidationException.AssetTooManyCategories(
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -52,6 +52,13 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}
+			else if (assetCategoryException.getType() ==
+						AssetCategoryException.TOO_MANY_CATEGORIES) {
+
+				throw new InfoFormValidationException.TooManyAssetCategories(
+					assetCategoryException,
+					assetCategoryException.getVocabulary());
+			}
 		}
 
 		if (exception instanceof ModelListenerException) {

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.info.item.handler;
 import com.liferay.asset.kernel.exception.AssetCategoryException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -28,6 +29,7 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	@TestInfo("LPD-96532")
 	public void testHandleInfoFormException() throws Exception {
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.handler;
+
+import com.liferay.asset.kernel.exception.AssetCategoryException;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jan Brychta
+ */
+public class ObjectEntryInfoItemExceptionRequestHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testHandleInfoFormException() throws Exception {
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.AT_LEAST_ONE_CATEGORY),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.RequiredAssetCategory
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.TOO_MANY_CATEGORIES),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.TooManyAssetCategories
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+}

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -72,7 +72,7 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 
 			Assert.fail();
 		}
-		catch (InfoFormValidationException.TooManyAssetCategories
+		catch (InfoFormValidationException.AssetTooManyCategories
 					infoFormValidationException) {
 
 			Assert.assertSame(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -198,7 +198,7 @@ export default function ContentEditorToolbar({
 
 		sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
 
-		if (getForm()?.querySelector('.form-group.has-error')) {
+		if (getForm()?.querySelector('.alert-danger, .form-group.has-error')) {
 			return;
 		}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1252,3 +1252,83 @@ test(
 		});
 	}
 );
+
+test(
+	'All section can be filtered by Category',
+	{tag: ['@LPD-85551', '@LPD-87956']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const categorizedTitle = getRandomString();
+		const categoryName = getRandomString();
+		const uncategorizedTitle = getRandomString();
+		const vocabularyName = getRandomString();
+
+		await test.step('Create a category and two contents, one categorized', async () => {
+			const site =
+				await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+					'cms'
+				);
+
+			const vocabulary =
+				await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary(
+					{
+						assetLibraries: [{id: -1}],
+						assetTypes: [
+							{
+								required: false,
+								subtype: 'AllAssetSubtypes',
+								type: 'AllAssetTypes',
+							},
+						],
+						name: vocabularyName,
+						siteId: site.id,
+						visibilityType: 'PUBLIC',
+					}
+				);
+
+			const category =
+				await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+					{
+						name: categoryName,
+						vocabularyId: vocabulary.id,
+					}
+				);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					taxonomyCategoryIds: [category.id],
+					title: categorizedTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: uncategorizedTitle,
+				},
+				applicationName,
+				'Default'
+			);
+		});
+
+		await test.step('Both contents are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(categorizedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(uncategorizedTitle)).toBeVisible();
+		});
+
+		await test.step('Filter by Category and check only the categorized content is visible', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Category',
+				value: `${categoryName} (${vocabularyName})`,
+			});
+
+			await expect(assetsPage.getItem(categorizedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(uncategorizedTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1492,3 +1492,63 @@ test(
 		});
 	}
 );
+
+test(
+	'All section can be filtered by Type',
+	{tag: ['@LPD-85551', '@LPD-87956', '@LPD-97359']},
+	async ({apiHelpers, assetsPage, page}) => {
+
+		// LPD-97359: the CMS Type filter (objectDefinitionExternalReferenceCode)
+		// returns "No Results Found" for a valid type, in both the Recycle Bin
+		// and the All section. Recorded as an expected failure until the fix
+		// lands, at which point this test turns green and test.fail() is removed.
+
+		test.fail();
+
+		const documentTitle = getRandomString();
+		const webContentTitle = getRandomString();
+
+		await test.step('Create one web content and one document', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: webContentTitle,
+				},
+				'cms/basic-web-contents',
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: _PNG_BASE64,
+						name: `${documentTitle}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: documentTitle,
+				},
+				'cms/basic-documents',
+				'Default'
+			);
+		});
+
+		await test.step('Both are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(webContentTitle)).toBeVisible();
+			await expect(assetsPage.getItem(documentTitle)).toBeVisible();
+		});
+
+		await test.step('Filtering by Type Basic Web Content shows only the web content', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Type',
+				value: 'Basic Web Content',
+			});
+
+			await expect(assetsPage.getItem(webContentTitle)).toBeVisible({
+				timeout: 5000,
+			});
+			await expect(assetsPage.getItem(documentTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1391,3 +1391,104 @@ test(
 		});
 	}
 );
+
+test(
+	'All section can be filtered by Author',
+	{tag: ['@LPD-85551', '@LPD-87956']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const authorATitle = getRandomString();
+		const authorBTitle = getRandomString();
+
+		let authorAFullName: string;
+
+		await test.step('Create a Space with two content authors', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: getRandomString(),
+					settings: {},
+					type: 'Space',
+				});
+
+			const authorA =
+				await apiHelpers.headlessAdminUser.postUserAccount();
+			authorAFullName = `${authorA.givenName} ${authorA.familyName}`;
+
+			userData[authorA.alternateName] = {
+				name: authorA.givenName,
+				password: 'test',
+				surname: authorA.familyName,
+			};
+
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+				space.externalReferenceCode,
+				authorA.externalReferenceCode
+			);
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+				space.externalReferenceCode,
+				authorA.externalReferenceCode,
+				['Asset Library Administrator']
+			);
+
+			const authorB =
+				await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[authorB.alternateName] = {
+				name: authorB.givenName,
+				password: 'test',
+				surname: authorB.familyName,
+			};
+
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+				space.externalReferenceCode,
+				authorB.externalReferenceCode
+			);
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+				space.externalReferenceCode,
+				authorB.externalReferenceCode,
+				['Asset Library Administrator']
+			);
+
+			await performUserSwitchViaApi(page, authorA.alternateName);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: authorATitle,
+				},
+				applicationName,
+				space.name
+			);
+
+			await performUserSwitchViaApi(page, authorB.alternateName);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: authorBTitle,
+				},
+				applicationName,
+				space.name
+			);
+
+			await performUserSwitchViaApi(page, authorA.alternateName);
+		});
+
+		await test.step('Both contents are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(authorATitle)).toBeVisible();
+			await expect(assetsPage.getItem(authorBTitle)).toBeVisible();
+		});
+
+		await test.step("Filter by Author and check only that author's content is visible", async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Author',
+				value: authorAFullName,
+			});
+
+			await expect(assetsPage.getItem(authorATitle)).toBeVisible();
+			await expect(assetsPage.getItem(authorBTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1332,3 +1332,62 @@ test(
 		});
 	}
 );
+
+test(
+	'All section can be filtered by Tags',
+	{tag: ['@LPD-85551', '@LPD-87956']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const taggedTitle = getRandomString();
+		const tagName = getRandomString();
+		const untaggedTitle = getRandomString();
+
+		await test.step('Create a tag and two contents, one tagged', async () => {
+			const site =
+				await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
+					'cms'
+				);
+
+			await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+				name: tagName,
+				siteId: site.id,
+			});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					keywords: [tagName],
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: taggedTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: untaggedTitle,
+				},
+				applicationName,
+				'Default'
+			);
+		});
+
+		await test.step('Both contents are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(taggedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(untaggedTitle)).toBeVisible();
+		});
+
+		await test.step('Filter by Tags and check only the tagged content is visible', async () => {
+			await applyFDSSelectionFilter(page, {
+				filter: 'Tags',
+				value: tagName,
+			});
+
+			await expect(assetsPage.getItem(taggedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(untaggedTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1552,3 +1552,38 @@ test(
 		});
 	}
 );
+
+test(
+	'All section renders content details in Cards view',
+	{tag: ['@LPD-85551', '@LPD-87956']},
+	async ({apiHelpers, assetsPage}) => {
+		const contentTitle = getRandomString();
+
+		await test.step('Create a content', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				'cms/basic-web-contents',
+				'Default'
+			);
+		});
+
+		await test.step('Switch to Cards view and check the card details', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.changeVisualizationMode('Cards');
+
+			const card = assetsPage.getCardItem(contentTitle);
+
+			await expect(card).toBeVisible();
+			await expect(
+				card.getByRole('link', {name: contentTitle})
+			).toBeVisible();
+			await expect(
+				card.getByText('Approved', {exact: true})
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -833,35 +833,17 @@ systemCategoryTest.describe('System category tests', () => {
 	);
 
 	systemCategoryTest(
-		'Add a subcategory to a system category',
-		{tag: '@LPD-96625'},
-		async ({categoriesPage, editCategoryPage, page}) => {
+		'Hide the add subcategory action for a system category',
+		{tag: '@LPD-97548'},
+		async ({categoriesPage}) => {
 			await categoriesPage.goto(systemVocabularyId, systemVocabularyName);
 
-			// Subcategories can still be added to a system category
+			// A subcategory cannot be added to a system category
 
-			await categoriesPage.execItemAction({
+			await categoriesPage.expectItemActionHidden({
 				action: 'Add Subcategory',
 				filter: systemCategoryName,
 			});
-
-			await expect(page.getByText('Basic Info')).toBeVisible();
-
-			const subcategoryName = getRandomString();
-
-			await editCategoryPage.fillName(subcategoryName);
-			await editCategoryPage.clickSave();
-
-			// The subcategory is created under the system category
-
-			await categoriesPage.gotoSubcategories(
-				systemCategoryId,
-				systemCategoryName,
-				systemVocabularyId,
-				systemVocabularyName
-			);
-
-			await expect(categoriesPage.getItem(subcategoryName)).toBeVisible();
 		}
 	);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -135,6 +135,8 @@ public class AssetCategoryLocalServiceImpl
 
 		validate(0, groupId, parentCategoryId, name, vocabularyId);
 
+		_checkSystemParentCategory(parentCategoryId);
+
 		AssetCategory parentCategory = null;
 
 		if (parentCategoryId > 0) {
@@ -936,6 +938,27 @@ public class AssetCategoryLocalServiceImpl
 		}
 	}
 
+	private void _checkSystemParentCategory(long parentCategoryId)
+		throws PortalException {
+
+		if (parentCategoryId <= 0) {
+			return;
+		}
+
+		AssetCategory parentCategory =
+			assetCategoryPersistence.findByPrimaryKey(parentCategoryId);
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				parentCategory.getCompanyId(), "LPD-86291") ||
+			!parentCategory.isSystem() ||
+			ExportImportThreadLocal.isImportInProcess()) {
+
+			return;
+		}
+
+		throw new SystemCategoryException.MustNotAddChild(parentCategoryId);
+	}
+
 	private boolean _equals(
 		Map<Locale, String> map1, Map<Locale, String> map2) {
 
@@ -964,6 +987,8 @@ public class AssetCategoryLocalServiceImpl
 	private AssetCategory _moveCategory(
 			AssetCategory category, long parentCategoryId, long vocabularyId)
 		throws PortalException {
+
+		_checkSystemParentCategory(parentCategoryId);
 
 		validate(
 			category.getCategoryId(), category.getGroupId(), parentCategoryId,

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
@@ -12,6 +12,20 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class SystemCategoryException extends PortalException {
 
+	public static class MustNotAddChild extends SystemCategoryException {
+
+		public MustNotAddChild(long categoryId) {
+			super(
+				String.format(
+					"Category %s cannot have child categories", categoryId));
+
+			this.categoryId = categoryId;
+		}
+
+		public long categoryId;
+
+	}
+
 	public static class MustNotDelete extends SystemCategoryException {
 
 		public MustNotDelete(long categoryId) {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
@@ -21,6 +21,7 @@ apply plugin: "org.springframework.boot"
 
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
@@ -10,6 +10,8 @@ package com.liferay.seo.studio.constants;
  */
 public class SEOStudioScanConstants {
 
+	public static final String STATE_COMPLETED = "completed";
+
 	public static final String STATE_FAILED = "failed";
 
 	public static final String STATE_RUNNING = "running";

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -1,0 +1,289 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.detector;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Noor Najjar
+ */
+public abstract class BaseDetector {
+
+	public abstract void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI crawlURI,
+			long seoStudioScanId)
+		throws Exception;
+
+	protected void postInsights(
+			long accountEntryId, JSONObject definitionJSONObject,
+			List<String> pageURLs, Map<String, Long> pageURLToPageIdMap,
+			long seoStudioScanId)
+		throws Exception {
+
+		if (ListUtil.isEmpty(pageURLs)) {
+			return;
+		}
+
+		long seoStudioInsightTypeId = _postInsightType(
+			accountEntryId, definitionJSONObject, seoStudioScanId);
+
+		_postScanInsights(
+			accountEntryId, definitionJSONObject.getString("classification"),
+			pageURLs, pageURLToPageIdMap, seoStudioInsightTypeId,
+			seoStudioScanId);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Posted ", pageURLs.size(), " ",
+					definitionJSONObject.getString("name"),
+					" scan insights for insight type ",
+					seoStudioInsightTypeId));
+		}
+	}
+
+	protected Map<String, Long> resolvePageIds(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		Map<String, Long> pageURLToPageIdMap = _getPages(seoStudioScanId);
+
+		List<String> missingPageURLs = ListUtil.filter(
+			pageURLs, pageURL -> !pageURLToPageIdMap.containsKey(pageURL));
+
+		if (ListUtil.isEmpty(missingPageURLs)) {
+			return pageURLToPageIdMap;
+		}
+
+		_postPages(accountEntryId, missingPageURLs, seoStudioScanId);
+
+		long deadline = System.currentTimeMillis() + 60000;
+
+		while (true) {
+			Set<String> readPageURLs = pageURLToPageIdMap.keySet();
+
+			if (readPageURLs.containsAll(pageURLs)) {
+				break;
+			}
+
+			if (System.currentTimeMillis() > deadline) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Timed out waiting for pages to be readable for scan " +
+							seoStudioScanId);
+				}
+
+				break;
+			}
+
+			Thread.sleep(1000);
+
+			pageURLToPageIdMap.putAll(_getPages(seoStudioScanId));
+		}
+
+		return pageURLToPageIdMap;
+	}
+
+	@Autowired
+	protected SEOStudioService seoStudioService;
+
+	private Map<String, Long> _getPages(long seoStudioScanId) {
+		Map<String, Long> pageURLToPageIdMap = new HashMap<>();
+
+		int page = 1;
+
+		while (true) {
+			JSONArray itemsJSONArray = new JSONObject(
+				seoStudioService.getPage(page, 2000, seoStudioScanId)
+			).optJSONArray(
+				"items"
+			);
+
+			if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+				break;
+			}
+
+			for (Object object : itemsJSONArray) {
+				JSONObject itemJSONObject = (JSONObject)object;
+
+				pageURLToPageIdMap.put(
+					itemJSONObject.getString("pageURL"),
+					itemJSONObject.getLong("id"));
+			}
+
+			page++;
+		}
+
+		return pageURLToPageIdMap;
+	}
+
+	private long _postInsightType(
+		long accountEntryId, JSONObject definitionJSONObject,
+		long seoStudioScanId) {
+
+		JSONObject insightTypeJSONObject = new JSONObject();
+
+		insightTypeJSONObject.put(
+			"category", definitionJSONObject.getString("category")
+		).put(
+			"description", definitionJSONObject.optString("description")
+		).put(
+			"externalReferenceCode",
+			definitionJSONObject.getString("name") + "_" + seoStudioScanId
+		).put(
+			"fixHint", definitionJSONObject.optString("fixHint")
+		).put(
+			"name", definitionJSONObject.getString("name")
+		).put(
+			"r_accountToSEOStudioInsightTypes_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"severity", definitionJSONObject.getString("severity")
+		);
+
+		return new JSONObject(
+			seoStudioService.postInsightType(insightTypeJSONObject)
+		).getLong(
+			"id"
+		);
+	}
+
+	private void _postPages(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray pagesJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				pagesJSONArray.put(
+					_toPageJSONObject(
+						accountEntryId, pageURL, seoStudioScanId));
+			}
+
+			seoStudioService.postPagesBatch(pagesJSONArray);
+		}
+	}
+
+	private void _postScanInsights(
+			long accountEntryId, String classification, List<String> pageURLs,
+			Map<String, Long> pageURLToPageIdMap, long seoStudioInsightTypeId,
+			long seoStudioScanId)
+		throws Exception {
+
+		String detectedDateString = Instant.now(
+		).truncatedTo(
+			ChronoUnit.SECONDS
+		).toString();
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray scanInsightsJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				Long seoStudioPageId = pageURLToPageIdMap.get(pageURL);
+
+				if (seoStudioPageId == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to find a page for URL " + pageURL +
+								"; skipping scan insight");
+					}
+
+					continue;
+				}
+
+				scanInsightsJSONArray.put(
+					_toScanInsightJSONObject(
+						accountEntryId, classification, detectedDateString,
+						seoStudioInsightTypeId, seoStudioPageId,
+						seoStudioScanId));
+			}
+
+			if (scanInsightsJSONArray.isEmpty()) {
+				continue;
+			}
+
+			seoStudioService.postScanInsightsBatch(scanInsightsJSONArray);
+		}
+	}
+
+	private JSONObject _toPageJSONObject(
+		long accountEntryId, String pageURL, long seoStudioScanId) {
+
+		JSONObject pageJSONObject = new JSONObject();
+
+		pageJSONObject.put(
+			"pageURL", pageURL
+		).put(
+			"r_accountToSEOStudioPages_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId", seoStudioScanId
+		);
+
+		return pageJSONObject;
+	}
+
+	private JSONObject _toScanInsightJSONObject(
+		long accountEntryId, String classification, String detectedDateString,
+		long seoStudioInsightTypeId, long seoStudioPageId,
+		long seoStudioScanId) {
+
+		JSONObject scanInsightJSONObject = new JSONObject();
+
+		scanInsightJSONObject.put(
+			"classification", classification
+		).put(
+			"detectedDate", detectedDateString
+		).put(
+			"r_accountToSEOStudioScanInsights_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioInsightTypeToScanInsights_seoStudioInsightTypeId",
+			seoStudioInsightTypeId
+		).put(
+			"r_seoStudioPageToSEOStudioScanInsights_seoStudioPageId",
+			seoStudioPageId
+		).put(
+			"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+			seoStudioScanId
+		);
+
+		return scanInsightJSONObject;
+	}
+
+	private static final int _BATCH_SIZE = 100;
+
+	private static final Log _log = LogFactory.getLog(BaseDetector.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.detector;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import java.net.URI;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class OrphanPagesDetector extends BaseDetector {
+
+	@Override
+	public void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI crawlURI,
+			long seoStudioScanId)
+		throws Exception {
+
+		Set<String> canonicalURLs = new LinkedHashSet<>();
+		Set<String> linkedURLs = new HashSet<>();
+
+		for (CrawlHit crawlHit : crawlHits) {
+			String canonicalURL = crawlHit.getCanonicalURL();
+
+			if (Validator.isNull(canonicalURL)) {
+				continue;
+			}
+
+			canonicalURLs.add(canonicalURL);
+
+			for (String linkedURL : crawlHit.getLinks()) {
+				if (Validator.isNotNull(linkedURL) &&
+					!linkedURL.equals(canonicalURL)) {
+
+					linkedURLs.add(linkedURL);
+				}
+			}
+		}
+
+		String domainURL = seoStudioService.toDomainURL(crawlURI);
+
+		List<String> orphanPageURLs = TransformUtil.transform(
+			canonicalURLs,
+			canonicalURL -> {
+				if (canonicalURL.equals(domainURL) ||
+					linkedURLs.contains(canonicalURL)) {
+
+					return null;
+				}
+
+				return canonicalURL;
+			});
+
+		if (ListUtil.isEmpty(orphanPageURLs)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"No orphan pages were detected for scan " +
+						seoStudioScanId);
+			}
+
+			return;
+		}
+
+		JSONObject definitionJSONObject = new JSONObject();
+
+		definitionJSONObject.put(
+			"category", "linksAndURLs"
+		).put(
+			"classification", "problem"
+		).put(
+			"description",
+			StringBundler.concat(
+				"This page is published and indexable but has zero internal ",
+				"links pointing to it. Orphan pages are nearly invisible to ",
+				"both users browsing the site and crawlers building the link ",
+				"graph. Even when they are listed in a sitemap, they collect ",
+				"very little ranking authority.")
+		).put(
+			"fixHint",
+			StringBundler.concat(
+				"Identify 2-5 topically related pages and add contextual ",
+				"internal links pointing to the orphan, with descriptive ",
+				"anchor text. If no relevant linking context exists anywhere ",
+				"on the site, that is a signal the page may not belong in the ",
+				"public site at all.")
+		).put(
+			"name", "orphanPages"
+		).put(
+			"severity", "2"
+		);
+
+		postInsights(
+			accountEntryId, definitionJSONObject, orphanPageURLs,
+			resolvePageIds(accountEntryId, orphanPageURLs, seoStudioScanId),
+			seoStudioScanId);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrphanPagesDetector.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class CrawlerJobStatusService {
+
+	@Scheduled(fixedDelay = 60000)
+	public void updateStatuses() {
+		JSONArray itemsJSONArray = new JSONObject(
+			_seoStudioService.getActiveScans()
+		).optJSONArray(
+			"items"
+		);
+
+		if (itemsJSONArray == null) {
+			return;
+		}
+
+		for (Object object : itemsJSONArray) {
+			JSONObject scanJSONObject = (JSONObject)object;
+
+			long seoStudioScanId = scanJSONObject.getLong("id");
+
+			try {
+				String executionId = scanJSONObject.optString("executionId");
+
+				if (Validator.isNull(executionId)) {
+					continue;
+				}
+
+				Job job = _kubernetesJobService.getJob(executionId);
+
+				String state = _getScanState(job);
+
+				if (Validator.isNull(state) ||
+					state.equals(scanJSONObject.optString("state"))) {
+
+					continue;
+				}
+
+				if (state.equals(SEOStudioScanConstants.STATE_COMPLETED)) {
+					DetectorResult detectorResult = _detectorService.detect(
+						scanJSONObject, seoStudioScanId);
+
+					_seoStudioService.patchScan(
+						detectorResult.getErrorMessage(), seoStudioScanId,
+						detectorResult.getState());
+				}
+				else if (state.equals(SEOStudioScanConstants.STATE_FAILED)) {
+					_seoStudioService.patchScan(
+						_getErrorMessage(job), seoStudioScanId,
+						SEOStudioScanConstants.STATE_FAILED);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to update status of scan " + seoStudioScanId,
+					exception);
+			}
+		}
+	}
+
+	private String _getErrorMessage(Job job) {
+		if (job == null) {
+			return "Kubernetes job does not exist";
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		List<JobCondition> jobConditions = jobStatus.getConditions();
+
+		if (ListUtil.isEmpty(jobConditions)) {
+			return "Kubernetes job failed";
+		}
+
+		for (JobCondition jobCondition : jobConditions) {
+			if (!Objects.equals(jobCondition.getType(), "Failed") ||
+				!Objects.equals(jobCondition.getStatus(), "True")) {
+
+				continue;
+			}
+
+			String errorMessage = jobCondition.getMessage();
+
+			if (Validator.isNotNull(errorMessage)) {
+				return errorMessage;
+			}
+		}
+
+		return "Kubernetes job failed";
+	}
+
+	private String _getScanState(Job job) {
+		if (job == null) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		if (jobStatus == null) {
+			return null;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getActive()) > 0) {
+			return SEOStudioScanConstants.STATE_RUNNING;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getFailed()) > 0) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getSucceeded()) > 0) {
+			return SEOStudioScanConstants.STATE_COMPLETED;
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerJobStatusService.class);
+
+	@Autowired
+	private DetectorService _detectorService;
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorResult.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+/**
+ * @author Brooke Dalton
+ */
+public class DetectorResult {
+
+	public DetectorResult(String errorMessage, String state) {
+		_errorMessage = errorMessage;
+		_state = state;
+	}
+
+	public String getErrorMessage() {
+		return _errorMessage;
+	}
+
+	public String getState() {
+		return _state;
+	}
+
+	private final String _errorMessage;
+	private final String _state;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.detector.BaseDetector;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import java.net.URI;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class DetectorService {
+
+	public DetectorResult detect(
+			JSONObject scanJSONObject, long seoStudioScanId)
+		throws Exception {
+
+		long seoStudioDomainId = scanJSONObject.getLong(
+			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+		String domainJSON = _seoStudioService.getDomain(seoStudioDomainId);
+
+		if (Validator.isNull(domainJSON)) {
+			return new DetectorResult(
+				"Unable to find a domain for SEO Studio domain ID " +
+					seoStudioDomainId,
+				SEOStudioScanConstants.STATE_FAILED);
+		}
+
+		List<CrawlHit> crawlHits = _seoStudioService.getCrawlHits(
+			seoStudioDomainId);
+
+		if (ListUtil.isEmpty(crawlHits)) {
+			return new DetectorResult(
+				"Unable to find crawl hits for SEO Studio domain ID " +
+					seoStudioDomainId,
+				SEOStudioScanConstants.STATE_FAILED);
+		}
+
+		long accountEntryId = scanJSONObject.getLong(
+			"r_accountToSEOStudioScans_accountEntryId");
+
+		URI crawlURI = _seoStudioService.toCrawlURI(
+			new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			));
+
+		for (BaseDetector detector : _detectors) {
+			detector.detect(
+				accountEntryId, crawlHits, crawlURI, seoStudioScanId);
+		}
+
+		return new DetectorResult(null, SEOStudioScanConstants.STATE_COMPLETED);
+	}
+
+	@Autowired
+	private List<BaseDetector> _detectors;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213

## What Is Being Fixed

The SEO Studio crawler could run a scan, but nothing consumed the result. There was no detection of orphan pages — canonical URLs that no other page links to — and the scan record's status was never reconciled with the Kubernetes job running the crawl, so a scan never reflected that it had completed or failed.

## How It Is Being Fixed

A scheduled poller, CrawlerJobStatusService, reads each active scan's Kubernetes job, maps its status to a scan state, and patches the scan accordingly. When a scan completes, detection runs through a new DetectorService, which collects every BaseDetector bean and invokes each one rather than hardcoding a single detector in the poller. The first detector, OrphanPagesDetector, compares the canonical URLs found during the crawl against the set of URLs linked from any page and reports those linked from nowhere, other than the domain root, as orphan-page scan insights. Shared work — resolving or creating page records and posting insight types and scan insights in batches — lives in the BaseDetector base class.

## PR Check

**pr-check: PASS** — tested on `647546b867ab636a2ee5b59bb29c8469f101228b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "647546b867ab636a2ee5b59bb29c8469f101228b"} -->
