### PR TITLE
LPD-98532 Fix Publications page failing on a stale search index

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -138,7 +139,7 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			com.liferay.change.tracking.model.CTCollection.class.getName(),
 			search, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
+				Field.ENTRY_CLASS_PK, Field.UID),
 			searchContext -> {
 				searchContext.setAttribute("statuses", statuses);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
@@ -148,8 +149,23 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 				}
 			},
 			sorts,
-			document -> _toCTCollection(
-				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
+			document -> {
+				long ctCollectionId = GetterUtil.getLong(
+					document.get(Field.ENTRY_CLASS_PK));
+
+				com.liferay.change.tracking.model.CTCollection ctCollection =
+					_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+
+				if (ctCollection == null) {
+					_indexer.delete(
+						contextCompany.getCompanyId(), document.get(Field.UID));
+
+					return null;
+				}
+
+				return _ctCollectionDTOConverter.toDTO(
+					_getDTOConverterContext(ctCollection), ctCollection);
+			});
 	}
 
 	@Override
@@ -481,6 +497,11 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 
 	@Reference
 	private CTPreferencesService _ctPreferencesService;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.change.tracking.model.CTCollection)"
+	)
+	private Indexer<?> _indexer;
 
 	@Reference
 	private PublishScheduler _publishScheduler;

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
@@ -67,11 +67,12 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 
 	@Override
 	public void deleteCTCollection(Long ctCollectionId) throws PortalException {
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
 
-		if (ctCollection != null) {
-			_ctCollectionService.deleteCTCollection(ctCollection);
+		if (serviceBuilderCTCollection != null) {
+			_ctCollectionService.deleteCTCollection(serviceBuilderCTCollection);
 		}
 	}
 
@@ -80,12 +81,14 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			String externalReferenceCode)
 		throws PortalException {
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.fetchCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					fetchCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
-		if (ctCollection != null) {
-			_ctCollectionService.deleteCTCollection(ctCollection);
+		if (serviceBuilderCTCollection != null) {
+			_ctCollectionService.deleteCTCollection(serviceBuilderCTCollection);
 		}
 	}
 
@@ -107,11 +110,13 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.getCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					getCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
-		return _getShareLink(ctCollection.getCtCollectionId());
+		return _getShareLink(serviceBuilderCTCollection.getCtCollectionId());
 	}
 
 	@Override
@@ -153,10 +158,12 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 				long ctCollectionId = GetterUtil.getLong(
 					document.get(Field.ENTRY_CLASS_PK));
 
-				com.liferay.change.tracking.model.CTCollection ctCollection =
-					_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+				com.liferay.change.tracking.model.CTCollection
+					serviceBuilderCTCollection =
+						_ctCollectionLocalService.fetchCTCollection(
+							ctCollectionId);
 
-				if (ctCollection == null) {
+				if (serviceBuilderCTCollection == null) {
 					_indexer.delete(
 						contextCompany.getCompanyId(), document.get(Field.UID));
 
@@ -164,7 +171,8 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 				}
 
 				return _ctCollectionDTOConverter.toDTO(
-					_getDTOConverterContext(ctCollection), ctCollection);
+					_getDTOConverterContext(serviceBuilderCTCollection),
+					serviceBuilderCTCollection);
 			});
 	}
 
@@ -178,13 +186,16 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			String externalReferenceCode, CTCollection ctCollection)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTCollection ctCollectionModel =
-			_ctCollectionLocalService.fetchCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					fetchCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
 		return _toCTCollection(
 			_ctCollectionService.updateCTCollection(
-				contextUser.getUserId(), ctCollectionModel.getCtCollectionId(),
+				contextUser.getUserId(),
+				serviceBuilderCTCollection.getCtCollectionId(),
 				ctCollection.getName(), ctCollection.getDescription()));
 	}
 
@@ -203,12 +214,15 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.getCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					getCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
 		_ctCollectionService.publishCTCollection(
-			contextUser.getUserId(), ctCollection.getCtCollectionId());
+			contextUser.getUserId(),
+			serviceBuilderCTCollection.getCtCollectionId());
 	}
 
 	@Override
@@ -216,11 +230,14 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			String externalReferenceCode, Date publishDate)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.getCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					getCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
-		_schedulePublish(ctCollection.getCtCollectionId(), publishDate);
+		_schedulePublish(
+			serviceBuilderCTCollection.getCtCollectionId(), publishDate);
 	}
 
 	@Override
@@ -268,7 +285,8 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 	}
 
 	private DefaultDTOConverterContext _getDTOConverterContext(
-			com.liferay.change.tracking.model.CTCollection ctCollection)
+			com.liferay.change.tracking.model.CTCollection
+				serviceBuilderCTCollection)
 		throws Exception {
 
 		return new DefaultDTOConverterContext(
@@ -276,94 +294,106 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			HashMapBuilder.put(
 				"checkout",
 				() -> {
-					if (!ctCollection.isInProgress() ||
-						(ctCollection.getCtCollectionId() ==
+					if (!serviceBuilderCTCollection.isInProgress() ||
+						(serviceBuilderCTCollection.getCtCollectionId() ==
 							CTCollectionThreadLocal.getCTCollectionId())) {
 
 						return null;
 					}
 
 					return addAction(
-						ActionKeys.VIEW, ctCollection.getCtCollectionId(),
+						ActionKeys.VIEW,
+						serviceBuilderCTCollection.getCtCollectionId(),
 						"postCTCollectionCheckout",
 						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"delete",
 				() -> addAction(
-					ActionKeys.DELETE, ctCollection.getCtCollectionId(),
+					ActionKeys.DELETE,
+					serviceBuilderCTCollection.getCtCollectionId(),
 					"deleteCTCollection", _ctCollectionModelResourcePermission)
 			).put(
 				"get",
 				addAction(
-					ActionKeys.VIEW, ctCollection.getCtCollectionId(),
+					ActionKeys.VIEW,
+					serviceBuilderCTCollection.getCtCollectionId(),
 					"getCTCollection", _ctCollectionModelResourcePermission)
 			).put(
 				"permissions",
 				() -> {
-					if (!ctCollection.isInProgress()) {
+					if (!serviceBuilderCTCollection.isInProgress()) {
 						return null;
 					}
 
 					return addAction(
 						ActionKeys.PERMISSIONS,
-						ctCollection.getCtCollectionId(), "patchCTCollection",
+						serviceBuilderCTCollection.getCtCollectionId(),
+						"patchCTCollection",
 						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"publish",
 				() -> {
-					if (!_isPublishEnabled(ctCollection.getCtCollectionId())) {
+					if (!_isPublishEnabled(
+							serviceBuilderCTCollection.getCtCollectionId())) {
+
 						return null;
 					}
 
 					return addAction(
-						CTActionKeys.PUBLISH, ctCollection.getCtCollectionId(),
+						CTActionKeys.PUBLISH,
+						serviceBuilderCTCollection.getCtCollectionId(),
 						"postCTCollectionPublish",
 						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"reactivate",
 				() -> {
-					if (ctCollection.getStatus() !=
+					if (serviceBuilderCTCollection.getStatus() !=
 							WorkflowConstants.STATUS_EXPIRED) {
 
 						return null;
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctCollection.getCtCollectionId(),
+						ActionKeys.UPDATE,
+						serviceBuilderCTCollection.getCtCollectionId(),
 						"putCTCollection",
 						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"schedule",
 				() -> {
-					if (!_isPublishEnabled(ctCollection.getCtCollectionId()) ||
+					if (!_isPublishEnabled(
+							serviceBuilderCTCollection.getCtCollectionId()) ||
 						!PropsValues.SCHEDULER_ENABLED) {
 
 						return null;
 					}
 
 					return addAction(
-						CTActionKeys.PUBLISH, ctCollection.getCtCollectionId(),
+						CTActionKeys.PUBLISH,
+						serviceBuilderCTCollection.getCtCollectionId(),
 						"postCTCollectionSchedulePublish",
 						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"update",
 				() -> {
-					if (!ctCollection.isInProgress()) {
+					if (!serviceBuilderCTCollection.isInProgress()) {
 						return null;
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctCollection.getCtCollectionId(),
+						ActionKeys.UPDATE,
+						serviceBuilderCTCollection.getCtCollectionId(),
 						"putCTCollection",
 						_ctCollectionModelResourcePermission);
 				}
 			).build(),
-			null, contextHttpServletRequest, ctCollection.getCtCollectionId(),
+			null, contextHttpServletRequest,
+			serviceBuilderCTCollection.getCtCollectionId(),
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}
@@ -400,10 +430,11 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 			return true;
 		}
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
 
-		return ctCollection.isInProgress();
+		return serviceBuilderCTCollection.isInProgress();
 	}
 
 	private void _schedulePublish(long ctCollectionId, Date publishDate)
@@ -423,10 +454,13 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 				"The publish time must be in the future");
 		}
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
 
-		if (ctCollection.getStatus() == WorkflowConstants.STATUS_SCHEDULED) {
+		if (serviceBuilderCTCollection.getStatus() ==
+				WorkflowConstants.STATUS_SCHEDULED) {
+
 			_publishScheduler.unschedulePublish(ctCollectionId);
 		}
 
@@ -435,33 +469,39 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 	}
 
 	private CTCollection _toCTCollection(
-			com.liferay.change.tracking.model.CTCollection ctCollection)
+			com.liferay.change.tracking.model.CTCollection
+				serviceBuilderCTCollection)
 		throws Exception {
 
-		if (ctCollection == null) {
+		if (serviceBuilderCTCollection == null) {
 			return null;
 		}
 
-		return _toCTCollection(ctCollection.getCtCollectionId());
+		return _toCTCollection(serviceBuilderCTCollection.getCtCollectionId());
 	}
 
 	private CTCollection _toCTCollection(Long ctCollectionId) throws Exception {
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.getCTCollection(ctCollectionId);
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.getCTCollection(ctCollectionId);
 
 		return _ctCollectionDTOConverter.toDTO(
-			_getDTOConverterContext(ctCollection), ctCollection);
+			_getDTOConverterContext(serviceBuilderCTCollection),
+			serviceBuilderCTCollection);
 	}
 
 	private CTCollection _toCTCollection(String externalReferenceCode)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTCollection ctCollection =
-			_ctCollectionLocalService.getCTCollectionByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection =
+				_ctCollectionLocalService.
+					getCTCollectionByExternalReferenceCode(
+						externalReferenceCode, contextCompany.getCompanyId());
 
 		return _ctCollectionDTOConverter.toDTO(
-			_getDTOConverterContext(ctCollection), ctCollection);
+			_getDTOConverterContext(serviceBuilderCTCollection),
+			serviceBuilderCTCollection);
 	}
 
 	private static final EntityModel _entityModel =

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTEntryResourceImpl.java
@@ -94,10 +94,11 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 				long ctEntryId = GetterUtil.getLong(
 					document.get(Field.ENTRY_CLASS_PK));
 
-				com.liferay.change.tracking.model.CTEntry ctEntry =
-					_ctEntryLocalService.fetchCTEntry(ctEntryId);
+				com.liferay.change.tracking.model.CTEntry
+					serviceBuilderCTEntry = _ctEntryLocalService.fetchCTEntry(
+						ctEntryId);
 
-				if (ctEntry == null) {
+				if (serviceBuilderCTEntry == null) {
 					_indexer.delete(
 						contextCompany.getCompanyId(), document.get(Field.UID));
 
@@ -105,7 +106,8 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 				}
 
 				return _ctEntryDTOConverter.toDTO(
-					_getDTOConverterContext(ctEntry), ctEntry);
+					_getDTOConverterContext(serviceBuilderCTEntry),
+					serviceBuilderCTEntry);
 			});
 	}
 
@@ -119,11 +121,11 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 			_ctCollectionHistoryProviderRegistry.getCTCollectionHistoryProvider(
 				modelClassNameId);
 
-		com.liferay.change.tracking.model.CTEntry ctEntry =
+		com.liferay.change.tracking.model.CTEntry serviceBuilderCTEntry =
 			ctCollectionHistoryProvider.getCTEntry(
 				ctCollectionId, modelClassNameId, modelClassPK);
 
-		if (ctEntry == null) {
+		if (serviceBuilderCTEntry == null) {
 			throw new NoSuchEntryException(
 				StringBundler.concat(
 					"No change tracking entry exists with change tracking ",
@@ -132,7 +134,8 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 		}
 
 		return _ctEntryDTOConverter.toDTO(
-			_getDTOConverterContext(ctEntry), ctEntry);
+			_getDTOConverterContext(serviceBuilderCTEntry),
+			serviceBuilderCTEntry);
 	}
 
 	@Override
@@ -225,11 +228,11 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 
 	private <T extends BaseModel<T>> DefaultDTOConverterContext
 			_getDTOConverterContext(
-				com.liferay.change.tracking.model.CTEntry ctEntry)
+				com.liferay.change.tracking.model.CTEntry serviceBuilderCTEntry)
 		throws Exception {
 
 		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
-			ctEntry.getCtCollectionId());
+			serviceBuilderCTEntry.getCtCollectionId());
 
 		return new DefaultDTOConverterContext(
 			contextAcceptLanguage.isAcceptAllLanguages(),
@@ -241,8 +244,9 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctEntry.getCtCollectionId(),
-						"getCTEntry", _ctCollectionModelResourcePermission);
+						ActionKeys.UPDATE,
+						serviceBuilderCTEntry.getCtCollectionId(), "getCTEntry",
+						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"delete",
@@ -252,14 +256,15 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.DELETE, ctEntry.getCtCollectionId(),
-						"getCTEntry", _ctCollectionModelResourcePermission);
+						ActionKeys.DELETE,
+						serviceBuilderCTEntry.getCtCollectionId(), "getCTEntry",
+						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"get",
 				addAction(
-					ActionKeys.VIEW, ctEntry.getCtCollectionId(), "getCTEntry",
-					_ctCollectionModelResourcePermission)
+					ActionKeys.VIEW, serviceBuilderCTEntry.getCtCollectionId(),
+					"getCTEntry", _ctCollectionModelResourcePermission)
 			).put(
 				"move-changes",
 				() -> {
@@ -271,8 +276,9 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctEntry.getCtCollectionId(),
-						"getCTEntry", _ctCollectionModelResourcePermission);
+						ActionKeys.UPDATE,
+						serviceBuilderCTEntry.getCtCollectionId(), "getCTEntry",
+						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"update",
@@ -282,8 +288,9 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctEntry.getCtCollectionId(),
-						"getCTEntry", _ctCollectionModelResourcePermission);
+						ActionKeys.UPDATE,
+						serviceBuilderCTEntry.getCtCollectionId(), "getCTEntry",
+						_ctCollectionModelResourcePermission);
 				}
 			).put(
 				"view-discard",
@@ -293,11 +300,13 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctEntry.getCtCollectionId(),
-						"getCTEntry", _ctCollectionModelResourcePermission);
+						ActionKeys.UPDATE,
+						serviceBuilderCTEntry.getCtCollectionId(), "getCTEntry",
+						_ctCollectionModelResourcePermission);
 				}
 			).build(),
-			null, contextHttpServletRequest, ctEntry.getCtCollectionId(),
+			null, contextHttpServletRequest,
+			serviceBuilderCTEntry.getCtCollectionId(),
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}
@@ -331,11 +340,12 @@ public class CTEntryResourceImpl extends BaseCTEntryResourceImpl {
 	}
 
 	private CTEntry _toCTEntry(Long ctEntryId) throws Exception {
-		com.liferay.change.tracking.model.CTEntry ctEntry =
+		com.liferay.change.tracking.model.CTEntry serviceBuilderCTEntry =
 			_ctEntryLocalService.getCTEntry(ctEntryId);
 
 		return _ctEntryDTOConverter.toDTO(
-			_getDTOConverterContext(ctEntry), ctEntry);
+			_getDTOConverterContext(serviceBuilderCTEntry),
+			serviceBuilderCTEntry);
 	}
 
 	private static final EntityModel _entityModel = new CTEntryEntityModel();

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTProcessResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTProcessResourceImpl.java
@@ -110,13 +110,13 @@ public class CTProcessResourceImpl extends BaseCTProcessResourceImpl {
 			Long ctProcessId, String description, String name)
 		throws Exception {
 
-		com.liferay.change.tracking.model.CTProcess ctProcess =
+		com.liferay.change.tracking.model.CTProcess serviceBuilderCTProcess =
 			_ctProcessLocalService.getCTProcess(ctProcessId);
 
 		if (Validator.isNull(name)) {
 			CTCollection ctCollection =
 				_ctCollectionLocalService.getCTCollection(
-					ctProcess.getCtCollectionId());
+					serviceBuilderCTProcess.getCtCollectionId());
 
 			name = StringBundler.concat(
 				_language.get(
@@ -125,27 +125,27 @@ public class CTProcessResourceImpl extends BaseCTProcessResourceImpl {
 		}
 
 		_ctCollectionService.undoCTCollection(
-			ctProcess.getCtCollectionId(), contextUser.getUserId(), name,
-			description);
+			serviceBuilderCTProcess.getCtCollectionId(),
+			contextUser.getUserId(), name, description);
 	}
 
 	private DefaultDTOConverterContext _getDTOConverterContext(
-			com.liferay.change.tracking.model.CTProcess ctProcess)
+			com.liferay.change.tracking.model.CTProcess serviceBuilderCTProcess)
 		throws Exception {
 
 		BackgroundTask backgroundTask =
 			_backgroundTaskLocalService.getBackgroundTask(
-				ctProcess.getBackgroundTaskId());
+				serviceBuilderCTProcess.getBackgroundTaskId());
 
 		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
-			ctProcess.getCtCollectionId());
+			serviceBuilderCTProcess.getCtCollectionId());
 
 		return new DefaultDTOConverterContext(
 			contextAcceptLanguage.isAcceptAllLanguages(),
 			HashMapBuilder.put(
 				"delete",
 				() -> addAction(
-					ActionKeys.DELETE, ctProcess.getCtProcessId(),
+					ActionKeys.DELETE, serviceBuilderCTProcess.getCtProcessId(),
 					"deleteCTProcess", _ctProcessModelResourcePermission)
 			).put(
 				"get",
@@ -157,7 +157,8 @@ public class CTProcessResourceImpl extends BaseCTProcessResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.VIEW, ctProcess.getCtCollectionId(),
+						ActionKeys.VIEW,
+						serviceBuilderCTProcess.getCtCollectionId(),
 						"getCTProcess", _ctCollectionModelResourcePermission);
 				}
 			).put(
@@ -181,17 +182,19 @@ public class CTProcessResourceImpl extends BaseCTProcessResourceImpl {
 						_ctCollectionModelResourcePermission);
 				}
 			).build(),
-			null, contextHttpServletRequest, ctProcess.getCtCollectionId(),
+			null, contextHttpServletRequest,
+			serviceBuilderCTProcess.getCtCollectionId(),
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}
 
 	private CTProcess _toCTProcess(Long ctProcessId) throws Exception {
-		com.liferay.change.tracking.model.CTProcess ctProcess =
+		com.liferay.change.tracking.model.CTProcess serviceBuilderCTProcess =
 			_ctProcessLocalService.getCTProcess(ctProcessId);
 
 		return _ctProcessDTOConverter.toDTO(
-			_getDTOConverterContext(ctProcess), ctProcess);
+			_getDTOConverterContext(serviceBuilderCTProcess),
+			serviceBuilderCTProcess);
 	}
 
 	private static final EntityModel _entityModel = new CTProcessEntityModel();

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTRemoteResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTRemoteResourceImpl.java
@@ -48,11 +48,11 @@ public class CTRemoteResourceImpl extends BaseCTRemoteResourceImpl {
 
 	@Override
 	public void deleteCTRemote(Long ctRemoteId) throws PortalException {
-		com.liferay.change.tracking.model.CTRemote ctRemote =
+		com.liferay.change.tracking.model.CTRemote serviceBuilderCTRemote =
 			_ctRemoteLocalService.fetchCTRemote(ctRemoteId);
 
-		if (ctRemote != null) {
-			_ctRemoteService.deleteCTRemote(ctRemote);
+		if (serviceBuilderCTRemote != null) {
+			_ctRemoteService.deleteCTRemote(serviceBuilderCTRemote);
 		}
 	}
 
@@ -119,7 +119,7 @@ public class CTRemoteResourceImpl extends BaseCTRemoteResourceImpl {
 	}
 
 	private DefaultDTOConverterContext _getDTOConverterContext(
-			com.liferay.change.tracking.model.CTRemote ctRemote)
+			com.liferay.change.tracking.model.CTRemote serviceBuilderCTRemote)
 		throws Exception {
 
 		return new DefaultDTOConverterContext(
@@ -127,50 +127,53 @@ public class CTRemoteResourceImpl extends BaseCTRemoteResourceImpl {
 			HashMapBuilder.put(
 				"delete",
 				() -> addAction(
-					ActionKeys.DELETE, ctRemote.getCtRemoteId(),
+					ActionKeys.DELETE, serviceBuilderCTRemote.getCtRemoteId(),
 					"deleteCTRemote", _ctRemoteModelResourcePermission)
 			).put(
 				"get",
 				addAction(
-					ActionKeys.VIEW, ctRemote.getCtRemoteId(), "getCTRemote",
-					_ctRemoteModelResourcePermission)
+					ActionKeys.VIEW, serviceBuilderCTRemote.getCtRemoteId(),
+					"getCTRemote", _ctRemoteModelResourcePermission)
 			).put(
 				"permissions",
 				() -> addAction(
-					ActionKeys.PERMISSIONS, ctRemote.getCtRemoteId(),
-					"patchCTRemote", _ctRemoteModelResourcePermission)
+					ActionKeys.PERMISSIONS,
+					serviceBuilderCTRemote.getCtRemoteId(), "patchCTRemote",
+					_ctRemoteModelResourcePermission)
 			).put(
 				"update",
 				() -> addAction(
-					ActionKeys.UPDATE, ctRemote.getCtRemoteId(), "putCTRemote",
-					_ctRemoteModelResourcePermission)
+					ActionKeys.UPDATE, serviceBuilderCTRemote.getCtRemoteId(),
+					"putCTRemote", _ctRemoteModelResourcePermission)
 			).build(),
-			null, contextHttpServletRequest, ctRemote.getCtRemoteId(),
+			null, contextHttpServletRequest,
+			serviceBuilderCTRemote.getCtRemoteId(),
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
 	}
 
 	private CTRemote _toCTRemote(
-			com.liferay.change.tracking.model.CTRemote ctRemote)
+			com.liferay.change.tracking.model.CTRemote serviceBuilderCTRemote)
 		throws Exception {
 
-		if (ctRemote == null) {
+		if (serviceBuilderCTRemote == null) {
 			return null;
 		}
 
-		return _toCTRemote(ctRemote.getCtRemoteId());
+		return _toCTRemote(serviceBuilderCTRemote.getCtRemoteId());
 	}
 
 	private CTRemote _toCTRemote(Long ctRemoteId) throws Exception {
-		com.liferay.change.tracking.model.CTRemote ctRemote =
+		com.liferay.change.tracking.model.CTRemote serviceBuilderCTRemote =
 			_ctRemoteLocalService.getCTRemote(ctRemoteId);
 
 		_ctRemoteModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), ctRemote,
-			ActionKeys.VIEW);
+			PermissionThreadLocal.getPermissionChecker(),
+			serviceBuilderCTRemote, ActionKeys.VIEW);
 
 		return _ctRemoteDTOConverter.toDTO(
-			_getDTOConverterContext(ctRemote), ctRemote);
+			_getDTOConverterContext(serviceBuilderCTRemote),
+			serviceBuilderCTRemote);
 	}
 
 	private static final EntityModel _entityModel = new CTRemoteEntityModel();

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTCollectionResourceTest.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CTCollectionResourceTest.java
@@ -15,19 +15,26 @@ import com.liferay.change.tracking.rest.client.pagination.Page;
 import com.liferay.change.tracking.rest.client.pagination.Pagination;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
+import com.liferay.change.tracking.service.persistence.CTCollectionPersistence;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -160,6 +167,8 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 		assertEquals(
 			(List<CTCollection>)descPage.getItems(),
 			(List<CTCollection>)page.getItems());
+
+		_testGetCTCollectionsPageWithStaleIndexDocument();
 	}
 
 	@Override
@@ -512,11 +521,56 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 			serviceBuilderCTCollection.getCtCollectionId());
 	}
 
+	private void _testGetCTCollectionsPageWithStaleIndexDocument()
+		throws Exception {
+
+		CTCollection ctCollection1 = _postCTCollection(randomCTCollection());
+		CTCollection ctCollection2 = _postCTCollection(randomCTCollection());
+
+		com.liferay.change.tracking.model.CTCollection
+			serviceBuilderCTCollection1 =
+				_ctCollectionLocalService.getCTCollection(
+					ctCollection1.getId());
+
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+		try {
+			TransactionInvokerUtil.invoke(
+				transactionConfig,
+				() -> _ctCollectionPersistence.remove(
+					serviceBuilderCTCollection1));
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
+
+		_resourceLocalService.deleteResource(
+			serviceBuilderCTCollection1.getCompanyId(),
+			com.liferay.change.tracking.model.CTCollection.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			serviceBuilderCTCollection1.getCtCollectionId());
+
+		Page<CTCollection> page = ctCollectionResource.getCTCollectionsPage(
+			null, null, null, Pagination.of(1, 10), null);
+
+		List<CTCollection> ctCollections = (List<CTCollection>)page.getItems();
+
+		assertContains(ctCollection2, ctCollections);
+
+		for (CTCollection ctCollection : ctCollections) {
+			Assert.assertNotEquals(ctCollection1.getId(), ctCollection.getId());
+		}
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private CTCollectionPersistence _ctCollectionPersistence;
 
 	@Inject
 	private CTPreferencesLocalService _ctPreferencesLocalService;
@@ -526,5 +580,8 @@ public class CTCollectionResourceTest extends BaseCTCollectionResourceTestCase {
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourceLocalService _resourceLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98532

## What Is Being Fixed

The Publications page failed to return any results whenever its search index held a document for a CTCollection that no longer existed in the database (for example, after a delete that never fully reconciled the index). Fetching that stale document threw partway through building the page's results, so the whole page came back empty instead of the collections that still existed.

## How It Is Being Fixed

`getCTCollectionsPage` now fetches the underlying Service Builder `CTCollection` for each search result and, when it no longer exists, deletes the stale index document through a newly injected `Indexer<?>` reference and skips it instead of failing the whole page. An integration test reproduces a stale index document by removing the persisted collection out from under its index entry and asserts the page still returns the remaining collections.

Alongside the fix, local variables and parameters holding the Service Builder model type across `CTCollectionResourceImpl`, `CTRemoteResourceImpl`, `CTEntryResourceImpl`, and `CTProcessResourceImpl` were renamed from ad hoc names (`ctCollection`, `ctCollectionModel`, etc.) to a consistent `serviceBuilderCT*` form, since each of those classes imports a REST DTO of the same simple name.

## PR Check

**pr-check: PASS** — tested on `a2fa065816abc82745f650dce7ca4bbd66350c7a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a2fa065816abc82745f650dce7ca4bbd66350c7a"} -->
