### PR TITLE
LPD-97981 Add API to detect in-progress sitemap regeneration

### DIFF
--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -79,6 +79,8 @@ public interface SitemapManager {
 			boolean privateLayout, ThemeDisplay themeDisplay)
 		throws PortalException;
 
+	public boolean isRegenerateSitemapInProgress(long companyId);
+
 	public void regenerateSitemap(
 			String assetTypeKey, long companyId, long groupId)
 		throws PortalException;

--- a/modules/apps/site/site-impl/build.gradle
+++ b/modules/apps/site/site-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:portal-lock:portal-lock-api")
 	compileOnly project(":apps:redirect:redirect-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -17,6 +17,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.lock.DuplicateLockException;
+import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
@@ -26,6 +29,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
@@ -68,6 +72,7 @@ import com.liferay.portal.kernel.xml.Attribute;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.lock.service.LockLocalService;
 import com.liferay.portal.theme.ThemeDisplayFactory;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
 import com.liferay.redirect.provider.RedirectProvider;
@@ -423,6 +428,21 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	@Override
+	public boolean isRegenerateSitemapInProgress(long companyId) {
+		List<com.liferay.portal.lock.model.Lock> locks =
+			_lockLocalService.getLocks(
+				companyId, SitemapManagerImpl.class.getName());
+
+		for (com.liferay.portal.lock.model.Lock lock : locks) {
+			if (!lock.isExpired()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
 	public void regenerateSitemap(
 			String assetTypeKey, long companyId, long groupId)
 		throws PortalException {
@@ -448,12 +468,23 @@ public class SitemapManagerImpl implements SitemapManager {
 			return;
 		}
 
-		ThemeDisplay themeDisplay = _createThemeDisplay(companyId, groupId);
+		Lock lock = _lockRegenerateSitemap(assetTypeKey, companyId, groupId);
 
-		_regenerateAssetTypeSitemap(
-			assetTypeClassNameId, groupId, false, themeDisplay);
+		if ((lock == null) || !lock.isNew()) {
+			return;
+		}
 
-		_getIndexSitemap(groupId, false, themeDisplay);
+		try {
+			ThemeDisplay themeDisplay = _createThemeDisplay(companyId, groupId);
+
+			_regenerateAssetTypeSitemap(
+				assetTypeClassNameId, groupId, false, themeDisplay);
+
+			_getIndexSitemap(groupId, false, themeDisplay);
+		}
+		finally {
+			_unlockRegenerateSitemap(assetTypeKey, companyId, groupId);
+		}
 	}
 
 	@Override
@@ -467,6 +498,12 @@ public class SitemapManagerImpl implements SitemapManager {
 					companyId)) {
 
 				return;
+			}
+
+			boolean force = false;
+
+			if (startDate != null) {
+				force = true;
 			}
 
 			if (startDate == null) {
@@ -483,11 +520,11 @@ public class SitemapManagerImpl implements SitemapManager {
 
 			if ((group == null) || group.isCompany()) {
 				_scheduleCompanyRegenerateSitemap(
-					assetTypeKey, companyId, startDate);
+					assetTypeKey, companyId, force, startDate);
 			}
 			else {
 				_scheduleGroupRegenerateSitemap(
-					assetTypeKey, companyId, groupId, startDate);
+					assetTypeKey, companyId, force, groupId, startDate);
 			}
 		}
 		catch (PortalException portalException) {
@@ -1231,6 +1268,28 @@ public class SitemapManagerImpl implements SitemapManager {
 		return false;
 	}
 
+	private Lock _lockRegenerateSitemap(
+			String assetTypeKey, long companyId, long groupId)
+		throws PortalException {
+
+		try {
+			User guestUser = _userLocalService.getGuestUser(companyId);
+
+			return _lockManager.lock(
+				guestUser.getUserId(), SitemapManagerImpl.class.getName(),
+				_getSchedulerJobName(assetTypeKey, companyId, groupId),
+				SitemapManagerImpl.class.getName(), false, Time.MINUTE * 20,
+				false);
+		}
+		catch (DuplicateLockException duplicateLockException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(duplicateLockException);
+			}
+
+			return null;
+		}
+	}
+
 	private void _regenerateAssetTypeSitemap(
 			long assetTypeClassNameId, long groupId, boolean privateLayout,
 			ThemeDisplay themeDisplay)
@@ -1328,7 +1387,7 @@ public class SitemapManagerImpl implements SitemapManager {
 	}
 
 	private void _scheduleCompanyRegenerateSitemap(
-			String assetTypeKey, long companyId, Date startDate)
+			String assetTypeKey, long companyId, boolean force, Date startDate)
 		throws PortalException {
 
 		for (Group group :
@@ -1336,12 +1395,13 @@ public class SitemapManagerImpl implements SitemapManager {
 					companyId, GroupConstants.ANY_PARENT_GROUP_ID, true)) {
 
 			_scheduleGroupRegenerateSitemap(
-				assetTypeKey, companyId, group.getGroupId(), startDate);
+				assetTypeKey, companyId, force, group.getGroupId(), startDate);
 		}
 	}
 
 	private void _scheduleGroupRegenerateSitemap(
-			String assetTypeKey, long companyId, long groupId, Date startDate)
+			String assetTypeKey, long companyId, boolean force, long groupId,
+			Date startDate)
 		throws PortalException {
 
 		SitemapURLProvider sitemapURLProvider = _serviceTrackerMap.getService(
@@ -1362,7 +1422,13 @@ public class SitemapManagerImpl implements SitemapManager {
 				StorageType.PERSISTED);
 
 		if (schedulerResponse != null) {
-			return;
+			if (!force) {
+				return;
+			}
+
+			_schedulerEngineHelper.delete(
+				schedulerJobName, SitemapDestinationNames.SITEMAP_REGENERATION,
+				StorageType.PERSISTED);
 		}
 
 		Message message = new Message();
@@ -1380,6 +1446,14 @@ public class SitemapManagerImpl implements SitemapManager {
 				"Sitemap regeneration for group ", groupId, " and asset type ",
 				assetTypeKey),
 			SitemapDestinationNames.SITEMAP_REGENERATION, message);
+	}
+
+	private void _unlockRegenerateSitemap(
+		String assetTypeKey, long companyId, long groupId) {
+
+		_lockManager.unlock(
+			SitemapManagerImpl.class.getName(),
+			_getSchedulerJobName(assetTypeKey, companyId, groupId));
 	}
 
 	private void _visitLayoutSet(
@@ -1524,6 +1598,12 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference
+	private LockLocalService _lockLocalService;
+
+	@Reference
+	private LockManager _lockManager;
 
 	private int _maximumEntries;
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapRegenerationSchedulerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapRegenerationSchedulerTest.java
@@ -26,6 +26,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -116,6 +117,31 @@ public class SitemapRegenerationSchedulerTest {
 
 		_sitemapStorageHelper.deleteSitemaps(
 			TestPropsValues.getCompanyId(), _group.getGroupId());
+	}
+
+	@Test
+	public void testIsRegenerateSitemapInProgress() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		Assert.assertFalse(
+			_sitemapManager.isRegenerateSitemapInProgress(companyId));
+
+		String key = RandomTestUtil.randomString();
+
+		_lockManager.lock(
+			TestPropsValues.getUserId(), _CLASS_NAME_SITEMAP_MANAGER_IMPL, key,
+			_CLASS_NAME_SITEMAP_MANAGER_IMPL, false, Time.MINUTE, false);
+
+		try {
+			Assert.assertTrue(
+				_sitemapManager.isRegenerateSitemapInProgress(companyId));
+		}
+		finally {
+			_lockManager.unlock(_CLASS_NAME_SITEMAP_MANAGER_IMPL, key);
+		}
+
+		Assert.assertFalse(
+			_sitemapManager.isRegenerateSitemapInProgress(companyId));
 	}
 
 	@Test
@@ -663,6 +689,9 @@ public class SitemapRegenerationSchedulerTest {
 		return _schedulerEngineHelper.getStartTime(schedulerResponses.get(0));
 	}
 
+	private static final String _CLASS_NAME_SITEMAP_MANAGER_IMPL =
+		"com.liferay.site.internal.manager.SitemapManagerImpl";
+
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
@@ -683,6 +712,9 @@ public class SitemapRegenerationSchedulerTest {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private LockManager _lockManager;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97981

## What Is Being Fixed

The sitemap admin UI had no way to tell whether a sitemap regeneration was currently running, so it could not show a loading indicator while a job was in progress. Regeneration also had no guard against overlapping runs for the same asset type and group.

## How It Is Being Fixed

Sitemap regeneration now acquires a lock — keyed by asset type, group, and company, held by the guest user with a 20-minute timeout — around each run and releases it in a finally block; a duplicate lock is treated as an in-progress run and skipped. A new SitemapManager.isRegenerationInProgress(companyId) API reports whether any non-expired lock exists for the company, letting the admin UI display a loading icon while a regeneration job runs. Scheduling gains a force flag so an explicit start date deletes and reschedules an existing job rather than being ignored. An integration test covers lock-based in-progress detection.

## PR Check

**pr-check: PASS** — tested on `5175a45886c17861f0360bc6e0344a2394f93800`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5175a45886c17861f0360bc6e0344a2394f93800"} -->
