### PR TITLE
LPD-91213 Add orphan page detection and scan status polling

### DIFF
--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/build.gradle
@@ -21,6 +21,7 @@ apply plugin: "org.springframework.boot"
 
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/constants/SEOStudioScanConstants.java
@@ -10,6 +10,8 @@ package com.liferay.seo.studio.constants;
  */
 public class SEOStudioScanConstants {
 
+	public static final String STATE_COMPLETED = "completed";
+
 	public static final String STATE_FAILED = "failed";
 
 	public static final String STATE_RUNNING = "running";

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -68,13 +68,13 @@ public class CrawlerRestController extends BaseRestController {
 			if (domain == null) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to find a domain for SEO Studio domain ID " +
+						"Unable to get a domain for SEO Studio domain ID " +
 							seoStudioDomainId);
 				}
 
 				return ResponseEntity.ok(
 					_seoStudioService.patchScan(
-						"Unable to find a domain for SEO Studio domain ID " +
+						"Unable to get a domain for SEO Studio domain ID " +
 							seoStudioDomainId,
 						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
 			}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -63,7 +63,8 @@ public class CrawlerRestController extends BaseRestController {
 			long seoStudioDomainId = valuesJSONObject.getLong(
 				"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
 
-			Domain domain = _seoStudioService.getDomain(seoStudioDomainId);
+			Domain domain = _seoStudioService.getSEOStudioDomain(
+				seoStudioDomainId);
 
 			if (domain == null) {
 				if (_log.isWarnEnabled()) {
@@ -73,7 +74,7 @@ public class CrawlerRestController extends BaseRestController {
 				}
 
 				return ResponseEntity.ok(
-					_seoStudioService.patchScan(
+					_seoStudioService.patchSEOStudioScan(
 						"Unable to get a domain for SEO Studio domain ID " +
 							seoStudioDomainId,
 						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
@@ -85,7 +86,7 @@ public class CrawlerRestController extends BaseRestController {
 			String canonicalDomainURL = _resolveCanonicalDomainURL(domainURL);
 
 			if (!canonicalDomainURL.equals(domainURL)) {
-				_seoStudioService.patchDomain(
+				_seoStudioService.patchSEOStudioDomain(
 					new JSONObject(
 					).put(
 						"hostname", canonicalDomainURL
@@ -101,12 +102,12 @@ public class CrawlerRestController extends BaseRestController {
 				}
 
 				return ResponseEntity.ok(
-					_seoStudioService.patchScan(
+					_seoStudioService.patchSEOStudioScan(
 						"Unable to reach the sitemap at " + sitemapURL,
 						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
 			}
 
-			_seoStudioService.patchScan(
+			_seoStudioService.patchSEOStudioScan(
 				null, seoStudioScanId, SEOStudioScanConstants.STATE_RUNNING);
 
 			JSONObject scopeConfigJSONObject = new JSONObject(
@@ -122,20 +123,21 @@ public class CrawlerRestController extends BaseRestController {
 
 			ObjectMeta objectMeta = job.getMetadata();
 
-			JSONObject scanJSONObject = new JSONObject(
+			JSONObject seoStudioScanJSONObject = new JSONObject(
 			).put(
 				"executionId", objectMeta.getName()
 			);
 
-			_seoStudioService.patchScan(scanJSONObject, seoStudioScanId);
+			_seoStudioService.patchSEOStudioScan(
+				seoStudioScanJSONObject, seoStudioScanId);
 
-			return ResponseEntity.ok(scanJSONObject.toString());
+			return ResponseEntity.ok(seoStudioScanJSONObject.toString());
 		}
 		catch (Exception exception) {
 			_log.error("Unable to scan the domain", exception);
 
 			return ResponseEntity.ok(
-				_seoStudioService.patchScan(
+				_seoStudioService.patchSEOStudioScan(
 					"Unable to scan the domain: " + exception.getMessage(),
 					seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -8,6 +8,7 @@ package com.liferay.seo.studio.controller;
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.model.Domain;
 import com.liferay.seo.studio.service.KubernetesJobService;
 import com.liferay.seo.studio.service.SEOStudioService;
 
@@ -62,9 +63,9 @@ public class CrawlerRestController extends BaseRestController {
 			long seoStudioDomainId = valuesJSONObject.getLong(
 				"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
 
-			String domainJSON = _seoStudioService.getDomain(seoStudioDomainId);
+			Domain domain = _seoStudioService.getDomain(seoStudioDomainId);
 
-			if (Validator.isNull(domainJSON)) {
+			if (domain == null) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						"Unable to find a domain for SEO Studio domain ID " +
@@ -78,14 +79,8 @@ public class CrawlerRestController extends BaseRestController {
 						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
 			}
 
-			String hostname = new JSONObject(
-				domainJSON
-			).getString(
-				"hostname"
-			);
-
 			String domainURL = _seoStudioService.toDomainURL(
-				_seoStudioService.toCrawlURI(hostname));
+				_seoStudioService.toCrawlURI(domain.getHostname()));
 
 			String canonicalDomainURL = _resolveCanonicalDomainURL(domainURL);
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/controller/CrawlerRestController.java
@@ -69,13 +69,13 @@ public class CrawlerRestController extends BaseRestController {
 			if (domain == null) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to get a domain for SEO Studio domain ID " +
+						"Unable to get a domain for SEO Studio Domain ID " +
 							seoStudioDomainId);
 				}
 
 				return ResponseEntity.ok(
 					_seoStudioService.patchSEOStudioScan(
-						"Unable to get a domain for SEO Studio domain ID " +
+						"Unable to get a domain for SEO Studio Domain ID " +
 							seoStudioDomainId,
 						seoStudioScanId, SEOStudioScanConstants.STATE_FAILED));
 			}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -257,9 +257,8 @@ public abstract class BaseDetector {
 		long seoStudioInsightTypeId, long seoStudioPageId,
 		long seoStudioScanId) {
 
-		JSONObject scanInsightJSONObject = new JSONObject();
-
-		scanInsightJSONObject.put(
+		return new JSONObject(
+		).put(
 			"classification", classification
 		).put(
 			"detectedDate", detectedDateString
@@ -275,8 +274,6 @@ public abstract class BaseDetector {
 			"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
 			seoStudioScanId
 		);
-
-		return scanInsightJSONObject;
 	}
 
 	private static final int _BATCH_SIZE = 100;

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -179,10 +179,10 @@ public abstract class BaseDetector {
 		throws Exception {
 
 		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			JSONArray pagesJSONArray = new JSONArray();
+
 			List<String> batchPageURLs = pageURLs.subList(
 				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
-
-			JSONArray pagesJSONArray = new JSONArray();
 
 			for (String pageURL : batchPageURLs) {
 				pagesJSONArray.put(
@@ -206,10 +206,10 @@ public abstract class BaseDetector {
 		).toString();
 
 		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			JSONArray scanInsightsJSONArray = new JSONArray();
+
 			List<String> batchPageURLs = pageURLs.subList(
 				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
-
-			JSONArray scanInsightsJSONArray = new JSONArray();
 
 			for (String pageURL : batchPageURLs) {
 				Long seoStudioPageId = pageURLToPageIdMap.get(pageURL);

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -145,30 +145,30 @@ public abstract class BaseDetector {
 		long accountEntryId, JSONObject definitionJSONObject,
 		long seoStudioScanId) {
 
-		JSONObject insightTypeJSONObject = new JSONObject();
-
-		insightTypeJSONObject.put(
-			"category", definitionJSONObject.getString("category")
-		).put(
-			"description", definitionJSONObject.optString("description")
-		).put(
-			"externalReferenceCode",
-			definitionJSONObject.getString("name") + "_" + seoStudioScanId
-		).put(
-			"fixHint", definitionJSONObject.optString("fixHint")
-		).put(
-			"name", definitionJSONObject.getString("name")
-		).put(
-			"r_accountToSEOStudioInsightTypes_accountEntryId", accountEntryId
-		).put(
-			"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
-			seoStudioScanId
-		).put(
-			"severity", definitionJSONObject.getString("severity")
-		);
-
 		return new JSONObject(
-			seoStudioService.postInsightType(insightTypeJSONObject)
+			seoStudioService.postInsightType(
+				new JSONObject(
+				).put(
+					"category", definitionJSONObject.getString("category")
+				).put(
+					"description", definitionJSONObject.optString("description")
+				).put(
+					"externalReferenceCode",
+					definitionJSONObject.getString("name") + "_" +
+						seoStudioScanId
+				).put(
+					"fixHint", definitionJSONObject.optString("fixHint")
+				).put(
+					"name", definitionJSONObject.getString("name")
+				).put(
+					"r_accountToSEOStudioInsightTypes_accountEntryId",
+					accountEntryId
+				).put(
+					"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+					seoStudioScanId
+				).put(
+					"severity", definitionJSONObject.getString("severity")
+				))
 		).getLong(
 			"id"
 		);

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -1,0 +1,289 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.detector;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.service.SEOStudioService;
+
+import java.net.URI;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Noor Najjar
+ */
+public abstract class BaseDetector {
+
+	public abstract void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI crawlURI,
+			long seoStudioScanId)
+		throws Exception;
+
+	protected void postInsights(
+			long accountEntryId, JSONObject definitionJSONObject,
+			List<String> pageURLs, Map<String, Long> pageURLToPageIdMap,
+			long seoStudioScanId)
+		throws Exception {
+
+		if (ListUtil.isEmpty(pageURLs)) {
+			return;
+		}
+
+		long seoStudioInsightTypeId = _postInsightType(
+			accountEntryId, definitionJSONObject, seoStudioScanId);
+
+		_postScanInsights(
+			accountEntryId, definitionJSONObject.getString("classification"),
+			pageURLs, pageURLToPageIdMap, seoStudioInsightTypeId,
+			seoStudioScanId);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Posted ", pageURLs.size(), " ",
+					definitionJSONObject.getString("name"),
+					" scan insights for insight type ",
+					seoStudioInsightTypeId));
+		}
+	}
+
+	protected Map<String, Long> resolvePageIds(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		Map<String, Long> pageURLToPageIdMap = _getPages(seoStudioScanId);
+
+		List<String> missingPageURLs = ListUtil.filter(
+			pageURLs, pageURL -> !pageURLToPageIdMap.containsKey(pageURL));
+
+		if (ListUtil.isEmpty(missingPageURLs)) {
+			return pageURLToPageIdMap;
+		}
+
+		_postPages(accountEntryId, missingPageURLs, seoStudioScanId);
+
+		long deadline = System.currentTimeMillis() + 60000;
+
+		while (true) {
+			Set<String> existingPageURLs = pageURLToPageIdMap.keySet();
+
+			if (existingPageURLs.containsAll(pageURLs)) {
+				break;
+			}
+
+			if (System.currentTimeMillis() > deadline) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Timed out waiting for pages to be readable for scan " +
+							seoStudioScanId);
+				}
+
+				break;
+			}
+
+			Thread.sleep(1000);
+
+			pageURLToPageIdMap.putAll(_getPages(seoStudioScanId));
+		}
+
+		return pageURLToPageIdMap;
+	}
+
+	@Autowired
+	protected SEOStudioService seoStudioService;
+
+	private Map<String, Long> _getPages(long seoStudioScanId) {
+		Map<String, Long> pageURLToPageIdMap = new HashMap<>();
+
+		int page = 1;
+
+		while (true) {
+			JSONArray itemsJSONArray = new JSONObject(
+				seoStudioService.getPage(page, 2000, seoStudioScanId)
+			).optJSONArray(
+				"items"
+			);
+
+			if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+				break;
+			}
+
+			for (Object object : itemsJSONArray) {
+				JSONObject itemJSONObject = (JSONObject)object;
+
+				pageURLToPageIdMap.put(
+					itemJSONObject.getString("pageURL"),
+					itemJSONObject.getLong("id"));
+			}
+
+			page++;
+		}
+
+		return pageURLToPageIdMap;
+	}
+
+	private long _postInsightType(
+		long accountEntryId, JSONObject definitionJSONObject,
+		long seoStudioScanId) {
+
+		JSONObject insightTypeJSONObject = new JSONObject();
+
+		insightTypeJSONObject.put(
+			"category", definitionJSONObject.getString("category")
+		).put(
+			"description", definitionJSONObject.optString("description")
+		).put(
+			"externalReferenceCode",
+			definitionJSONObject.getString("name") + "_" + seoStudioScanId
+		).put(
+			"fixHint", definitionJSONObject.optString("fixHint")
+		).put(
+			"name", definitionJSONObject.getString("name")
+		).put(
+			"r_accountToSEOStudioInsightTypes_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioInsightTypes_seoStudioScanId",
+			seoStudioScanId
+		).put(
+			"severity", definitionJSONObject.getString("severity")
+		);
+
+		return new JSONObject(
+			seoStudioService.postInsightType(insightTypeJSONObject)
+		).getLong(
+			"id"
+		);
+	}
+
+	private void _postPages(
+			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
+		throws Exception {
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray pagesJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				pagesJSONArray.put(
+					_toPageJSONObject(
+						accountEntryId, pageURL, seoStudioScanId));
+			}
+
+			seoStudioService.postPagesBatch(pagesJSONArray);
+		}
+	}
+
+	private void _postScanInsights(
+			long accountEntryId, String classification, List<String> pageURLs,
+			Map<String, Long> pageURLToPageIdMap, long seoStudioInsightTypeId,
+			long seoStudioScanId)
+		throws Exception {
+
+		String detectedDateString = Instant.now(
+		).truncatedTo(
+			ChronoUnit.SECONDS
+		).toString();
+
+		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
+			List<String> batchPageURLs = pageURLs.subList(
+				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
+
+			JSONArray scanInsightsJSONArray = new JSONArray();
+
+			for (String pageURL : batchPageURLs) {
+				Long seoStudioPageId = pageURLToPageIdMap.get(pageURL);
+
+				if (seoStudioPageId == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to find a page for URL " + pageURL +
+								"; skipping scan insight");
+					}
+
+					continue;
+				}
+
+				scanInsightsJSONArray.put(
+					_toScanInsightJSONObject(
+						accountEntryId, classification, detectedDateString,
+						seoStudioInsightTypeId, seoStudioPageId,
+						seoStudioScanId));
+			}
+
+			if (scanInsightsJSONArray.isEmpty()) {
+				continue;
+			}
+
+			seoStudioService.postScanInsightsBatch(scanInsightsJSONArray);
+		}
+	}
+
+	private JSONObject _toPageJSONObject(
+		long accountEntryId, String pageURL, long seoStudioScanId) {
+
+		JSONObject pageJSONObject = new JSONObject();
+
+		pageJSONObject.put(
+			"pageURL", pageURL
+		).put(
+			"r_accountToSEOStudioPages_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioScanToSEOStudioPages_seoStudioScanId", seoStudioScanId
+		);
+
+		return pageJSONObject;
+	}
+
+	private JSONObject _toScanInsightJSONObject(
+		long accountEntryId, String classification, String detectedDateString,
+		long seoStudioInsightTypeId, long seoStudioPageId,
+		long seoStudioScanId) {
+
+		JSONObject scanInsightJSONObject = new JSONObject();
+
+		scanInsightJSONObject.put(
+			"classification", classification
+		).put(
+			"detectedDate", detectedDateString
+		).put(
+			"r_accountToSEOStudioScanInsights_accountEntryId", accountEntryId
+		).put(
+			"r_seoStudioInsightTypeToScanInsights_seoStudioInsightTypeId",
+			seoStudioInsightTypeId
+		).put(
+			"r_seoStudioPageToSEOStudioScanInsights_seoStudioPageId",
+			seoStudioPageId
+		).put(
+			"r_seoStudioScanToSEOStudioScanInsights_seoStudioScanId",
+			seoStudioScanId
+		);
+
+		return scanInsightJSONObject;
+	}
+
+	private static final int _BATCH_SIZE = 100;
+
+	private static final Log _log = LogFactory.getLog(BaseDetector.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -38,9 +38,9 @@ public abstract class BaseDetector {
 			long seoStudioScanId)
 		throws Exception;
 
-	protected void postInsights(
+	protected void postSEOStudioScanInsights(
 			long accountEntryId, JSONObject definitionJSONObject,
-			List<String> pageURLs, Map<String, Long> pageIds,
+			List<String> pageURLs, Map<String, Long> seoStudioPageIds,
 			long seoStudioScanId)
 		throws Exception {
 
@@ -48,12 +48,12 @@ public abstract class BaseDetector {
 			return;
 		}
 
-		long seoStudioInsightTypeId = _postInsightType(
+		long seoStudioInsightTypeId = _postSEOStudioInsightType(
 			accountEntryId, definitionJSONObject, seoStudioScanId);
 
-		_postScanInsights(
+		_postSEOStudioScanInsights(
 			accountEntryId, definitionJSONObject.getString("classification"),
-			pageURLs, pageIds, seoStudioInsightTypeId,
+			pageURLs, seoStudioInsightTypeId, seoStudioPageIds,
 			seoStudioScanId);
 
 		if (_log.isInfoEnabled()) {
@@ -66,25 +66,26 @@ public abstract class BaseDetector {
 		}
 	}
 
-	protected Map<String, Long> resolvePageIds(
+	protected Map<String, Long> resolveSEOStudioPageIds(
 			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
 		throws Exception {
 
-		Map<String, Long> pageIds = _getPageIds(seoStudioScanId);
+		Map<String, Long> seoStudioPageIds = _getSEOStudioPageIds(
+			seoStudioScanId);
 
 		List<String> missingPageURLs = ListUtil.filter(
-			pageURLs, pageURL -> !pageIds.containsKey(pageURL));
+			pageURLs, pageURL -> !seoStudioPageIds.containsKey(pageURL));
 
 		if (ListUtil.isEmpty(missingPageURLs)) {
-			return pageIds;
+			return seoStudioPageIds;
 		}
 
-		_postPages(accountEntryId, missingPageURLs, seoStudioScanId);
+		_postSEOStudioPages(accountEntryId, missingPageURLs, seoStudioScanId);
 
 		long deadline = System.currentTimeMillis() + 60000;
 
 		while (true) {
-			Set<String> existingPageURLs = pageIds.keySet();
+			Set<String> existingPageURLs = seoStudioPageIds.keySet();
 
 			if (existingPageURLs.containsAll(pageURLs)) {
 				break;
@@ -102,23 +103,23 @@ public abstract class BaseDetector {
 
 			Thread.sleep(1000);
 
-			pageIds.putAll(_getPageIds(seoStudioScanId));
+			seoStudioPageIds.putAll(_getSEOStudioPageIds(seoStudioScanId));
 		}
 
-		return pageIds;
+		return seoStudioPageIds;
 	}
 
 	@Autowired
 	protected SEOStudioService seoStudioService;
 
-	private Map<String, Long> _getPageIds(long seoStudioScanId) {
-		Map<String, Long> pageIds = new HashMap<>();
+	private Map<String, Long> _getSEOStudioPageIds(long seoStudioScanId) {
+		Map<String, Long> seoStudioPageIds = new HashMap<>();
 
 		int page = 1;
 
 		while (true) {
 			JSONArray itemsJSONArray = new JSONObject(
-				seoStudioService.getPage(page, 2000, seoStudioScanId)
+				seoStudioService.getSEOStudioPages(page, 2000, seoStudioScanId)
 			).optJSONArray(
 				"items"
 			);
@@ -130,7 +131,7 @@ public abstract class BaseDetector {
 			for (Object object : itemsJSONArray) {
 				JSONObject itemJSONObject = (JSONObject)object;
 
-				pageIds.put(
+				seoStudioPageIds.put(
 					itemJSONObject.getString("pageURL"),
 					itemJSONObject.getLong("id"));
 			}
@@ -138,15 +139,15 @@ public abstract class BaseDetector {
 			page++;
 		}
 
-		return pageIds;
+		return seoStudioPageIds;
 	}
 
-	private long _postInsightType(
+	private long _postSEOStudioInsightType(
 		long accountEntryId, JSONObject definitionJSONObject,
 		long seoStudioScanId) {
 
 		return new JSONObject(
-			seoStudioService.postInsightType(
+			seoStudioService.postSEOStudioInsightType(
 				new JSONObject(
 				).put(
 					"category", definitionJSONObject.getString("category")
@@ -174,29 +175,29 @@ public abstract class BaseDetector {
 		);
 	}
 
-	private void _postPages(
+	private void _postSEOStudioPages(
 			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
 		throws Exception {
 
 		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
-			JSONArray pagesJSONArray = new JSONArray();
+			JSONArray seoStudioPagesJSONArray = new JSONArray();
 
 			List<String> batchPageURLs = pageURLs.subList(
 				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
 
 			for (String pageURL : batchPageURLs) {
-				pagesJSONArray.put(
-					_toPageJSONObject(
+				seoStudioPagesJSONArray.put(
+					_toSEOStudioPageJSONObject(
 						accountEntryId, pageURL, seoStudioScanId));
 			}
 
-			seoStudioService.postPagesBatch(pagesJSONArray);
+			seoStudioService.postSEOStudioPagesBatch(seoStudioPagesJSONArray);
 		}
 	}
 
-	private void _postScanInsights(
+	private void _postSEOStudioScanInsights(
 			long accountEntryId, String classification, List<String> pageURLs,
-			Map<String, Long> pageIds, long seoStudioInsightTypeId,
+			long seoStudioInsightTypeId, Map<String, Long> seoStudioPageIds,
 			long seoStudioScanId)
 		throws Exception {
 
@@ -206,13 +207,13 @@ public abstract class BaseDetector {
 		).toString();
 
 		for (int i = 0; i < pageURLs.size(); i += _BATCH_SIZE) {
-			JSONArray scanInsightsJSONArray = new JSONArray();
+			JSONArray seoStudioScanInsightsJSONArray = new JSONArray();
 
 			List<String> batchPageURLs = pageURLs.subList(
 				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
 
 			for (String pageURL : batchPageURLs) {
-				Long seoStudioPageId = pageIds.get(pageURL);
+				Long seoStudioPageId = seoStudioPageIds.get(pageURL);
 
 				if (seoStudioPageId == null) {
 					if (_log.isWarnEnabled()) {
@@ -222,22 +223,23 @@ public abstract class BaseDetector {
 					continue;
 				}
 
-				scanInsightsJSONArray.put(
-					_toScanInsightJSONObject(
+				seoStudioScanInsightsJSONArray.put(
+					_toSEOStudioScanInsightJSONObject(
 						accountEntryId, classification, detectedDateString,
 						seoStudioInsightTypeId, seoStudioPageId,
 						seoStudioScanId));
 			}
 
-			if (scanInsightsJSONArray.isEmpty()) {
+			if (seoStudioScanInsightsJSONArray.isEmpty()) {
 				continue;
 			}
 
-			seoStudioService.postScanInsightsBatch(scanInsightsJSONArray);
+			seoStudioService.postSEOStudioScanInsightsBatch(
+				seoStudioScanInsightsJSONArray);
 		}
 	}
 
-	private JSONObject _toPageJSONObject(
+	private JSONObject _toSEOStudioPageJSONObject(
 		long accountEntryId, String pageURL, long seoStudioScanId) {
 
 		return new JSONObject(
@@ -250,7 +252,7 @@ public abstract class BaseDetector {
 		);
 	}
 
-	private JSONObject _toScanInsightJSONObject(
+	private JSONObject _toSEOStudioScanInsightJSONObject(
 		long accountEntryId, String classification, String detectedDateString,
 		long seoStudioInsightTypeId, long seoStudioPageId,
 		long seoStudioScanId) {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -40,7 +40,7 @@ public abstract class BaseDetector {
 
 	protected void postInsights(
 			long accountEntryId, JSONObject definitionJSONObject,
-			List<String> pageURLs, Map<String, Long> pageURLToPageIdMap,
+			List<String> pageURLs, Map<String, Long> pageIds,
 			long seoStudioScanId)
 		throws Exception {
 
@@ -53,7 +53,7 @@ public abstract class BaseDetector {
 
 		_postScanInsights(
 			accountEntryId, definitionJSONObject.getString("classification"),
-			pageURLs, pageURLToPageIdMap, seoStudioInsightTypeId,
+			pageURLs, pageIds, seoStudioInsightTypeId,
 			seoStudioScanId);
 
 		if (_log.isInfoEnabled()) {
@@ -70,13 +70,13 @@ public abstract class BaseDetector {
 			long accountEntryId, List<String> pageURLs, long seoStudioScanId)
 		throws Exception {
 
-		Map<String, Long> pageURLToPageIdMap = _getPages(seoStudioScanId);
+		Map<String, Long> pageIds = _getPageIds(seoStudioScanId);
 
 		List<String> missingPageURLs = ListUtil.filter(
-			pageURLs, pageURL -> !pageURLToPageIdMap.containsKey(pageURL));
+			pageURLs, pageURL -> !pageIds.containsKey(pageURL));
 
 		if (ListUtil.isEmpty(missingPageURLs)) {
-			return pageURLToPageIdMap;
+			return pageIds;
 		}
 
 		_postPages(accountEntryId, missingPageURLs, seoStudioScanId);
@@ -84,7 +84,7 @@ public abstract class BaseDetector {
 		long deadline = System.currentTimeMillis() + 60000;
 
 		while (true) {
-			Set<String> existingPageURLs = pageURLToPageIdMap.keySet();
+			Set<String> existingPageURLs = pageIds.keySet();
 
 			if (existingPageURLs.containsAll(pageURLs)) {
 				break;
@@ -102,17 +102,17 @@ public abstract class BaseDetector {
 
 			Thread.sleep(1000);
 
-			pageURLToPageIdMap.putAll(_getPages(seoStudioScanId));
+			pageIds.putAll(_getPageIds(seoStudioScanId));
 		}
 
-		return pageURLToPageIdMap;
+		return pageIds;
 	}
 
 	@Autowired
 	protected SEOStudioService seoStudioService;
 
-	private Map<String, Long> _getPages(long seoStudioScanId) {
-		Map<String, Long> pageURLToPageIdMap = new HashMap<>();
+	private Map<String, Long> _getPageIds(long seoStudioScanId) {
+		Map<String, Long> pageIds = new HashMap<>();
 
 		int page = 1;
 
@@ -130,7 +130,7 @@ public abstract class BaseDetector {
 			for (Object object : itemsJSONArray) {
 				JSONObject itemJSONObject = (JSONObject)object;
 
-				pageURLToPageIdMap.put(
+				pageIds.put(
 					itemJSONObject.getString("pageURL"),
 					itemJSONObject.getLong("id"));
 			}
@@ -138,7 +138,7 @@ public abstract class BaseDetector {
 			page++;
 		}
 
-		return pageURLToPageIdMap;
+		return pageIds;
 	}
 
 	private long _postInsightType(
@@ -196,7 +196,7 @@ public abstract class BaseDetector {
 
 	private void _postScanInsights(
 			long accountEntryId, String classification, List<String> pageURLs,
-			Map<String, Long> pageURLToPageIdMap, long seoStudioInsightTypeId,
+			Map<String, Long> pageIds, long seoStudioInsightTypeId,
 			long seoStudioScanId)
 		throws Exception {
 
@@ -212,7 +212,7 @@ public abstract class BaseDetector {
 				i, Math.min(i + _BATCH_SIZE, pageURLs.size()));
 
 			for (String pageURL : batchPageURLs) {
-				Long seoStudioPageId = pageURLToPageIdMap.get(pageURL);
+				Long seoStudioPageId = pageIds.get(pageURL);
 
 				if (seoStudioPageId == null) {
 					if (_log.isWarnEnabled()) {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -216,9 +216,7 @@ public abstract class BaseDetector {
 
 				if (seoStudioPageId == null) {
 					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to find a page for URL " + pageURL +
-								"; skipping scan insight");
+						_log.warn("Unable to get a page for URL " + pageURL);
 					}
 
 					continue;

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -242,17 +242,14 @@ public abstract class BaseDetector {
 	private JSONObject _toPageJSONObject(
 		long accountEntryId, String pageURL, long seoStudioScanId) {
 
-		JSONObject pageJSONObject = new JSONObject();
-
-		pageJSONObject.put(
+		return new JSONObject(
+		).put(
 			"pageURL", pageURL
 		).put(
 			"r_accountToSEOStudioPages_accountEntryId", accountEntryId
 		).put(
 			"r_seoStudioScanToSEOStudioPages_seoStudioScanId", seoStudioScanId
 		);
-
-		return pageJSONObject;
 	}
 
 	private JSONObject _toScanInsightJSONObject(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/BaseDetector.java
@@ -61,7 +61,7 @@ public abstract class BaseDetector {
 				StringBundler.concat(
 					"Posted ", pageURLs.size(), " ",
 					definitionJSONObject.getString("name"),
-					" scan insights for insight type ",
+					" SEO Studio Scan Insights for SEO Studio Insight Type ID ",
 					seoStudioInsightTypeId));
 		}
 	}
@@ -94,8 +94,8 @@ public abstract class BaseDetector {
 			if (System.currentTimeMillis() > deadline) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Timed out waiting for pages to be readable for scan " +
-							seoStudioScanId);
+						"Timed out waiting for pages to be readable for SEO " +
+							"Studio Scan ID " + seoStudioScanId);
 				}
 
 				break;

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
@@ -82,9 +82,8 @@ public class OrphanPagesDetector extends BaseDetector {
 			return;
 		}
 
-		JSONObject definitionJSONObject = new JSONObject();
-
-		definitionJSONObject.put(
+		JSONObject definitionJSONObject = new JSONObject(
+		).put(
 			"category", "linksAndURLs"
 		).put(
 			"classification", "problem"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
@@ -109,9 +109,10 @@ public class OrphanPagesDetector extends BaseDetector {
 			"severity", "2"
 		);
 
-		postInsights(
+		postSEOStudioScanInsights(
 			accountEntryId, definitionJSONObject, orphanPageURLs,
-			resolvePageIds(accountEntryId, orphanPageURLs, seoStudioScanId),
+			resolveSEOStudioPageIds(
+				accountEntryId, orphanPageURLs, seoStudioScanId),
 			seoStudioScanId);
 	}
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.detector;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.model.CrawlHit;
+
+import java.net.URI;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Brooke Dalton
+ */
+@Component
+public class OrphanPagesDetector extends BaseDetector {
+
+	@Override
+	public void detect(
+			long accountEntryId, List<CrawlHit> crawlHits, URI crawlURI,
+			long seoStudioScanId)
+		throws Exception {
+
+		Set<String> canonicalURLs = new LinkedHashSet<>();
+		Set<String> linkedURLs = new HashSet<>();
+
+		for (CrawlHit crawlHit : crawlHits) {
+			String canonicalURL = crawlHit.getCanonicalURL();
+
+			if (Validator.isNull(canonicalURL)) {
+				continue;
+			}
+
+			canonicalURLs.add(canonicalURL);
+
+			for (String linkedURL : crawlHit.getLinks()) {
+				if (Validator.isNotNull(linkedURL) &&
+					!linkedURL.equals(canonicalURL)) {
+
+					linkedURLs.add(linkedURL);
+				}
+			}
+		}
+
+		String domainURL = seoStudioService.toDomainURL(crawlURI);
+
+		List<String> orphanPageURLs = TransformUtil.transform(
+			canonicalURLs,
+			canonicalURL -> {
+				if (canonicalURL.equals(domainURL) ||
+					linkedURLs.contains(canonicalURL)) {
+
+					return null;
+				}
+
+				return canonicalURL;
+			});
+
+		if (ListUtil.isEmpty(orphanPageURLs)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"No orphan pages were detected for scan " +
+						seoStudioScanId);
+			}
+
+			return;
+		}
+
+		JSONObject definitionJSONObject = new JSONObject();
+
+		definitionJSONObject.put(
+			"category", "linksAndURLs"
+		).put(
+			"classification", "problem"
+		).put(
+			"description",
+			StringBundler.concat(
+				"This page is published and indexable but has zero internal ",
+				"links pointing to it. Orphan pages are nearly invisible to ",
+				"both users browsing the site and crawlers building the link ",
+				"graph. Even when they are listed in a sitemap, they collect ",
+				"very little ranking authority.")
+		).put(
+			"fixHint",
+			StringBundler.concat(
+				"Identify 2-5 topically related pages and add contextual ",
+				"internal links pointing to the orphan, with descriptive ",
+				"anchor text. If no relevant linking context exists anywhere ",
+				"on the site, that is a signal the page may not belong in the ",
+				"public site at all.")
+		).put(
+			"name", "orphanPages"
+		).put(
+			"severity", "2"
+		);
+
+		postInsights(
+			accountEntryId, definitionJSONObject, orphanPageURLs,
+			resolvePageIds(accountEntryId, orphanPageURLs, seoStudioScanId),
+			seoStudioScanId);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrphanPagesDetector.class);
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/detector/OrphanPagesDetector.java
@@ -75,7 +75,7 @@ public class OrphanPagesDetector extends BaseDetector {
 		if (ListUtil.isEmpty(orphanPageURLs)) {
 			if (_log.isInfoEnabled()) {
 				_log.info(
-					"No orphan pages were detected for scan " +
+					"No orphan pages were detected for SEO Studio Scan ID " +
 						seoStudioScanId);
 			}
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/DetectorResult.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/DetectorResult.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+/**
+ * @author Brooke Dalton
+ */
+public class DetectorResult {
+
+	public DetectorResult(String errorMessage, String state) {
+		_errorMessage = errorMessage;
+		_state = state;
+	}
+
+	public String getErrorMessage() {
+		return _errorMessage;
+	}
+
+	public String getState() {
+		return _state;
+	}
+
+	private final String _errorMessage;
+	private final String _state;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/Domain.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/model/Domain.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brooke Dalton
+ */
+public class Domain {
+
+	public Domain(JSONObject jsonObject) {
+		_hostname = jsonObject.optString("hostname", null);
+	}
+
+	public String getHostname() {
+		return _hostname;
+	}
+
+	private final String _hostname;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.model.DetectorResult;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class CrawlerJobStatusService {
+
+	@Scheduled(fixedDelay = 60000)
+	public void scheduledUpdateStatuses() {
+		JSONArray itemsJSONArray = new JSONObject(
+			_seoStudioService.getActiveScans()
+		).optJSONArray(
+			"items"
+		);
+
+		if (itemsJSONArray == null) {
+			return;
+		}
+
+		for (Object object : itemsJSONArray) {
+			JSONObject scanJSONObject = (JSONObject)object;
+
+			long seoStudioScanId = scanJSONObject.getLong("id");
+
+			try {
+				String executionId = scanJSONObject.optString("executionId");
+
+				if (Validator.isNull(executionId)) {
+					continue;
+				}
+
+				Job job = _kubernetesJobService.getJob(executionId);
+
+				String state = _getScanState(job);
+
+				if (Validator.isNull(state) ||
+					state.equals(scanJSONObject.optString("state"))) {
+
+					continue;
+				}
+
+				if (state.equals(SEOStudioScanConstants.STATE_COMPLETED)) {
+					DetectorResult detectorResult = _detectorService.detect(
+						scanJSONObject, seoStudioScanId);
+
+					_seoStudioService.patchScan(
+						detectorResult.getErrorMessage(), seoStudioScanId,
+						detectorResult.getState());
+				}
+				else if (state.equals(SEOStudioScanConstants.STATE_FAILED)) {
+					_seoStudioService.patchScan(
+						_getErrorMessage(job), seoStudioScanId,
+						SEOStudioScanConstants.STATE_FAILED);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to update status of scan " + seoStudioScanId,
+					exception);
+			}
+		}
+	}
+
+	private String _getErrorMessage(Job job) {
+		if (job == null) {
+			return "Kubernetes job does not exist";
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		List<JobCondition> jobConditions = jobStatus.getConditions();
+
+		if (ListUtil.isEmpty(jobConditions)) {
+			return "Kubernetes job failed";
+		}
+
+		for (JobCondition jobCondition : jobConditions) {
+			if (!Objects.equals(jobCondition.getType(), "Failed") ||
+				!Objects.equals(jobCondition.getStatus(), "True")) {
+
+				continue;
+			}
+
+			String errorMessage = jobCondition.getMessage();
+
+			if (Validator.isNotNull(errorMessage)) {
+				return errorMessage;
+			}
+		}
+
+		return "Kubernetes job failed";
+	}
+
+	private String _getScanState(Job job) {
+		if (job == null) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		if (jobStatus == null) {
+			return null;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getActive()) > 0) {
+			return SEOStudioScanConstants.STATE_RUNNING;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getFailed()) > 0) {
+			return SEOStudioScanConstants.STATE_FAILED;
+		}
+
+		if (GetterUtil.getInteger(jobStatus.getSucceeded()) > 0) {
+			return SEOStudioScanConstants.STATE_COMPLETED;
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerJobStatusService.class);
+
+	@Autowired
+	private DetectorService _detectorService;
+
+	@Autowired
+	private KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -37,7 +37,7 @@ public class CrawlerJobStatusService {
 	@Scheduled(fixedDelay = 60000)
 	public void scheduledUpdateStatuses() {
 		JSONArray itemsJSONArray = new JSONObject(
-			_seoStudioService.getActiveScans()
+			_seoStudioService.getActiveSEOStudioScans()
 		).optJSONArray(
 			"items"
 		);
@@ -47,12 +47,13 @@ public class CrawlerJobStatusService {
 		}
 
 		for (Object object : itemsJSONArray) {
-			JSONObject scanJSONObject = (JSONObject)object;
+			JSONObject seoStudioScanJSONObject = (JSONObject)object;
 
-			long seoStudioScanId = scanJSONObject.getLong("id");
+			long seoStudioScanId = seoStudioScanJSONObject.getLong("id");
 
 			try {
-				String executionId = scanJSONObject.optString("executionId");
+				String executionId = seoStudioScanJSONObject.optString(
+					"executionId");
 
 				if (Validator.isNull(executionId)) {
 					continue;
@@ -60,24 +61,24 @@ public class CrawlerJobStatusService {
 
 				Job job = _kubernetesJobService.getJob(executionId);
 
-				String state = _getScanState(job);
+				String state = _getSEOStudioScanState(job);
 
 				if (Validator.isNull(state) ||
-					state.equals(scanJSONObject.optString("state"))) {
+					state.equals(seoStudioScanJSONObject.optString("state"))) {
 
 					continue;
 				}
 
 				if (state.equals(SEOStudioScanConstants.STATE_COMPLETED)) {
 					DetectorResult detectorResult = _detectorService.detect(
-						scanJSONObject, seoStudioScanId);
+						seoStudioScanId, seoStudioScanJSONObject);
 
-					_seoStudioService.patchScan(
+					_seoStudioService.patchSEOStudioScan(
 						detectorResult.getErrorMessage(), seoStudioScanId,
 						detectorResult.getState());
 				}
 				else if (state.equals(SEOStudioScanConstants.STATE_FAILED)) {
-					_seoStudioService.patchScan(
+					_seoStudioService.patchSEOStudioScan(
 						_getErrorMessage(job), seoStudioScanId,
 						SEOStudioScanConstants.STATE_FAILED);
 				}
@@ -120,7 +121,7 @@ public class CrawlerJobStatusService {
 		return "Kubernetes job failed";
 	}
 
-	private String _getScanState(Job job) {
+	private String _getSEOStudioScanState(Job job) {
 		if (job == null) {
 			return SEOStudioScanConstants.STATE_FAILED;
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/CrawlerJobStatusService.java
@@ -85,7 +85,8 @@ public class CrawlerJobStatusService {
 			}
 			catch (Exception exception) {
 				_log.error(
-					"Unable to update status of scan " + seoStudioScanId,
+					"Unable to update status of SEO Studio Scan ID " +
+						seoStudioScanId,
 					exception);
 			}
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -6,11 +6,11 @@
 package com.liferay.seo.studio.service;
 
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.constants.SEOStudioScanConstants;
 import com.liferay.seo.studio.detector.BaseDetector;
 import com.liferay.seo.studio.model.CrawlHit;
 import com.liferay.seo.studio.model.DetectorResult;
+import com.liferay.seo.studio.model.Domain;
 
 import java.net.URI;
 
@@ -34,9 +34,9 @@ public class DetectorService {
 		long seoStudioDomainId = scanJSONObject.getLong(
 			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
 
-		String domainJSON = _seoStudioService.getDomain(seoStudioDomainId);
+		Domain domain = _seoStudioService.getDomain(seoStudioDomainId);
 
-		if (Validator.isNull(domainJSON)) {
+		if (domain == null) {
 			return new DetectorResult(
 				"Unable to find a domain for SEO Studio domain ID " +
 					seoStudioDomainId,
@@ -56,12 +56,7 @@ public class DetectorService {
 		long accountEntryId = scanJSONObject.getLong(
 			"r_accountToSEOStudioScans_accountEntryId");
 
-		URI crawlURI = _seoStudioService.toCrawlURI(
-			new JSONObject(
-				domainJSON
-			).getString(
-				"hostname"
-			));
+		URI crawlURI = _seoStudioService.toCrawlURI(domain.getHostname());
 
 		for (BaseDetector detector : _detectors) {
 			detector.detect(

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -38,7 +38,7 @@ public class DetectorService {
 
 		if (domain == null) {
 			return new DetectorResult(
-				"Unable to find a domain for SEO Studio domain ID " +
+				"Unable to get a domain for SEO Studio domain ID " +
 					seoStudioDomainId,
 				SEOStudioScanConstants.STATE_FAILED);
 		}
@@ -48,7 +48,7 @@ public class DetectorService {
 
 		if (ListUtil.isEmpty(crawlHits)) {
 			return new DetectorResult(
-				"Unable to find crawl hits for SEO Studio domain ID " +
+				"Unable to get crawl hits for SEO Studio domain ID " +
 					seoStudioDomainId,
 				SEOStudioScanConstants.STATE_FAILED);
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.service;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.constants.SEOStudioScanConstants;
+import com.liferay.seo.studio.detector.BaseDetector;
+import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.model.DetectorResult;
+
+import java.net.URI;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Brooke Dalton
+ */
+@Service
+public class DetectorService {
+
+	public DetectorResult detect(
+			JSONObject scanJSONObject, long seoStudioScanId)
+		throws Exception {
+
+		long seoStudioDomainId = scanJSONObject.getLong(
+			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
+
+		String domainJSON = _seoStudioService.getDomain(seoStudioDomainId);
+
+		if (Validator.isNull(domainJSON)) {
+			return new DetectorResult(
+				"Unable to find a domain for SEO Studio domain ID " +
+					seoStudioDomainId,
+				SEOStudioScanConstants.STATE_FAILED);
+		}
+
+		List<CrawlHit> crawlHits = _seoStudioService.getCrawlHits(
+			seoStudioDomainId);
+
+		if (ListUtil.isEmpty(crawlHits)) {
+			return new DetectorResult(
+				"Unable to find crawl hits for SEO Studio domain ID " +
+					seoStudioDomainId,
+				SEOStudioScanConstants.STATE_FAILED);
+		}
+
+		long accountEntryId = scanJSONObject.getLong(
+			"r_accountToSEOStudioScans_accountEntryId");
+
+		URI crawlURI = _seoStudioService.toCrawlURI(
+			new JSONObject(
+				domainJSON
+			).getString(
+				"hostname"
+			));
+
+		for (BaseDetector detector : _detectors) {
+			detector.detect(
+				accountEntryId, crawlHits, crawlURI, seoStudioScanId);
+		}
+
+		return new DetectorResult(null, SEOStudioScanConstants.STATE_COMPLETED);
+	}
+
+	@Autowired
+	private List<BaseDetector> _detectors;
+
+	@Autowired
+	private SEOStudioService _seoStudioService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -28,13 +28,13 @@ import org.springframework.stereotype.Service;
 public class DetectorService {
 
 	public DetectorResult detect(
-			JSONObject scanJSONObject, long seoStudioScanId)
+			long seoStudioScanId, JSONObject seoStudioScanJSONObject)
 		throws Exception {
 
-		long seoStudioDomainId = scanJSONObject.getLong(
+		long seoStudioDomainId = seoStudioScanJSONObject.getLong(
 			"r_seoStudioDomainToSEOStudioScans_seoStudioDomainId");
 
-		Domain domain = _seoStudioService.getDomain(seoStudioDomainId);
+		Domain domain = _seoStudioService.getSEOStudioDomain(seoStudioDomainId);
 
 		if (domain == null) {
 			return new DetectorResult(
@@ -57,7 +57,7 @@ public class DetectorService {
 
 		for (BaseDetector detector : _detectors) {
 			detector.detect(
-				scanJSONObject.getLong(
+				seoStudioScanJSONObject.getLong(
 					"r_accountToSEOStudioScans_accountEntryId"),
 				crawlHits, crawlURI, seoStudioScanId);
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -53,14 +53,13 @@ public class DetectorService {
 				SEOStudioScanConstants.STATE_FAILED);
 		}
 
-		long accountEntryId = scanJSONObject.getLong(
-			"r_accountToSEOStudioScans_accountEntryId");
-
 		URI crawlURI = _seoStudioService.toCrawlURI(domain.getHostname());
 
 		for (BaseDetector detector : _detectors) {
 			detector.detect(
-				accountEntryId, crawlHits, crawlURI, seoStudioScanId);
+				scanJSONObject.getLong(
+					"r_accountToSEOStudioScans_accountEntryId"),
+				crawlHits, crawlURI, seoStudioScanId);
 		}
 
 		return new DetectorResult(null, SEOStudioScanConstants.STATE_COMPLETED);

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/DetectorService.java
@@ -38,7 +38,7 @@ public class DetectorService {
 
 		if (domain == null) {
 			return new DetectorResult(
-				"Unable to get a domain for SEO Studio domain ID " +
+				"Unable to get a domain for SEO Studio Domain ID " +
 					seoStudioDomainId,
 				SEOStudioScanConstants.STATE_FAILED);
 		}
@@ -48,7 +48,7 @@ public class DetectorService {
 
 		if (ListUtil.isEmpty(crawlHits)) {
 			return new DetectorResult(
-				"Unable to get crawl hits for SEO Studio domain ID " +
+				"Unable to get crawl hits for SEO Studio Domain ID " +
 					seoStudioDomainId,
 				SEOStudioScanConstants.STATE_FAILED);
 		}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -33,7 +33,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class SEOStudioService extends BaseService {
 
-	public String getActiveScans() {
+	public String getActiveSEOStudioScans() {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/scans"
 		).queryParam(
@@ -79,7 +79,7 @@ public class SEOStudioService extends BaseService {
 		return crawlHits;
 	}
 
-	public Domain getDomain(long seoStudioDomainId) {
+	public Domain getSEOStudioDomain(long seoStudioDomainId) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/domains/" + seoStudioDomainId
 		).build();
@@ -93,7 +93,9 @@ public class SEOStudioService extends BaseService {
 		return new Domain(new JSONObject(responseJSON));
 	}
 
-	public String getSEOStudioPage(int page, int pageSize, long seoStudioScanId) {
+	public String getSEOStudioPages(
+		int page, int pageSize, long seoStudioScanId) {
+
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/pages"
 		).queryParam(
@@ -109,7 +111,9 @@ public class SEOStudioService extends BaseService {
 		return get(_getAuthorization(), uriComponents.toUri());
 	}
 
-	public String patchSEOStudioDomain(JSONObject jsonObject, long seoStudioDomainId) {
+	public String patchSEOStudioDomain(
+		JSONObject jsonObject, long seoStudioDomainId) {
+
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/domains/" + seoStudioDomainId
 		).build();
@@ -118,7 +122,9 @@ public class SEOStudioService extends BaseService {
 			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
 	}
 
-	public String patchScan(JSONObject jsonObject, long seoStudioScanId) {
+	public String patchSEOStudioScan(
+		JSONObject jsonObject, long seoStudioScanId) {
+
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/scans/" + seoStudioScanId
 		).build();
@@ -127,7 +133,7 @@ public class SEOStudioService extends BaseService {
 			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
 	}
 
-	public String patchScan(
+	public String patchSEOStudioScan(
 		String errorMessage, long seoStudioScanId, String state) {
 
 		JSONObject jsonObject = new JSONObject();
@@ -138,7 +144,7 @@ public class SEOStudioService extends BaseService {
 
 		jsonObject.put("state", state);
 
-		return patchScan(jsonObject, seoStudioScanId);
+		return patchSEOStudioScan(jsonObject, seoStudioScanId);
 	}
 
 	public String postSEOStudioInsightType(JSONObject jsonObject) {
@@ -150,7 +156,7 @@ public class SEOStudioService extends BaseService {
 			_getAuthorization(), jsonObject.toString(), uriComponents.toUri());
 	}
 
-	public String postPagesBatch(JSONArray jsonArray) {
+	public String postSEOStudioPagesBatch(JSONArray jsonArray) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/pages/batch"
 		).build();
@@ -159,7 +165,7 @@ public class SEOStudioService extends BaseService {
 			_getAuthorization(), jsonArray.toString(), uriComponents.toUri());
 	}
 
-	public String postScanInsightsBatch(JSONArray jsonArray) {
+	public String postSEOStudioScanInsightsBatch(JSONArray jsonArray) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/scan-insights/batch"
 		).build();

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -51,10 +51,11 @@ public class SEOStudioService extends BaseService {
 		String lastURL = null;
 
 		while (true) {
-			JSONObject hitsJSONObject = new JSONObject(
-				_getCrawlHits(lastURL, 2000, seoStudioDomainId));
-
-			JSONArray itemsJSONArray = hitsJSONObject.optJSONArray("items");
+			JSONArray itemsJSONArray = new JSONObject(
+				_getCrawlHits(lastURL, 2000, seoStudioDomainId)
+			).optJSONArray(
+				"items"
+			);
 
 			if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
 				break;

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -93,7 +93,7 @@ public class SEOStudioService extends BaseService {
 		return new Domain(new JSONObject(responseJSON));
 	}
 
-	public String getPage(int page, int pageSize, long seoStudioScanId) {
+	public String getSEOStudioPage(int page, int pageSize, long seoStudioScanId) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/pages"
 		).queryParam(
@@ -109,7 +109,7 @@ public class SEOStudioService extends BaseService {
 		return get(_getAuthorization(), uriComponents.toUri());
 	}
 
-	public String patchDomain(JSONObject jsonObject, long seoStudioDomainId) {
+	public String patchSEOStudioDomain(JSONObject jsonObject, long seoStudioDomainId) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/domains/" + seoStudioDomainId
 		).build();
@@ -141,7 +141,7 @@ public class SEOStudioService extends BaseService {
 		return patchScan(jsonObject, seoStudioScanId);
 	}
 
-	public String postInsightType(JSONObject jsonObject) {
+	public String postSEOStudioInsightType(JSONObject jsonObject) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/insight-types"
 		).build();

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-etc-crawler/src/main/java/com/liferay/seo/studio/service/SEOStudioService.java
@@ -11,6 +11,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.seo.studio.model.CrawlHit;
+import com.liferay.seo.studio.model.Domain;
 
 import java.net.URI;
 
@@ -77,12 +78,18 @@ public class SEOStudioService extends BaseService {
 		return crawlHits;
 	}
 
-	public String getDomain(long seoStudioDomainId) {
+	public Domain getDomain(long seoStudioDomainId) {
 		UriComponents uriComponents = UriComponentsBuilder.fromPath(
 			"/o/seo-studio/domains/" + seoStudioDomainId
 		).build();
 
-		return get(_getAuthorization(), uriComponents.toUri());
+		String responseJSON = get(_getAuthorization(), uriComponents.toUri());
+
+		if (Validator.isNull(responseJSON)) {
+			return null;
+		}
+
+		return new Domain(new JSONObject(responseJSON));
 	}
 
 	public String getPage(int page, int pageSize, long seoStudioScanId) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91213

## What Is Being Fixed

The SEO Studio crawler client extension had no way to react to a scan finishing. Nothing polled the underlying Kubernetes job, so a scan's state was never advanced to completed or failed and no post-crawl analysis ran once the crawl was done. It also lacked any detector for orphan pages, which are published, indexable pages that no other page on the site links to.

## How It Is Being Fixed

Adds a scheduled poller, `CrawlerJobStatusService`, that every 60 seconds inspects the Kubernetes job backing each active scan and patches the scan state accordingly. When a scan completes, it runs `DetectorService`, which executes the detectors and records the result; when the job fails, it records the job's error message on the scan.

Introduces the detector framework (`BaseDetector`, `DetectorService`, `DetectorResult`) and its first detector, `OrphanPagesDetector`. The detector compares each crawled page's canonical URL against the set of URLs that are linked to internally, and reports the pages that nothing links to as SEO scan insights with a description and fix hint.

Also returns a typed `Domain` object instead of raw domain JSON, aligns scan status messages with the JSON object labels, and folds in related inlining and readability refactors.

## PR Check

**pr-check: PASS** — tested on `44111c463c32d8313b7a759ea4706f30968e7d6a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "44111c463c32d8313b7a759ea4706f30968e7d6a"} -->
