### PR TITLE
LPD-98536 seo-studio-web - Add the AI Hub Cell agent invocation hook

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-web/package.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/package.json
@@ -13,6 +13,7 @@
 		"@clayui/toolbar": "^3.165.0",
 		"@liferay/frontend-data-set-web": "*",
 		"classnames": "2.3.1",
+		"eventsource": "^4.0.0",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0",

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/api.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/api.ts
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EventSource} from 'eventsource';
+import {fetch} from 'frontend-js-web';
+
+const AI_HUB_ENDPOINT = '/o/ai-hub/v1.0';
+
+export type AgentContext = Record<string, unknown>;
+
+interface AuthorizationToken {
+	accessToken: string;
+	serviceURL: string;
+	userToken: string;
+}
+
+async function postAuthorizationToken(): Promise<AuthorizationToken> {
+	const response = await fetch('/o/ai-hub-cell/v1.0/authorization-tokens', {
+		method: 'POST',
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Unable to generate authorization token: ${response.statusText}`
+		);
+	}
+
+	const data = await response.json();
+
+	if (!data?.accessToken) {
+		throw new Error('Unable to generate authorization token');
+	}
+
+	if (!data?.userToken) {
+		throw new Error('Unable to generate user token');
+	}
+
+	if (!data?.serviceURL) {
+		throw new Error('Unable to find service URL');
+	}
+
+	return data;
+}
+
+export async function createAgentInvocationEventSource(): Promise<EventSource> {
+	const authorizationToken = await postAuthorizationToken();
+
+	return new EventSource(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/agent-instances/subscribe`,
+		{
+			fetch: (input, init) =>
+				fetch(input as RequestInfo, {
+					...init,
+					headers: new Headers({
+						Accept: 'text/event-stream',
+						Authorization: `Bearer ${authorizationToken.accessToken}`,
+					}),
+				}),
+			withCredentials: true,
+		}
+	);
+}
+
+export async function postAgentInvocation({
+	agentExternalReferenceCode,
+	context,
+	sseEventSinkKey,
+}: {
+	agentExternalReferenceCode: string;
+	context: AgentContext;
+	sseEventSinkKey: string;
+}): Promise<Response> {
+	const authorizationToken = await postAuthorizationToken();
+
+	const response = await fetch(
+		`${authorizationToken.serviceURL}${AI_HUB_ENDPOINT}/agent-instances`,
+		{
+			body: JSON.stringify({
+				agentDefinitionExternalReferenceCode:
+					agentExternalReferenceCode,
+				context,
+				sseEventSinkKey,
+			}),
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${authorizationToken.accessToken}`,
+				'Content-Type': 'application/json',
+				'Liferay-AI-Hub-Cell-On-Behalf-Of':
+					authorizationToken.userToken,
+			}),
+			method: 'POST',
+		}
+	);
+
+	if (!response.ok) {
+		throw new Error(`Unable to invoke agent: ${response.statusText}`);
+	}
+
+	return response;
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/invokeAgent.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/invokeAgent.ts
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	AgentContext,
+	createAgentInvocationEventSource,
+	postAgentInvocation,
+} from './api';
+
+export function invokeAgent({
+	agentExternalReferenceCode,
+	context,
+	signal,
+	timeout = 60000,
+}: {
+	agentExternalReferenceCode: string;
+	context: AgentContext;
+	signal?: AbortSignal;
+	timeout?: number;
+}): Promise<string> {
+	return new Promise<string>((resolve, reject) => {
+		let eventSource: EventSource | undefined;
+		let settled = false;
+
+		const timeoutId = setTimeout(() => {
+			settle(() =>
+				reject(new Error('Timed out waiting for the agent response'))
+			);
+		}, timeout);
+
+		function settle(action: () => void) {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+
+			clearTimeout(timeoutId);
+			eventSource?.close();
+
+			action();
+		}
+
+		if (signal) {
+			signal.addEventListener('abort', () => {
+				settle(() =>
+					reject(new Error('The agent invocation was cancelled'))
+				);
+			});
+
+			if (signal.aborted) {
+				settle(() =>
+					reject(new Error('The agent invocation was cancelled'))
+				);
+
+				return;
+			}
+		}
+
+		createAgentInvocationEventSource().then(
+			(createdEventSource) => {
+				if (settled) {
+					createdEventSource.close();
+
+					return;
+				}
+
+				eventSource = createdEventSource;
+
+				eventSource.addEventListener('error', () => {
+					settle(() =>
+						reject(new Error('Unable to connect to the agent'))
+					);
+				});
+
+				// The SSE event is named after the agent's external reference
+				// code.
+
+				eventSource.addEventListener(
+					agentExternalReferenceCode,
+					(event) => {
+						try {
+							const {data} = JSON.parse(event.data);
+
+							settle(() => resolve(data ?? ''));
+						}
+						catch (error) {
+							settle(() => reject(error as Error));
+						}
+					},
+					{once: true}
+				);
+
+				eventSource.addEventListener(
+					'Subscribe',
+					(event) => {
+						postAgentInvocation({
+							agentExternalReferenceCode,
+							context,
+							sseEventSinkKey: event.data,
+						}).catch((error) => {
+							settle(() => reject(error));
+						});
+					},
+					{once: true}
+				);
+			},
+			(error) => {
+				settle(() => reject(error));
+			}
+		);
+	});
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/invokeAgent.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/js/agent/invokeAgent.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {EventSource} from 'eventsource';
+
 import {
 	AgentContext,
 	createAgentInvocationEventSource,
@@ -44,23 +46,23 @@ export function invokeAgent({
 		}
 
 		if (signal) {
-			signal.addEventListener('abort', () => {
+			const handleAbort = () => {
 				settle(() =>
 					reject(new Error('The agent invocation was cancelled'))
 				);
-			});
+			};
+
+			signal.addEventListener('abort', handleAbort, {once: true});
 
 			if (signal.aborted) {
-				settle(() =>
-					reject(new Error('The agent invocation was cancelled'))
-				);
+				handleAbort();
 
 				return;
 			}
 		}
 
-		createAgentInvocationEventSource().then(
-			(createdEventSource) => {
+		createAgentInvocationEventSource()
+			.then((createdEventSource) => {
 				if (settled) {
 					createdEventSource.close();
 
@@ -69,11 +71,19 @@ export function invokeAgent({
 
 				eventSource = createdEventSource;
 
-				eventSource.addEventListener('error', () => {
-					settle(() =>
-						reject(new Error('Unable to connect to the agent'))
-					);
-				});
+				eventSource.addEventListener(
+					'Subscribe',
+					(event) => {
+						postAgentInvocation({
+							agentExternalReferenceCode,
+							context,
+							sseEventSinkKey: event.data,
+						}).catch((error) => {
+							settle(() => reject(error));
+						});
+					},
+					{once: true}
+				);
 
 				// The SSE event is named after the agent's external reference
 				// code.
@@ -93,23 +103,21 @@ export function invokeAgent({
 					{once: true}
 				);
 
-				eventSource.addEventListener(
-					'Subscribe',
-					(event) => {
-						postAgentInvocation({
-							agentExternalReferenceCode,
-							context,
-							sseEventSinkKey: event.data,
-						}).catch((error) => {
-							settle(() => reject(error));
-						});
-					},
-					{once: true}
-				);
-			},
-			(error) => {
+				// A transient reconnect also fires "error" with readyState
+				// CONNECTING; only a CLOSED connection has actually failed.
+
+				eventSource.addEventListener('error', () => {
+					if (eventSource?.readyState !== EventSource.CLOSED) {
+						return;
+					}
+
+					settle(() =>
+						reject(new Error('Unable to connect to the agent'))
+					);
+				});
+			})
+			.catch((error) => {
 				settle(() => reject(error));
-			}
-		);
+			});
 	});
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/api.spec.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/api.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EventSource} from 'eventsource';
+
+import {
+	createAgentInvocationEventSource,
+	postAgentInvocation,
+} from '../../../js/agent/api';
+
+const mockFetch = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	fetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+jest.mock('eventsource', () => ({EventSource: jest.fn()}));
+
+const randomString = () => Math.random().toString(36).slice(2, 10);
+
+const AGENT_EXTERNAL_REFERENCE_CODE = 'L_TITLE_GENERATOR';
+
+const AUTHORIZATION_TOKEN = {
+	accessToken: randomString(),
+	serviceURL: 'http://localhost:8080',
+	userToken: randomString(),
+};
+
+const AUTHORIZATION_TOKEN_FAILURE_MESSAGE =
+	'Unable to generate authorization token';
+
+const SSE_EVENT_SINK_KEY = 'sink-1';
+
+function mockAuthorizationTokenResponse(ok = true) {
+	mockFetch.mockResolvedValueOnce({
+		json: () => Promise.resolve(AUTHORIZATION_TOKEN),
+		ok,
+		statusText: ok ? 'OK' : 'Unauthorized',
+	});
+}
+
+describe('createAgentInvocationEventSource', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+
+		(EventSource as unknown as jest.Mock).mockReset();
+	});
+
+	it('constructs an EventSource against the authorized service URL', async () => {
+		mockAuthorizationTokenResponse();
+
+		await createAgentInvocationEventSource();
+
+		expect(EventSource).toHaveBeenCalledWith(
+			`${AUTHORIZATION_TOKEN.serviceURL}/o/ai-hub/v1.0/agent-instances/subscribe`,
+			expect.objectContaining({withCredentials: true})
+		);
+	});
+
+	it('throws when the authorization token request fails', async () => {
+		mockAuthorizationTokenResponse(false);
+
+		await expect(createAgentInvocationEventSource()).rejects.toThrow(
+			AUTHORIZATION_TOKEN_FAILURE_MESSAGE
+		);
+	});
+});
+
+describe('postAgentInvocation', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	it('resolves with the response when the request succeeds', async () => {
+		mockAuthorizationTokenResponse();
+
+		const response = {ok: true};
+
+		mockFetch.mockResolvedValueOnce(response);
+
+		await expect(
+			postAgentInvocation({
+				agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+				context: {},
+				sseEventSinkKey: SSE_EVENT_SINK_KEY,
+			})
+		).resolves.toBe(response);
+
+		expect(mockFetch).toHaveBeenNthCalledWith(
+			1,
+			'/o/ai-hub-cell/v1.0/authorization-tokens',
+			expect.objectContaining({method: 'POST'})
+		);
+		expect(mockFetch).toHaveBeenNthCalledWith(
+			2,
+			`${AUTHORIZATION_TOKEN.serviceURL}/o/ai-hub/v1.0/agent-instances`,
+			expect.objectContaining({method: 'POST'})
+		);
+	});
+
+	it('throws when the authorization token request fails', async () => {
+		mockAuthorizationTokenResponse(false);
+
+		await expect(
+			postAgentInvocation({
+				agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+				context: {},
+				sseEventSinkKey: SSE_EVENT_SINK_KEY,
+			})
+		).rejects.toThrow(AUTHORIZATION_TOKEN_FAILURE_MESSAGE);
+	});
+
+	it.each([
+		{
+			field: 'accessToken',
+			message: AUTHORIZATION_TOKEN_FAILURE_MESSAGE,
+		},
+		{field: 'userToken', message: 'Unable to generate user token'},
+		{field: 'serviceURL', message: 'Unable to find service URL'},
+	])(
+		'throws when $field is missing from the authorization token response',
+		async ({field, message}) => {
+			mockFetch.mockResolvedValueOnce({
+				json: () =>
+					Promise.resolve({
+						...AUTHORIZATION_TOKEN,
+						[field]: undefined,
+					}),
+				ok: true,
+				statusText: 'OK',
+			});
+
+			await expect(
+				postAgentInvocation({
+					agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+					context: {},
+					sseEventSinkKey: SSE_EVENT_SINK_KEY,
+				})
+			).rejects.toThrow(message);
+		}
+	);
+
+	it('throws when the agent invocation request fails', async () => {
+		mockAuthorizationTokenResponse();
+
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			statusText: 'Not Found',
+		});
+
+		await expect(
+			postAgentInvocation({
+				agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+				context: {},
+				sseEventSinkKey: SSE_EVENT_SINK_KEY,
+			})
+		).rejects.toThrow('Unable to invoke agent');
+	});
+});

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/invokeAgent.spec.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/invokeAgent.spec.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {EventSource} from 'eventsource';
+
 import {
 	createAgentInvocationEventSource,
 	postAgentInvocation,
@@ -12,7 +14,12 @@ import {invokeAgent} from '../../../js/agent/invokeAgent';
 jest.mock('../../../js/agent/api');
 
 const AGENT_EXTERNAL_REFERENCE_CODE = 'L_TITLE_GENERATOR';
+const AGENT_INVOCATION_FAILURE_MESSAGE =
+	'Agent invocation failed with status 404: Not Found';
 const AGENT_RESPONSE = 'Best Espresso Machines for Home Brewing';
+const AUTHORIZATION_TOKEN_FAILURE_MESSAGE =
+	'Unable to generate authorization token: Unauthorized';
+const ERROR_EVENT_TYPE = 'error';
 const PAGE_CONTENT = 'Espresso machines for home brewing';
 const SSE_EVENT_SINK_KEY = 'sink-1';
 const SUBSCRIBE_EVENT_TYPE = 'Subscribe';
@@ -38,6 +45,7 @@ function createFakeEventSource() {
 		emit(type: string, data: string) {
 			listeners[type]?.({data});
 		},
+		readyState: EventSource.OPEN as number,
 	};
 }
 
@@ -79,7 +87,7 @@ describe('invokeAgent', () => {
 		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
 	});
 
-	it('rejects when the event source fails to connect', async () => {
+	it('rejects when the event source closes', async () => {
 		const fakeEventSource = createFakeEventSource();
 
 		mockCreateAgentInvocationEventSource.mockResolvedValue(
@@ -93,14 +101,44 @@ describe('invokeAgent', () => {
 
 		await Promise.resolve();
 
-		fakeEventSource.emit('error', '');
+		fakeEventSource.readyState = EventSource.CLOSED;
+
+		fakeEventSource.emit(ERROR_EVENT_TYPE, '');
 
 		await expect(promise).rejects.toThrow('Unable to connect to the agent');
 	});
 
+	it('does not reject on a transient reconnect error', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {pageContent: PAGE_CONTENT},
+		});
+
+		await Promise.resolve();
+
+		fakeEventSource.readyState = EventSource.CONNECTING;
+
+		fakeEventSource.emit(ERROR_EVENT_TYPE, '');
+
+		fakeEventSource.emit(SUBSCRIBE_EVENT_TYPE, SSE_EVENT_SINK_KEY);
+
+		fakeEventSource.emit(
+			AGENT_EXTERNAL_REFERENCE_CODE,
+			JSON.stringify({data: AGENT_RESPONSE})
+		);
+
+		await expect(promise).resolves.toBe(AGENT_RESPONSE);
+	});
+
 	it('rejects when the authorization token request fails', async () => {
 		mockCreateAgentInvocationEventSource.mockRejectedValue(
-			new Error('Unable to generate authorization token: Unauthorized')
+			new Error(AUTHORIZATION_TOKEN_FAILURE_MESSAGE)
 		);
 
 		const promise = invokeAgent({
@@ -109,13 +147,13 @@ describe('invokeAgent', () => {
 		});
 
 		await expect(promise).rejects.toThrow(
-			'Unable to generate authorization token: Unauthorized'
+			AUTHORIZATION_TOKEN_FAILURE_MESSAGE
 		);
 	});
 
 	it('rejects immediately when the agent invocation request fails', async () => {
 		mockPostAgentInvocation.mockRejectedValue(
-			new Error('Agent invocation failed with status 404: Not Found')
+			new Error(AGENT_INVOCATION_FAILURE_MESSAGE)
 		);
 
 		const fakeEventSource = createFakeEventSource();
@@ -133,9 +171,7 @@ describe('invokeAgent', () => {
 
 		fakeEventSource.emit(SUBSCRIBE_EVENT_TYPE, SSE_EVENT_SINK_KEY);
 
-		await expect(promise).rejects.toThrow(
-			'Agent invocation failed with status 404: Not Found'
-		);
+		await expect(promise).rejects.toThrow(AGENT_INVOCATION_FAILURE_MESSAGE);
 		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
 	});
 

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/invokeAgent.spec.ts
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/resources/META-INF/resources/tests/js/agent/invokeAgent.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	createAgentInvocationEventSource,
+	postAgentInvocation,
+} from '../../../js/agent/api';
+import {invokeAgent} from '../../../js/agent/invokeAgent';
+
+jest.mock('../../../js/agent/api');
+
+const AGENT_EXTERNAL_REFERENCE_CODE = 'L_TITLE_GENERATOR';
+const AGENT_RESPONSE = 'Best Espresso Machines for Home Brewing';
+const PAGE_CONTENT = 'Espresso machines for home brewing';
+const SSE_EVENT_SINK_KEY = 'sink-1';
+const SUBSCRIBE_EVENT_TYPE = 'Subscribe';
+
+const mockCreateAgentInvocationEventSource =
+	createAgentInvocationEventSource as jest.MockedFunction<
+		typeof createAgentInvocationEventSource
+	>;
+const mockPostAgentInvocation = postAgentInvocation as jest.MockedFunction<
+	typeof postAgentInvocation
+>;
+
+function createFakeEventSource() {
+	const listeners: Record<string, (event: {data: string}) => void> = {};
+
+	return {
+		addEventListener: jest.fn(
+			(type: string, handler: (event: {data: string}) => void) => {
+				listeners[type] = handler;
+			}
+		),
+		close: jest.fn(),
+		emit(type: string, data: string) {
+			listeners[type]?.({data});
+		},
+	};
+}
+
+describe('invokeAgent', () => {
+	beforeEach(() => {
+		mockCreateAgentInvocationEventSource.mockReset();
+		mockPostAgentInvocation.mockReset();
+		mockPostAgentInvocation.mockResolvedValue(undefined as never);
+	});
+
+	it('subscribes, posts the agent instance, and resolves with the agent response', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {pageContent: PAGE_CONTENT},
+		});
+
+		await Promise.resolve();
+
+		fakeEventSource.emit(SUBSCRIBE_EVENT_TYPE, SSE_EVENT_SINK_KEY);
+
+		expect(mockPostAgentInvocation).toHaveBeenCalledWith({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {pageContent: PAGE_CONTENT},
+			sseEventSinkKey: SSE_EVENT_SINK_KEY,
+		});
+
+		fakeEventSource.emit(
+			AGENT_EXTERNAL_REFERENCE_CODE,
+			JSON.stringify({data: AGENT_RESPONSE})
+		);
+
+		await expect(promise).resolves.toBe(AGENT_RESPONSE);
+		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects when the event source fails to connect', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {},
+		});
+
+		await Promise.resolve();
+
+		fakeEventSource.emit('error', '');
+
+		await expect(promise).rejects.toThrow('Unable to connect to the agent');
+	});
+
+	it('rejects when the authorization token request fails', async () => {
+		mockCreateAgentInvocationEventSource.mockRejectedValue(
+			new Error('Unable to generate authorization token: Unauthorized')
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {},
+		});
+
+		await expect(promise).rejects.toThrow(
+			'Unable to generate authorization token: Unauthorized'
+		);
+	});
+
+	it('rejects immediately when the agent invocation request fails', async () => {
+		mockPostAgentInvocation.mockRejectedValue(
+			new Error('Agent invocation failed with status 404: Not Found')
+		);
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {},
+		});
+
+		await Promise.resolve();
+
+		fakeEventSource.emit(SUBSCRIBE_EVENT_TYPE, SSE_EVENT_SINK_KEY);
+
+		await expect(promise).rejects.toThrow(
+			'Agent invocation failed with status 404: Not Found'
+		);
+		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+	});
+
+	it('closes the event source and stops waiting when the signal is aborted', async () => {
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const controller = new AbortController();
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {},
+			signal: controller.signal,
+		});
+
+		controller.abort();
+
+		await expect(promise).rejects.toThrow(
+			'The agent invocation was cancelled'
+		);
+		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects when no response arrives before the timeout', async () => {
+		jest.useFakeTimers();
+
+		const fakeEventSource = createFakeEventSource();
+
+		mockCreateAgentInvocationEventSource.mockResolvedValue(
+			fakeEventSource as never
+		);
+
+		const promise = invokeAgent({
+			agentExternalReferenceCode: AGENT_EXTERNAL_REFERENCE_CODE,
+			context: {},
+			timeout: 1000,
+		});
+
+		promise.catch(() => {});
+
+		jest.advanceTimersByTime(1000);
+
+		await expect(promise).rejects.toThrow(
+			'Timed out waiting for the agent response'
+		);
+		expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+
+		jest.useRealTimers();
+	});
+});


### PR DESCRIPTION
## Summary
The generic AI Hub Cell agent invocation hook (`js/agent/api.ts`, `js/agent/invokeAgent.ts`) that lets seo-studio-web request an authorization token and stream an agent invocation over SSE. This is the frontend API described in LPD-98536.

Scope was deliberately narrowed to just this standalone piece — the Auto Fix panel/service, the write-back endpoint, and the page-content endpoint all live in a shared `SEOStudioAutoFixApplication.java`/`AutoFixPanel.tsx` that also carry Title-tag- and Description-specific wiring (LPD-97011 and its sibling ticket respectively), so those are left for their own tickets.

## Test plan
- [x] `yarn test` on `api.spec.ts` and `invokeAgent.spec.ts` — 11/11 passing
- [x] `liferay build seo-studio-web` — deploys cleanly with the new `eventsource` dependency
- [x] `liferay sf seo-studio-web` — no formatting changes needed