### PR TITLE
LPD-98776 Add object encryption properties to seo-studio-web env

### DIFF
--- a/modules/test/playwright/tests/seo-studio-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/seo-studio-web/main/env/portal-ext.properties
@@ -1,0 +1,3 @@
+feature.flag.LPD-62272=true
+object.encryption.algorithm=AES
+object.encryption.key=D9z5Rwxkn+8SctNWW/q/OA==


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98776

## What Is Being Fixed

The seo-studio-web Playwright tests (parent LPD-96843) were failing because their test environment lacked the object encryption configuration the portal expects at startup.

## How It Is Being Fixed

Adds a portal-ext.properties to the seo-studio-web `main` project env folder, setting object.encryption.algorithm and object.encryption.key so the test bundle boots with the required object encryption configuration.

## Why Are There No Tests?

This change only adds a test-environment configuration file for the existing seo-studio-web Playwright tests. It is test infrastructure, not product code, and is exercised by those tests when they run.

## PR Check

**pr-check: PASS** — tested on `46ea6eb640ab244ad47af5eb287181ee319094ce`

| Validation | Result |
| --- | --- |
| Per-Module Compile | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "46ea6eb640ab244ad47af5eb287181ee319094ce"} -->
