### PR TITLE
LPD-98532 Prevent Publications page from failing when the search index is out of sync

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -138,7 +139,7 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			com.liferay.change.tracking.model.CTCollection.class.getName(),
 			search, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
+				Field.ENTRY_CLASS_PK, Field.UID),
 			searchContext -> {
 				searchContext.setAttribute("statuses", statuses);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
@@ -148,8 +149,23 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 				}
 			},
 			sorts,
-			document -> _toCTCollection(
-				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
+			document -> {
+				long ctCollectionId = GetterUtil.getLong(
+					document.get(Field.ENTRY_CLASS_PK));
+
+				com.liferay.change.tracking.model.CTCollection ctCollection =
+					_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+
+				if (ctCollection == null) {
+					_indexer.delete(
+						contextCompany.getCompanyId(), document.get(Field.UID));
+
+					return null;
+				}
+
+				return _ctCollectionDTOConverter.toDTO(
+					_getDTOConverterContext(ctCollection), ctCollection);
+			});
 	}
 
 	@Override
@@ -481,6 +497,11 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 
 	@Reference
 	private CTPreferencesService _ctPreferencesService;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.change.tracking.model.CTCollection)"
+	)
+	private Indexer<?> _indexer;
 
 	@Reference
 	private PublishScheduler _publishScheduler;

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTCollectionResourceTest.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTCollectionResourceTest.java
@@ -15,6 +15,7 @@ import com.liferay.change.tracking.rest.client.pagination.Page;
 import com.liferay.change.tracking.rest.client.pagination.Pagination;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
+import com.liferay.change.tracking.service.persistence.CTCollectionPersistence;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.lang.SafeCloseable;
@@ -22,12 +23,17 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -160,6 +166,43 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 		assertEquals(
 			(List<CTCollection>)descPage.getItems(),
 			(List<CTCollection>)page.getItems());
+	}
+
+	@Test
+	public void testGetCTCollectionsPageWithStaleIndexDocument()
+		throws Throwable {
+
+		CTCollection ctCollection1 = _postCTCollection(randomCTCollection());
+		CTCollection ctCollection2 = _postCTCollection(randomCTCollection());
+
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection1 =
+				_ctCollectionLocalService.getCTCollection(
+					ctCollection1.getId());
+
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+		TransactionInvokerUtil.invoke(
+			transactionConfig,
+			() -> _ctCollectionPersistence.remove(serviceBuilderCTCollection1));
+
+		_resourceLocalService.deleteResource(
+			serviceBuilderCTCollection1.getCompanyId(),
+			com.liferay.change.tracking.model.CTCollection.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			serviceBuilderCTCollection1.getCtCollectionId());
+
+		Page<CTCollection> page = ctCollectionResource.getCTCollectionsPage(
+			null, null, null, Pagination.of(1, 10), null);
+
+		List<CTCollection> ctCollections = (List<CTCollection>)page.getItems();
+
+		assertContains(ctCollection2, ctCollections);
+
+		for (CTCollection ctCollection : ctCollections) {
+			Assert.assertNotEquals(ctCollection1.getId(), ctCollection.getId());
+		}
 	}
 
 	@Override
@@ -519,6 +562,9 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Inject
+	private CTCollectionPersistence _ctCollectionPersistence;
+
+	@Inject
 	private CTPreferencesLocalService _ctPreferencesLocalService;
 
 	@Inject
@@ -526,5 +572,8 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourceLocalService _resourceLocalService;
 
 }


### PR DESCRIPTION
## Summary
- `CTCollectionResourceImpl#getCTCollectionsPage` threw when the search index held a stale document for a `CTCollection` that had since been deleted from the DB, failing the whole Publications page request instead of returning the collections that still exist.
- Applies the same self-healing pattern already used by `CTEntryResourceImpl#getCtCollectionCTEntriesPage`: fetch instead of get, and if the DB row is missing, delete the stale document from the index and drop that hit from the page instead of failing the request.

## Test plan
- Added `CTCollectionResourceTest#testGetCTCollectionsPageWithStaleIndexDocument`, which indexes a `CTCollection`, removes the underlying row directly via persistence (bypassing the indexed delete path) to simulate index/DB drift, then asserts `getCTCollectionsPage` returns the remaining collections without throwing.
- Ran the full `CTCollectionResourceTest` class — all tests pass.