### PR TITLE
LPD-86008 Using back button sends users to /web url

### DIFF
--- a/modules/apps/portal/portal-i18n-filter/src/main/java/com/liferay/portal/i18n/filter/internal/I18nFilter.java
+++ b/modules/apps/portal/portal-i18n-filter/src/main/java/com/liferay/portal/i18n/filter/internal/I18nFilter.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -135,6 +136,13 @@ public class I18nFilter extends BasePortalFilter {
 		String contextPath = _portal.getPathContext();
 
 		String requestURI = httpServletRequest.getRequestURI();
+
+		if (!PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
+			HttpComponentsUtil.isForwarded(httpServletRequest)) {
+
+			requestURI = (String)httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI);
+		}
 
 		if (Validator.isNotNull(contextPath) &&
 			requestURI.startsWith(contextPath)) {

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.PrefsPropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -142,6 +143,12 @@ public class I18nFilterTest {
 			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
 			_getPrependI18nLanguageId(
 				3, LocaleUtil.US, LocaleUtil.SPAIN, null, null, null));
+	}
+
+	@Test
+	public void testGetRedirectPublicServletMapping() throws Exception {
+		_testGetRedirectPublicServletMapping(false);
+		_testGetRedirectPublicServletMapping(true);
 	}
 
 	@Test
@@ -419,6 +426,60 @@ public class I18nFilterTest {
 		Assert.assertEquals(
 			i18nLanguageId,
 			mockHttpServletRequest.getAttribute(WebKeys.I18N_LANGUAGE_ID));
+	}
+
+	private void _testGetRedirectPublicServletMapping(
+			boolean layoutFriendlyURLPublicServletMappingEnabled)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.addHeader("Host", "localhost");
+		mockHttpServletRequest.setServerName("localhost");
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI,
+			_group.getFriendlyURL());
+		mockHttpServletRequest.setRequestURI(
+			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+				_group.getFriendlyURL());
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		httpSession.setAttribute(WebKeys.LOCALE, LocaleUtil.SPAIN);
+
+		String i18nPath =
+			"/" + _portal.getI18nPathLanguageId(LocaleUtil.SPAIN, null);
+
+		String expectedRedirect = i18nPath + _group.getFriendlyURL();
+
+		if (layoutFriendlyURLPublicServletMappingEnabled) {
+			expectedRedirect =
+				i18nPath +
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+						_group.getFriendlyURL();
+		}
+
+		long companyId = PortalInstances.getCompanyId(mockHttpServletRequest);
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class,
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					layoutFriendlyURLPublicServletMappingEnabled);
+			SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					companyId, PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+					1)) {
+
+			Assert.assertEquals(
+				expectedRedirect,
+				ReflectionTestUtil.invoke(
+					_i18nFilter, "getRedirect",
+					new Class<?>[] {long.class, HttpServletRequest.class},
+					companyId, mockHttpServletRequest));
+		}
 	}
 
 	private void _testGetRequestedLanguageIdWithImpersonation()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86008

**What is being fixed:** When layout.friendly.url.public.servlet.mapping.enabled is false, VirtualHostFilter forwards public friendly URLs through the internal /web path so they reach the friendly URL servlet. I18nFilter built the locale redirect from that forwarded request URI, so the internal /web leaked into the external redirect for sites other than the virtual host's own group. After viewing a localized variant, the locale cookie made a plain page request redirect to /es/web/..., which the browser's back button surfaced as a /web URL that stuck.

**How it is being fixed:** In the mapping-disabled case, I18nFilter now builds the redirect from the original jakarta.servlet.forward.request_uri the browser requested — which never contains /web — instead of the forwarded request URI. The change is scoped to the mapping-disabled configuration so the default configuration is unaffected. An integration test covers the redirect with the public servlet mapping both on and off.