### PR TITLE
LPD-88837 Add PageSpeed scanner to SEO Studio workspace

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -22,6 +22,7 @@ apply plugin: "org.springframework.boot"
 dependencies {
 	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/build.gradle
@@ -22,7 +22,7 @@ apply plugin: "org.springframework.boot"
 dependencies {
 	implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.18.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
-	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.concurrent", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/SEOStudioSpringBootApplication.java
@@ -10,10 +10,12 @@ import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringB
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * @author Kiana Suetani
  */
+@EnableScheduling
 @Import(ClientExtensionUtilSpringBootComponentScan.class)
 @SpringBootApplication
 public class SEOStudioSpringBootApplication {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.constants;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedConstants {
+
+	public static final String STATE_COMPLETED = "completed";
+
+	public static final String STATE_FAILED = "failed";
+
+	public static final String STATE_QUEUED = "queued";
+
+	public static final String STATE_RUNNING = "running";
+
+	public static final String STRATEGY_DESKTOP = "DESKTOP";
+
+	public static final String STRATEGY_MOBILE = "MOBILE";
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -13,7 +13,7 @@ import org.json.JSONObject;
 public class Domain {
 
 	public Domain(JSONObject jsonObject) {
-		_domainHostname = jsonObject.optString("domainHostname", null);
+		_hostname = jsonObject.optString("hostname", null);
 
 		JSONObject seoStudioInstanceJSONObject = jsonObject.optJSONObject(
 			"seoStudioInstance");
@@ -21,21 +21,28 @@ public class Domain {
 		if (seoStudioInstanceJSONObject != null) {
 			_googlePageSpeedAPIKey = seoStudioInstanceJSONObject.optString(
 				"googlePageSpeedAPIKey", null);
+			_seoStudioInstanceId = seoStudioInstanceJSONObject.getLong("id");
 		}
 		else {
 			_googlePageSpeedAPIKey = null;
+			_seoStudioInstanceId = 0;
 		}
-	}
-
-	public String getDomainHostname() {
-		return _domainHostname;
 	}
 
 	public String getGooglePageSpeedAPIKey() {
 		return _googlePageSpeedAPIKey;
 	}
 
-	private final String _domainHostname;
+	public String getHostname() {
+		return _hostname;
+	}
+
+	public long getSEOStudioInstanceId() {
+		return _seoStudioInstanceId;
+	}
+
 	private final String _googlePageSpeedAPIKey;
+	private final String _hostname;
+	private final long _seoStudioInstanceId;
 
 }

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+/**
+ * @author Kiana Suetani
+ */
+public class PageSpeedScanResult {
+
+	public PageSpeedScanResult(
+		PageSpeedReport averagePageSpeedReport, int pagesErrored,
+		int pagesScanned, int pagesTotal, String strategy) {
+
+		_averagePageSpeedReport = averagePageSpeedReport;
+		_pagesErrored = pagesErrored;
+		_pagesScanned = pagesScanned;
+		_pagesTotal = pagesTotal;
+		_strategy = strategy;
+	}
+
+	public PageSpeedReport getAveragePageSpeedReport() {
+		return _averagePageSpeedReport;
+	}
+
+	public int getPagesErrored() {
+		return _pagesErrored;
+	}
+
+	public int getPagesScanned() {
+		return _pagesScanned;
+	}
+
+	public int getPagesTotal() {
+		return _pagesTotal;
+	}
+
+	public String getStrategy() {
+		return _strategy;
+	}
+
+	private final PageSpeedReport _averagePageSpeedReport;
+	private final int _pagesErrored;
+	private final int _pagesScanned;
+	private final int _pagesTotal;
+	private final String _strategy;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -14,7 +14,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.PageSpeedConstants;
-import com.liferay.seo.studio.model.Domain;
 import com.liferay.seo.studio.model.PageSpeedReport;
 import com.liferay.seo.studio.model.PageSpeedScanResult;
 
@@ -50,38 +49,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class LiferayService extends BaseService {
 
-	public Domain getDomain(long domainId) {
-		UriComponents uriComponents = UriComponentsBuilder.fromPath(
-			"/o/seo-studio/domains/" + domainId
-		).queryParam(
-			"nestedFields", "seoStudioInstance"
-		).build();
-
-		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
-
-		String message = "Unable to get domain " + domainId;
-
-		if (Validator.isNull(responseJSON)) {
-			throw new IllegalArgumentException(message);
-		}
-
-		try {
-			return new Domain(new JSONObject(responseJSON));
-		}
-		catch (JSONException jsonException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(message, jsonException);
-			}
-
-			throw new IllegalArgumentException(message, jsonException);
-		}
-	}
-
 	public JSONArray getQueuedSEOStudioScansJSONArray() {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/c/seostudioscans"
 		).queryParam(
 			"filter", "state eq '" + PageSpeedConstants.STATE_QUEUED + "'"
+		).queryParam(
+			"nestedFields",
+			"seoStudioScanRun,seoStudioDomain,seoStudioInstance"
+		).queryParam(
+			"nestedFieldsDepth", 3
 		).queryParam(
 			"pageSize", 20
 		).build();
@@ -112,32 +89,6 @@ public class LiferayService extends BaseService {
 			}
 
 			return new JSONArray();
-		}
-	}
-
-	public JSONObject getScanRunJSONObject(long seoStudioScanRunId) {
-		UriComponents uriComponents = UriComponentsBuilder.fromPath(
-			"/o/c/seostudioscanruns/" + seoStudioScanRunId
-		).build();
-
-		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
-
-		String message =
-			"Unable to get the SEO Studio scan run " + seoStudioScanRunId;
-
-		if (Validator.isNull(responseJSON)) {
-			throw new IllegalArgumentException(message);
-		}
-
-		try {
-			return new JSONObject(responseJSON);
-		}
-		catch (JSONException jsonException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(message, jsonException);
-			}
-
-			throw new IllegalArgumentException(message, jsonException);
 		}
 	}
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -13,7 +13,10 @@ import com.liferay.client.extension.util.spring.boot3.service.BaseService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.PageSpeedConstants;
 import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.PageSpeedReport;
+import com.liferay.seo.studio.model.PageSpeedScanResult;
 
 import java.io.IOException;
 
@@ -32,6 +35,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -53,12 +57,9 @@ public class LiferayService extends BaseService {
 			"nestedFields", "seoStudioInstance"
 		).build();
 
-		String responseJSON = get(
-			_liferayOAuth2AccessTokenManager.getAuthorization(
-				"liferay-seostudio-etc-pagespeed-oahs"),
-			uriComponents.toUri());
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
 
-		String message = "Unable to find domain " + domainId;
+		String message = "Unable to get domain " + domainId;
 
 		if (Validator.isNull(responseJSON)) {
 			throw new IllegalArgumentException(message);
@@ -76,19 +77,150 @@ public class LiferayService extends BaseService {
 		}
 	}
 
+	public JSONArray getQueuedSEOStudioScansJSONArray() {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscans"
+		).queryParam(
+			"filter", "state eq '" + PageSpeedConstants.STATE_QUEUED + "'"
+		).queryParam(
+			"pageSize", 20
+		).build();
+
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
+
+		if (Validator.isNull(responseJSON)) {
+			return new JSONArray();
+		}
+
+		try {
+			JSONArray itemsJSONArray = new JSONObject(
+				responseJSON
+			).optJSONArray(
+				"items"
+			);
+
+			if (itemsJSONArray == null) {
+				return new JSONArray();
+			}
+
+			return itemsJSONArray;
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to parse the queued scans response", jsonException);
+			}
+
+			return new JSONArray();
+		}
+	}
+
+	public JSONObject getScanRunJSONObject(long seoStudioScanRunId) {
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscanruns/" + seoStudioScanRunId
+		).build();
+
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
+
+		String message =
+			"Unable to get the SEO Studio scan run " + seoStudioScanRunId;
+
+		if (Validator.isNull(responseJSON)) {
+			throw new IllegalArgumentException(message);
+		}
+
+		try {
+			return new JSONObject(responseJSON);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(message, jsonException);
+			}
+
+			throw new IllegalArgumentException(message, jsonException);
+		}
+	}
+
 	public List<String> getSitemapPageURLs(String hostname, int limit) {
-		if ((limit <= 0) || Validator.isNull(hostname)) {
-			return Collections.emptyList();
+		if (Validator.isNull(hostname)) {
+			throw new IllegalArgumentException(
+				"Unable to get a sitemap without a hostname");
+		}
+
+		if (limit <= 0) {
+			throw new IllegalArgumentException(
+				"Unable to get a sitemap without a positive limit");
 		}
 
 		String sitemapXML = _getSitemapXML(
 			"https://" + hostname + "/sitemap.xml");
 
 		if (Validator.isNull(sitemapXML)) {
-			return Collections.emptyList();
+			throw new IllegalStateException(
+				"Unable to get a sitemap for " + hostname);
 		}
 
 		return _parseSitemapPageURLs(0, hostname, limit, sitemapXML);
+	}
+
+	public String patchSEOStudioScan(
+		String errorMessage, long seoStudioScanId, String state) {
+
+		JSONObject jsonObject = new JSONObject();
+
+		if (Validator.isNotNull(errorMessage)) {
+			jsonObject.put("errorMessage", errorMessage);
+		}
+
+		jsonObject.put("state", state);
+
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudioscans/" + seoStudioScanId
+		).build();
+
+		return patch(
+			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
+	}
+
+	public String postSEOStudioPageSpeedResult(
+		PageSpeedScanResult pageSpeedScanResult, long seoStudioScanId) {
+
+		PageSpeedReport averagePageSpeedReport =
+			pageSpeedScanResult.getAveragePageSpeedReport();
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"accessibilityScore", averagePageSpeedReport.getAccessibility()
+		).put(
+			"bestPracticesScore", averagePageSpeedReport.getBestPractices()
+		).put(
+			"pagesErrored", pageSpeedScanResult.getPagesErrored()
+		).put(
+			"pagesScanned", pageSpeedScanResult.getPagesScanned()
+		).put(
+			"pagesTotal", pageSpeedScanResult.getPagesTotal()
+		).put(
+			"performanceScore", averagePageSpeedReport.getPerformance()
+		).put(
+			"r_seoStudioScanToSEOStudioPageSpeedResults_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"seoScore", averagePageSpeedReport.getSEO()
+		).put(
+			"strategy", pageSpeedScanResult.getStrategy()
+		);
+
+		UriComponents uriComponents = UriComponentsBuilder.fromPath(
+			"/o/c/seostudiopagespeedresults"
+		).build();
+
+		return post(
+			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
+	}
+
+	private String _getAuthorization() {
+		return _liferayOAuth2AccessTokenManager.getAuthorization(
+			"liferay-seostudio-etc-pagespeed-oahs");
 	}
 
 	private String _getSitemapXML(String url) {
@@ -107,7 +239,7 @@ public class LiferayService extends BaseService {
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						StringBundler.concat(
-							"Unable to fetch sitemap ", url, ", HTTP ",
+							"Unable to get a sitemap ", url, ", HTTP ",
 							httpResponse.statusCode()));
 				}
 
@@ -118,7 +250,7 @@ public class LiferayService extends BaseService {
 		}
 		catch (IllegalArgumentException | IOException exception) {
 			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to fetch sitemap " + url, exception);
+				_log.debug("Unable to get a sitemap " + url, exception);
 			}
 
 			return null;
@@ -126,7 +258,7 @@ public class LiferayService extends BaseService {
 		catch (InterruptedException interruptedException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
-					"Unable to fetch sitemap " + url, interruptedException);
+					"Unable to get a sitemap " + url, interruptedException);
 			}
 
 			Thread thread = Thread.currentThread();

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -55,8 +55,7 @@ public class LiferayService extends BaseService {
 		).queryParam(
 			"filter", "state eq '" + PageSpeedConstants.STATE_QUEUED + "'"
 		).queryParam(
-			"nestedFields",
-			"seoStudioScanRun,seoStudioDomain,seoStudioInstance"
+			"nestedFields", "seoStudioScanRun,seoStudioDomain,seoStudioInstance"
 		).queryParam(
 			"nestedFieldsDepth", 3
 		).queryParam(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,16 +35,15 @@ public class PageSpeedScanService {
 
 	@Scheduled(fixedDelay = 30000)
 	public void scheduledProcessQueuedScans() {
-		JSONArray scansJSONArray =
-			_liferayService.getQueuedSEOStudioScansJSONArray();
+		for (Object object :
+				_liferayService.getQueuedSEOStudioScansJSONArray()) {
 
-		for (Object object : scansJSONArray) {
-			JSONObject scanJSONObject = (JSONObject)object;
+			JSONObject seoStudioScanJSONObject = (JSONObject)object;
 
-			long seoStudioScanId = scanJSONObject.getLong("id");
+			long seoStudioScanId = seoStudioScanJSONObject.getLong("id");
 
 			try {
-				_runScan(scanJSONObject, seoStudioScanId);
+				_runScan(seoStudioScanId, seoStudioScanJSONObject);
 			}
 			catch (Exception exception1) {
 				_log.error(
@@ -164,20 +162,20 @@ public class PageSpeedScanService {
 			strategy);
 	}
 
-	private void _runScan(JSONObject scanJSONObject, long seoStudioScanId) {
+	private void _runScan(
+		long seoStudioScanId, JSONObject seoStudioScanJSONObject) {
+
 		_liferayService.patchSEOStudioScan(
 			null, seoStudioScanId, PageSpeedConstants.STATE_RUNNING);
 
-		long seoStudioScanRunId = scanJSONObject.getLong(
-			"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId");
+		JSONObject seoStudioDomainJSONObject =
+			seoStudioScanJSONObject.getJSONObject(
+				"seoStudioScanRun"
+			).getJSONObject(
+				"seoStudioDomain"
+			);
 
-		JSONObject scanRunJSONObject = _liferayService.getScanRunJSONObject(
-			seoStudioScanRunId);
-
-		long domainId = scanRunJSONObject.getLong(
-			"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId");
-
-		Domain domain = _liferayService.getDomain(domainId);
+		Domain domain = new Domain(seoStudioDomainJSONObject);
 
 		String googlePageSpeedAPIKey = domain.getGooglePageSpeedAPIKey();
 
@@ -190,9 +188,8 @@ public class PageSpeedScanService {
 			return;
 		}
 
-		String scopeConfig = scanJSONObject.optString("scopeConfig");
-
-		JSONObject scopeConfigJSONObject = new JSONObject(scopeConfig);
+		JSONObject scopeConfigJSONObject = new JSONObject(
+			seoStudioScanJSONObject.optString("scopeConfig"));
 
 		int maxPagesPerScan = scopeConfigJSONObject.optInt(
 			"maxPagesPerScan", 100);
@@ -200,19 +197,16 @@ public class PageSpeedScanService {
 		List<String> urls = _liferayService.getSitemapPageURLs(
 			domain.getHostname(), maxPagesPerScan);
 
-		PageSpeedScanResult desktopPageSpeedScanResult =
+		_liferayService.postSEOStudioPageSpeedResult(
 			_getPageSpeedScanResult(
 				googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_DESKTOP,
-				urls);
-
+				urls),
+			seoStudioScanId);
 		_liferayService.postSEOStudioPageSpeedResult(
-			desktopPageSpeedScanResult, seoStudioScanId);
-
-		PageSpeedScanResult mobilePageSpeedScanResult = _getPageSpeedScanResult(
-			googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_MOBILE, urls);
-
-		_liferayService.postSEOStudioPageSpeedResult(
-			mobilePageSpeedScanResult, seoStudioScanId);
+			_getPageSpeedScanResult(
+				googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_MOBILE,
+				urls),
+			seoStudioScanId);
 
 		_liferayService.patchSEOStudioScan(
 			null, seoStudioScanId, PageSpeedConstants.STATE_COMPLETED);

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.PageSpeedConstants;
+import com.liferay.seo.studio.model.Domain;
+import com.liferay.seo.studio.model.PageSpeedReport;
+import com.liferay.seo.studio.model.PageSpeedScanResult;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kiana Suetani
+ */
+@Component
+public class PageSpeedScanService {
+
+	@Scheduled(fixedDelay = 30000)
+	public void scheduledProcessQueuedScans() {
+		JSONArray scansJSONArray =
+			_liferayService.getQueuedSEOStudioScansJSONArray();
+
+		for (Object object : scansJSONArray) {
+			JSONObject scanJSONObject = (JSONObject)object;
+
+			long seoStudioScanId = scanJSONObject.getLong("id");
+
+			try {
+				_runScan(scanJSONObject, seoStudioScanId);
+			}
+			catch (Exception exception1) {
+				_log.error(
+					"Unable to run the PageSpeed scan " + seoStudioScanId,
+					exception1);
+
+				try {
+					_liferayService.patchSEOStudioScan(
+						exception1.getMessage(), seoStudioScanId,
+						PageSpeedConstants.STATE_FAILED);
+				}
+				catch (Exception exception2) {
+					_log.error(
+						"Unable to mark the scan " + seoStudioScanId +
+							" as failed",
+						exception2);
+				}
+			}
+		}
+	}
+
+	private PageSpeedReport _getPageSpeedReport(
+		String googlePageSpeedAPIKey, String strategy, String url) {
+
+		try {
+			return _pageSpeedReportService.getPageSpeedReport(
+				googlePageSpeedAPIKey, strategy, url);
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to complete the PageSpeed scan " + url,
+					interruptedException);
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get PageSpeed scores " + url, ioException);
+			}
+
+			return null;
+		}
+	}
+
+	private PageSpeedScanResult _getPageSpeedScanResult(
+		String googlePageSpeedAPIKey, String strategy, List<String> urls) {
+
+		List<CompletableFuture<PageSpeedReport>> completableFutures =
+			TransformUtil.transform(
+				urls,
+				url -> CompletableFuture.supplyAsync(
+					() -> _getPageSpeedReport(
+						googlePageSpeedAPIKey, strategy, url)));
+
+		int pagesErrored = 0;
+
+		List<PageSpeedReport> pageSpeedReports = new ArrayList<>();
+
+		for (CompletableFuture<PageSpeedReport> completableFuture :
+				completableFutures) {
+
+			try {
+				PageSpeedReport pageSpeedReport = completableFuture.join();
+
+				if (pageSpeedReport == null) {
+					pagesErrored++;
+				}
+				else {
+					pageSpeedReports.add(pageSpeedReport);
+				}
+			}
+			catch (Exception exception) {
+				pagesErrored++;
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Unable to add PageSpeed scores", exception);
+				}
+			}
+		}
+
+		int pagesScanned = pageSpeedReports.size();
+
+		if (pagesScanned == 0) {
+			return new PageSpeedScanResult(
+				new PageSpeedReport(0, 0, 0, 0), pagesErrored, pagesScanned,
+				urls.size(), strategy);
+		}
+
+		int totalAccessibility = 0;
+		int totalBestPractices = 0;
+		int totalPerformance = 0;
+		int totalSEO = 0;
+
+		for (PageSpeedReport pageSpeedReport : pageSpeedReports) {
+			totalAccessibility += pageSpeedReport.getAccessibility();
+			totalBestPractices += pageSpeedReport.getBestPractices();
+			totalPerformance += pageSpeedReport.getPerformance();
+			totalSEO += pageSpeedReport.getSEO();
+		}
+
+		PageSpeedReport averagePageSpeedReport = new PageSpeedReport(
+			Math.round((float)totalAccessibility / pagesScanned),
+			Math.round((float)totalBestPractices / pagesScanned),
+			Math.round((float)totalPerformance / pagesScanned),
+			Math.round((float)totalSEO / pagesScanned));
+
+		return new PageSpeedScanResult(
+			averagePageSpeedReport, pagesErrored, pagesScanned, urls.size(),
+			strategy);
+	}
+
+	private void _runScan(JSONObject scanJSONObject, long seoStudioScanId) {
+		_liferayService.patchSEOStudioScan(
+			null, seoStudioScanId, PageSpeedConstants.STATE_RUNNING);
+
+		long seoStudioScanRunId = scanJSONObject.getLong(
+			"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId");
+
+		JSONObject scanRunJSONObject = _liferayService.getScanRunJSONObject(
+			seoStudioScanRunId);
+
+		long domainId = scanRunJSONObject.getLong(
+			"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId");
+
+		Domain domain = _liferayService.getDomain(domainId);
+
+		String googlePageSpeedAPIKey = domain.getGooglePageSpeedAPIKey();
+
+		if (Validator.isNull(googlePageSpeedAPIKey)) {
+			_liferayService.patchSEOStudioScan(
+				"Unable to get a Google PageSpeed API key for SEO Studio " +
+					"instance ID " + domain.getSEOStudioInstanceId(),
+				seoStudioScanId, PageSpeedConstants.STATE_FAILED);
+
+			return;
+		}
+
+		String scopeConfig = scanJSONObject.optString("scopeConfig");
+
+		JSONObject scopeConfigJSONObject = new JSONObject(scopeConfig);
+
+		int maxPagesPerScan = scopeConfigJSONObject.optInt(
+			"maxPagesPerScan", 100);
+
+		List<String> urls = _liferayService.getSitemapPageURLs(
+			domain.getHostname(), maxPagesPerScan);
+
+		PageSpeedScanResult desktopPageSpeedScanResult =
+			_getPageSpeedScanResult(
+				googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_DESKTOP,
+				urls);
+
+		_liferayService.postSEOStudioPageSpeedResult(
+			desktopPageSpeedScanResult, seoStudioScanId);
+
+		PageSpeedScanResult mobilePageSpeedScanResult = _getPageSpeedScanResult(
+			googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_MOBILE, urls);
+
+		_liferayService.postSEOStudioPageSpeedResult(
+			mobilePageSpeedScanResult, seoStudioScanId);
+
+		_liferayService.patchSEOStudioScan(
+			null, seoStudioScanId, PageSpeedConstants.STATE_COMPLETED);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		PageSpeedScanService.class);
+
+	@Autowired
+	private LiferayService _liferayService;
+
+	@Autowired
+	private PageSpeedReportService _pageSpeedReportService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -5,18 +5,21 @@
 
 package com.liferay.seo.studio.service;
 
-import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.PageSpeedConstants;
 import com.liferay.seo.studio.model.Domain;
 import com.liferay.seo.studio.model.PageSpeedReport;
 import com.liferay.seo.studio.model.PageSpeedScanResult;
 
+import jakarta.annotation.PreDestroy;
+
 import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +35,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class PageSpeedScanService {
+
+	@PreDestroy
+	public void preDestroy() {
+		_executorService.shutdown();
+	}
 
 	@Scheduled(fixedDelay = 30000)
 	public void scheduledProcessQueuedScans() {
@@ -98,22 +106,29 @@ public class PageSpeedScanService {
 	private PageSpeedScanResult _getPageSpeedScanResult(
 		String googlePageSpeedAPIKey, String strategy, List<String> urls) {
 
-		List<CompletableFuture<PageSpeedReport>> completableFutures =
-			TransformUtil.transform(
-				urls,
-				url -> CompletableFuture.supplyAsync(
+		List<DefaultNoticeableFuture<PageSpeedReport>>
+			defaultNoticeableFutures = new ArrayList<>();
+
+		for (String url : urls) {
+			DefaultNoticeableFuture<PageSpeedReport> defaultNoticeableFuture =
+				new DefaultNoticeableFuture<>(
 					() -> _getPageSpeedReport(
-						googlePageSpeedAPIKey, strategy, url)));
+						googlePageSpeedAPIKey, strategy, url));
+
+			_executorService.execute(defaultNoticeableFuture);
+
+			defaultNoticeableFutures.add(defaultNoticeableFuture);
+		}
 
 		int pagesErrored = 0;
 
 		List<PageSpeedReport> pageSpeedReports = new ArrayList<>();
 
-		for (CompletableFuture<PageSpeedReport> completableFuture :
-				completableFutures) {
+		for (DefaultNoticeableFuture<PageSpeedReport> defaultNoticeableFuture :
+				defaultNoticeableFutures) {
 
 			try {
-				PageSpeedReport pageSpeedReport = completableFuture.join();
+				PageSpeedReport pageSpeedReport = defaultNoticeableFuture.get();
 
 				if (pageSpeedReport == null) {
 					pagesErrored++;
@@ -214,6 +229,9 @@ public class PageSpeedScanService {
 
 	private static final Log _log = LogFactory.getLog(
 		PageSpeedScanService.class);
+
+	private final ExecutorService _executorService =
+		Executors.newFixedThreadPool(4);
 
 	@Autowired
 	private LiferayService _liferayService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88837

## What Is Being Fixed

SEO Studio has no way to run Google PageSpeed Insights against a domain's pages. When a scan of type `pageSpeed` is queued, nothing acts on it — there is no worker that reads the queued scan, discovers the pages to test, calls the PageSpeed API, and writes results back.

## How It Is Being Fixed

The `liferay-seostudio-etc-pagespeed` CET gains a scheduled poller (`PageSpeedScanService.scheduledProcessQueuedScans`) that runs every 30 seconds. On each tick it queries queued `SEOStudioScan` entries with `nestedFields=seoStudioScanRun,seoStudioDomain,seoStudioInstance&nestedFieldsDepth=3`, so the parent scan run, its domain, and the domain's SEO Studio instance (which carries the Google PageSpeed API key) all trickle down from that single fetch. The poller parses `scopeConfig.maxPagesPerScan` (defaulting to `100`) to bound the sitemap fetch, and runs the sitemap URLs concurrently across both the desktop and mobile strategies on a fixed thread pool via `DefaultNoticeableFuture`. Per-page results are averaged and posted as `SEOStudioPageSpeedResult` entries; whole-scan failures update the scan's `state` and `errorMessage`. The scanner reuses the existing `LiferayService` HTTP helpers and adds `getQueuedSEOStudioScansJSONArray`, `patchSEOStudioScan`, and `postSEOStudioPageSpeedResult`, following the naming and shape conventions established by the sibling `etc-crawler` CET.

## Why Are There No Tests?

Workspace CETs are covered by E2E tests in the portal's main test suite; CET-local tests are rejected per workspace convention.

## PR Check

**pr-check: PASS** — tested on `4b07935842f20540caef622a93afc0a4a53f300e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "4b07935842f20540caef622a93afc0a4a53f300e"} -->
