### PR TITLE
LPD-88838 Add PageSpeed object action endpoint and per-strategy errors

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/ObjectActionPageSpeedRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/ObjectActionPageSpeedRestController.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kiana Suetani
+ */
+@RequestMapping("/object/action/pagespeed")
+@RestController
+public class ObjectActionPageSpeedRestController extends BaseRestController {
+
+	@PostMapping
+	public ResponseEntity<String> post(
+		@AuthenticationPrincipal Jwt jwt, @RequestBody String json) {
+
+		log(jwt, _log, json);
+
+		return new ResponseEntity<>(json, HttpStatus.OK);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		ObjectActionPageSpeedRestController.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/constants/PageSpeedConstants.java
@@ -10,6 +10,8 @@ package com.liferay.seo.studio.constants;
  */
 public class PageSpeedConstants {
 
+	public static final String SCAN_TYPE_PAGESPEED = "pageSpeed";
+
 	public static final String STATE_COMPLETED = "completed";
 
 	public static final String STATE_FAILED = "failed";

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedResult.java
@@ -8,9 +8,9 @@ package com.liferay.seo.studio.model;
 /**
  * @author Kiana Suetani
  */
-public class PageSpeedScanResult {
+public class PageSpeedResult {
 
-	public PageSpeedScanResult(
+	public PageSpeedResult(
 		PageSpeedReport averagePageSpeedReport, String errorMessage,
 		int pagesErrored, int pagesScanned, int pagesTotal, String strategy) {
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/model/PageSpeedScanResult.java
@@ -11,10 +11,11 @@ package com.liferay.seo.studio.model;
 public class PageSpeedScanResult {
 
 	public PageSpeedScanResult(
-		PageSpeedReport averagePageSpeedReport, int pagesErrored,
-		int pagesScanned, int pagesTotal, String strategy) {
+		PageSpeedReport averagePageSpeedReport, String errorMessage,
+		int pagesErrored, int pagesScanned, int pagesTotal, String strategy) {
 
 		_averagePageSpeedReport = averagePageSpeedReport;
+		_errorMessage = errorMessage;
 		_pagesErrored = pagesErrored;
 		_pagesScanned = pagesScanned;
 		_pagesTotal = pagesTotal;
@@ -23,6 +24,10 @@ public class PageSpeedScanResult {
 
 	public PageSpeedReport getAveragePageSpeedReport() {
 		return _averagePageSpeedReport;
+	}
+
+	public String getErrorMessage() {
+		return _errorMessage;
 	}
 
 	public int getPagesErrored() {
@@ -42,6 +47,7 @@ public class PageSpeedScanResult {
 	}
 
 	private final PageSpeedReport _averagePageSpeedReport;
+	private final String _errorMessage;
 	private final int _pagesErrored;
 	private final int _pagesScanned;
 	private final int _pagesTotal;

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.PageSpeedConstants;
 import com.liferay.seo.studio.model.PageSpeedReport;
-import com.liferay.seo.studio.model.PageSpeedScanResult;
+import com.liferay.seo.studio.model.PageSpeedResult;
 
 import java.io.IOException;
 
@@ -136,10 +136,10 @@ public class LiferayService extends BaseService {
 	}
 
 	public String postSEOStudioPageSpeedResult(
-		PageSpeedScanResult pageSpeedScanResult, long seoStudioScanId) {
+		PageSpeedResult pageSpeedResult, long seoStudioScanId) {
 
 		PageSpeedReport averagePageSpeedReport =
-			pageSpeedScanResult.getAveragePageSpeedReport();
+			pageSpeedResult.getAveragePageSpeedReport();
 
 		JSONObject jsonObject = new JSONObject(
 		).put(
@@ -147,13 +147,13 @@ public class LiferayService extends BaseService {
 		).put(
 			"bestPracticesScore", averagePageSpeedReport.getBestPractices()
 		).put(
-			"errorMessage", pageSpeedScanResult.getErrorMessage()
+			"errorMessage", pageSpeedResult.getErrorMessage()
 		).put(
-			"pagesErrored", pageSpeedScanResult.getPagesErrored()
+			"pagesErrored", pageSpeedResult.getPagesErrored()
 		).put(
-			"pagesScanned", pageSpeedScanResult.getPagesScanned()
+			"pagesScanned", pageSpeedResult.getPagesScanned()
 		).put(
-			"pagesTotal", pageSpeedScanResult.getPagesTotal()
+			"pagesTotal", pageSpeedResult.getPagesTotal()
 		).put(
 			"performanceScore", averagePageSpeedReport.getPerformance()
 		).put(
@@ -162,7 +162,7 @@ public class LiferayService extends BaseService {
 		).put(
 			"seoScore", averagePageSpeedReport.getSEO()
 		).put(
-			"strategy", pageSpeedScanResult.getStrategy()
+			"strategy", pageSpeedResult.getStrategy()
 		);
 
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -87,7 +87,7 @@ public class LiferayService extends BaseService {
 		catch (JSONException jsonException) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to parse the queued scans response", jsonException);
+					"Unable to parse queued scans response", jsonException);
 			}
 
 			return new JSONArray();
@@ -146,9 +146,15 @@ public class LiferayService extends BaseService {
 			"accessibilityScore", averagePageSpeedReport.getAccessibility()
 		).put(
 			"bestPracticesScore", averagePageSpeedReport.getBestPractices()
-		).put(
-			"errorMessage", pageSpeedResult.getErrorMessage()
-		).put(
+		);
+
+		String errorMessage = pageSpeedResult.getErrorMessage();
+
+		if (Validator.isNotNull(errorMessage)) {
+			jsonObject.put("errorMessage", errorMessage);
+		}
+
+		jsonObject.put(
 			"pagesErrored", pageSpeedResult.getPagesErrored()
 		).put(
 			"pagesScanned", pageSpeedResult.getPagesScanned()

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/LiferayService.java
@@ -53,7 +53,10 @@ public class LiferayService extends BaseService {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/c/seostudioscans"
 		).queryParam(
-			"filter", "state eq '" + PageSpeedConstants.STATE_QUEUED + "'"
+			"filter",
+			StringBundler.concat(
+				"scanType eq '", PageSpeedConstants.SCAN_TYPE_PAGESPEED,
+				"' and state eq '", PageSpeedConstants.STATE_QUEUED, "'")
 		).queryParam(
 			"nestedFields", "seoStudioScanRun,seoStudioDomain,seoStudioInstance"
 		).queryParam(
@@ -143,6 +146,8 @@ public class LiferayService extends BaseService {
 			"accessibilityScore", averagePageSpeedReport.getAccessibility()
 		).put(
 			"bestPracticesScore", averagePageSpeedReport.getBestPractices()
+		).put(
+			"errorMessage", pageSpeedScanResult.getErrorMessage()
 		).put(
 			"pagesErrored", pageSpeedScanResult.getPagesErrored()
 		).put(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedReportService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedReportService.java
@@ -6,6 +6,7 @@
 package com.liferay.seo.studio.service;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.model.PageSpeedReport;
 
 import java.io.IOException;
@@ -21,6 +22,13 @@ import java.nio.charset.StandardCharsets;
 
 import java.time.Duration;
 
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.springframework.stereotype.Component;
@@ -38,7 +46,7 @@ public class PageSpeedReportService {
 		HttpResponse<String> httpResponse = _httpClient.send(
 			HttpRequest.newBuilder(
 			).uri(
-				URI.create(_buildURL(apiKey, strategy, url))
+				URI.create(_buildReportURL(apiKey, strategy, url))
 			).timeout(
 				Duration.ofSeconds(60)
 			).GET(
@@ -54,7 +62,61 @@ public class PageSpeedReportService {
 		return _parsePageSpeedReport(httpResponse.body());
 	}
 
-	private String _buildURL(String apiKey, String strategy, String url) {
+	public boolean isValidAPIKey(String apiKey) throws InterruptedException {
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				HttpRequest.newBuilder(
+				).uri(
+					URI.create(_buildValidationURL(apiKey))
+				).timeout(
+					Duration.ofSeconds(30)
+				).GET(
+				).build(),
+				HttpResponse.BodyHandlers.ofString());
+
+			JSONObject responseJSONObject = new JSONObject(httpResponse.body());
+
+			JSONObject errorJSONObject = responseJSONObject.optJSONObject(
+				"error");
+
+			if (errorJSONObject == null) {
+				return true;
+			}
+
+			if (Objects.equals(
+					errorJSONObject.optString("status"), "PERMISSION_DENIED")) {
+
+				return false;
+			}
+
+			JSONArray detailsJSONArray = errorJSONObject.optJSONArray(
+				"details");
+
+			if (detailsJSONArray != null) {
+				for (Object object : detailsJSONArray) {
+					JSONObject detailJSONObject = (JSONObject)object;
+
+					if (Validator.isNotNull(
+							detailJSONObject.optString("reason"))) {
+
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+		catch (IOException | JSONException exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to validate the PageSpeed API key", exception);
+			}
+
+			return false;
+		}
+	}
+
+	private String _buildReportURL(String apiKey, String strategy, String url) {
 		StringBundler sb = new StringBundler(10);
 
 		sb.append("https://content-pagespeedonline.googleapis.com");
@@ -67,6 +129,16 @@ public class PageSpeedReportService {
 		sb.append(strategy);
 		sb.append("&url=");
 		sb.append(URLEncoder.encode(url, StandardCharsets.UTF_8));
+
+		return sb.toString();
+	}
+
+	private String _buildValidationURL(String apiKey) {
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("https://content-pagespeedonline.googleapis.com");
+		sb.append("/pagespeedonline/v5/runPagespeed?url=invalid_url&key=");
+		sb.append(URLEncoder.encode(apiKey, StandardCharsets.UTF_8));
 
 		return sb.toString();
 	}
@@ -93,6 +165,9 @@ public class PageSpeedReportService {
 				categoriesJSONObject.getJSONObject("performance")),
 			_getPageSpeedScore(categoriesJSONObject.getJSONObject("seo")));
 	}
+
+	private static final Log _log = LogFactory.getLog(
+		PageSpeedReportService.class);
 
 	private final HttpClient _httpClient = HttpClient.newBuilder(
 	).connectTimeout(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -55,7 +55,7 @@ public class PageSpeedScanService {
 			}
 			catch (Exception exception1) {
 				_log.error(
-					"Unable to run the PageSpeed scan " + seoStudioScanId,
+					"Unable to run PageSpeed scan " + seoStudioScanId,
 					exception1);
 
 				try {
@@ -65,8 +65,7 @@ public class PageSpeedScanService {
 				}
 				catch (Exception exception2) {
 					_log.error(
-						"Unable to mark the scan " + seoStudioScanId +
-							" as failed",
+						"Unable to mark scan " + seoStudioScanId + " as failed",
 						exception2);
 				}
 			}
@@ -86,12 +85,12 @@ public class PageSpeedScanService {
 			thread.interrupt();
 
 			throw new RuntimeException(
-				"Unable to complete the PageSpeed scan " + url,
+				"Unable to complete PageSpeed scan " + url,
 				interruptedException);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(
-				"Unable to get the PageSpeed scores " + url, ioException);
+				"Unable to get PageSpeed scores " + url, ioException);
 		}
 	}
 
@@ -204,6 +203,25 @@ public class PageSpeedScanService {
 				seoStudioScanId, PageSpeedConstants.STATE_FAILED);
 
 			return;
+		}
+
+		try {
+			if (!_pageSpeedReportService.isValidAPIKey(googlePageSpeedAPIKey)) {
+				_liferayService.patchSEOStudioScan(
+					"Unable to validate Google PageSpeed API key for SEO " +
+						"Studio instance ID " + domain.getSEOStudioInstanceId(),
+					seoStudioScanId, PageSpeedConstants.STATE_FAILED);
+
+				return;
+			}
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			throw new RuntimeException(
+				"Unable to validate PageSpeed API key", interruptedException);
 		}
 
 		JSONObject scopeConfigJSONObject = new JSONObject(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -10,7 +10,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.PageSpeedConstants;
 import com.liferay.seo.studio.model.Domain;
 import com.liferay.seo.studio.model.PageSpeedReport;
-import com.liferay.seo.studio.model.PageSpeedScanResult;
+import com.liferay.seo.studio.model.PageSpeedResult;
 
 import jakarta.annotation.PreDestroy;
 
@@ -95,7 +95,7 @@ public class PageSpeedScanService {
 		}
 	}
 
-	private PageSpeedScanResult _getPageSpeedScanResult(
+	private PageSpeedResult _getPageSpeedResult(
 		String googlePageSpeedAPIKey, String strategy, List<String> urls) {
 
 		List<DefaultNoticeableFuture<PageSpeedReport>>
@@ -152,7 +152,7 @@ public class PageSpeedScanService {
 		int pagesScanned = pageSpeedReports.size();
 
 		if (pagesScanned == 0) {
-			return new PageSpeedScanResult(
+			return new PageSpeedResult(
 				new PageSpeedReport(0, 0, 0, 0), errorMessage, pagesErrored,
 				pagesScanned, urls.size(), strategy);
 		}
@@ -175,7 +175,7 @@ public class PageSpeedScanService {
 			Math.round((float)totalPerformance / pagesScanned),
 			Math.round((float)totalSEO / pagesScanned));
 
-		return new PageSpeedScanResult(
+		return new PageSpeedResult(
 			averagePageSpeedReport, errorMessage, pagesErrored, pagesScanned,
 			urls.size(), strategy);
 	}
@@ -216,12 +216,12 @@ public class PageSpeedScanService {
 			domain.getHostname(), maxPagesPerScan);
 
 		_liferayService.postSEOStudioPageSpeedResult(
-			_getPageSpeedScanResult(
+			_getPageSpeedResult(
 				googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_DESKTOP,
 				urls),
 			seoStudioScanId);
 		_liferayService.postSEOStudioPageSpeedResult(
-			_getPageSpeedScanResult(
+			_getPageSpeedResult(
 				googlePageSpeedAPIKey, PageSpeedConstants.STRATEGY_MOBILE,
 				urls),
 			seoStudioScanId);

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-pagespeed/src/main/java/com/liferay/seo/studio/service/PageSpeedScanService.java
@@ -85,21 +85,13 @@ public class PageSpeedScanService {
 
 			thread.interrupt();
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to complete the PageSpeed scan " + url,
-					interruptedException);
-			}
-
-			return null;
+			throw new RuntimeException(
+				"Unable to complete the PageSpeed scan " + url,
+				interruptedException);
 		}
 		catch (IOException ioException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to get PageSpeed scores " + url, ioException);
-			}
-
-			return null;
+			throw new RuntimeException(
+				"Unable to get the PageSpeed scores " + url, ioException);
 		}
 	}
 
@@ -120,6 +112,7 @@ public class PageSpeedScanService {
 			defaultNoticeableFutures.add(defaultNoticeableFuture);
 		}
 
+		String errorMessage = null;
 		int pagesErrored = 0;
 
 		List<PageSpeedReport> pageSpeedReports = new ArrayList<>();
@@ -128,17 +121,27 @@ public class PageSpeedScanService {
 				defaultNoticeableFutures) {
 
 			try {
-				PageSpeedReport pageSpeedReport = defaultNoticeableFuture.get();
-
-				if (pageSpeedReport == null) {
-					pagesErrored++;
-				}
-				else {
-					pageSpeedReports.add(pageSpeedReport);
-				}
+				pageSpeedReports.add(defaultNoticeableFuture.get());
 			}
 			catch (Exception exception) {
 				pagesErrored++;
+
+				if (exception instanceof InterruptedException) {
+					Thread thread = Thread.currentThread();
+
+					thread.interrupt();
+				}
+
+				if (errorMessage == null) {
+					Throwable throwable = exception.getCause();
+
+					if (throwable != null) {
+						errorMessage = throwable.getMessage();
+					}
+					else {
+						errorMessage = exception.getMessage();
+					}
+				}
 
 				if (_log.isDebugEnabled()) {
 					_log.debug("Unable to add PageSpeed scores", exception);
@@ -150,8 +153,8 @@ public class PageSpeedScanService {
 
 		if (pagesScanned == 0) {
 			return new PageSpeedScanResult(
-				new PageSpeedReport(0, 0, 0, 0), pagesErrored, pagesScanned,
-				urls.size(), strategy);
+				new PageSpeedReport(0, 0, 0, 0), errorMessage, pagesErrored,
+				pagesScanned, urls.size(), strategy);
 		}
 
 		int totalAccessibility = 0;
@@ -173,8 +176,8 @@ public class PageSpeedScanService {
 			Math.round((float)totalSEO / pagesScanned));
 
 		return new PageSpeedScanResult(
-			averagePageSpeedReport, pagesErrored, pagesScanned, urls.size(),
-			strategy);
+			averagePageSpeedReport, errorMessage, pagesErrored, pagesScanned,
+			urls.size(), strategy);
 	}
 
 	private void _runScan(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88838

## What Is Being Fixed

The PageSpeed poller ran against every queued `SEOStudioScan` regardless of scan type, so a queued scan for another integration (e.g. crawler) would still hit the Google PageSpeed API. When calls failed mid-scan, the failure disappeared into a debug log — the `SEOStudioPageSpeedResult` row landed with `errorMessage` unset, giving no signal at the object level. And there was no HTTP surface for Liferay object actions to notify this CET.

## How It Is Being Fixed

`ObjectActionPageSpeedRestController` accepts `POST /object/action/pagespeed` from Liferay's object action webhook, logging the JWT and payload as the foundation for downstream object-action-driven work. `PageSpeedScanService` narrows the poller filter to `scanType eq 'pageSpeed'` (via the new `SCAN_TYPE_PAGESPEED` constant) so only pageSpeed-typed scans are picked up. `_getPageSpeedReport` now throws a `RuntimeException` instead of swallowing IOException/InterruptedException and returning `null`, letting the failure propagate through the `DefaultNoticeableFuture` to a single catch site that captures the first exception's message and stores it on the `PageSpeedScanResult` for persistence via the object endpoint. Finally, `PageSpeedScanResult` is renamed to `PageSpeedResult` to match the `SEOStudioPageSpeedResult` object it maps to.

## Why Are There No Tests?

Workspace CETs are covered by E2E tests in the portal's main test suite; CET-local tests are rejected per workspace convention.

## PR Check

**pr-check: PASS** — tested on `8aaff356abf3a651c21fdf27d7b2839b52426d37`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "8aaff356abf3a651c21fdf27d7b2839b52426d37"} -->
