### PR TITLE
LPD-98328 Allow suppressing the ControlMenu portlet header

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-api/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Product Navigation Control Menu API
 Bundle-SymbolicName: com.liferay.product.navigation.control.menu.api
-Bundle-Version: 13.1.5
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.product.navigation.control.menu,\
 	com.liferay.product.navigation.control.menu.constants,\

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/constants/ProductNavigationControlMenuWebKeys.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/constants/ProductNavigationControlMenuWebKeys.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.product.navigation.control.menu.web.internal.constants;
+package com.liferay.product.navigation.control.menu.constants;
 
 /**
  * @author Julio Camarero

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/resources/com/liferay/product/navigation/control/menu/constants/packageinfo
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/resources/com/liferay/product/navigation/control/menu/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/product-navigation/product-navigation-control-menu-test/src/testIntegration/java/com/liferay/product/navigation/control/menu/web/internal/test/PortletHeaderProductNavigationControlMenuEntryTest.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-test/src/testIntegration/java/com/liferay/product/navigation/control/menu/web/internal/test/PortletHeaderProductNavigationControlMenuEntryTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.product.navigation.control.menu.web.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.impl.LayoutImpl;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuWebKeys;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class PortletHeaderProductNavigationControlMenuEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-98328")
+	public void testIsShow() throws Exception {
+		Layout layout = new LayoutImpl();
+
+		layout.setType(LayoutConstants.TYPE_CONTENT);
+
+		Assert.assertFalse(
+			_productNavigationControlMenuEntry.isShow(
+				_getMockHttpServletRequest(layout, null)));
+
+		PortletDisplay portletDisplay = new PortletDisplay();
+
+		Assert.assertFalse(
+			_productNavigationControlMenuEntry.isShow(
+				_getMockHttpServletRequest(layout, portletDisplay)));
+
+		layout.setType(LayoutConstants.TYPE_CONTROL_PANEL);
+
+		Assert.assertFalse(
+			_productNavigationControlMenuEntry.isShow(
+				_getMockHttpServletRequest(layout, null)));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(layout, portletDisplay);
+
+		Assert.assertTrue(
+			_productNavigationControlMenuEntry.isShow(mockHttpServletRequest));
+
+		mockHttpServletRequest.setAttribute(
+			ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER,
+			Boolean.TRUE);
+
+		Assert.assertFalse(
+			_productNavigationControlMenuEntry.isShow(mockHttpServletRequest));
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(
+		Layout layout, PortletDisplay portletDisplay) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay() {
+
+			@Override
+			public PortletDisplay getPortletDisplay() {
+				return portletDisplay;
+			}
+
+		};
+
+		themeDisplay.setLayout(layout);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockHttpServletRequest;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.product.navigation.control.menu.web.internal.PortletHeaderProductNavigationControlMenuEntry"
+	)
+	private ProductNavigationControlMenuEntry
+		_productNavigationControlMenuEntry;
+
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/PortletHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/PortletHeaderProductNavigationControlMenuEntry.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.control.menu.BaseJSPProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
@@ -65,6 +66,13 @@ public class PortletHeaderProductNavigationControlMenuEntry
 	@Override
 	public boolean isShow(HttpServletRequest httpServletRequest)
 		throws PortalException {
+
+		if (GetterUtil.getBoolean(
+				httpServletRequest.getAttribute(
+					ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER))) {
+
+			return false;
+		}
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/PortletHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/PortletHeaderProductNavigationControlMenuEntry.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.control.menu.BaseJSPProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
-import com.liferay.product.navigation.control.menu.web.internal.constants.ProductNavigationControlMenuWebKeys;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuWebKeys;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/constants/ProductNavigationControlMenuWebKeys.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/constants/ProductNavigationControlMenuWebKeys.java
@@ -10,6 +10,8 @@ package com.liferay.product.navigation.control.menu.web.internal.constants;
  */
 public class ProductNavigationControlMenuWebKeys {
 
+	public static final String HIDE_PORTLET_HEADER = "HIDE_PORTLET_HEADER";
+
 	public static final String PORTLET_TITLE = "PORTLET_TITLE";
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -39,7 +39,7 @@ page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
 page import="com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuPortletKeys" %><%@
-page import="com.liferay.product.navigation.control.menu.web.internal.constants.ProductNavigationControlMenuWebKeys" %><%@
+page import="com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuWebKeys" %><%@
 page import="com.liferay.product.navigation.control.menu.web.internal.display.context.AddContentPanelDisplayContext" %>
 
 <%@ page import="jakarta.portlet.PortletRequest" %>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98328

## What Is Being Fixed

In Design Library, the Fragment portlet is served under `type=control_panel`. `PortletHeaderProductNavigationControlMenuEntry` in `product-navigation-control-menu-web` renders an `<h1 data-qa-id="headerTitle">` whenever `layout.isTypeControlPanel()` is `true`. A separate ControlMenu contributor needs to render its own breadcrumb using the same `data-qa-id="headerTitle"` on the last crumb node, replacing the native title. A CSS-only workaround leaves the `<h1>` in the DOM, duplicates the `data-qa-id`, and breaks QA asserts.

## How It Is Being Fixed

This PR introduces a generic contract to suppress the native ControlMenu portlet header without leaving DOM residue. The constant `ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER` is added, and `PortletHeaderProductNavigationControlMenuEntry.isShow(HttpServletRequest)` short-circuits to `false` when the request attribute is set to `Boolean.TRUE`. Naming is intentionally generic (no mention of Design Library or Fragment) so other portlets can reuse the same mechanism. The first real consumer (`fragment-web`) will arrive in LPD-97637.

## PR Check

**pr-check: PASS** — tested on `ecfe22c6bcc2104584f635d8d21ea5e4d5bc5295`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ecfe22c6bcc2104584f635d8d21ea5e4d5bc5295"} -->
