### PR TITLE
LPD-93368 Add scheduled scan sweeper for Auto Scan

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v6_5_0/test/CommerceProductStatusUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v6_5_0/test/CommerceProductStatusUpgradeProcessTest.java
@@ -156,6 +156,32 @@ public class CommerceProductStatusUpgradeProcessTest {
 	}
 
 	@Test
+	public void testUpgradeCPOption() throws Exception {
+		CPOption cpOption = CPTestUtil.addCPOption(
+			TestPropsValues.getGroupId(), false);
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update CPOption set status = ? where CPOptionId = ?")) {
+
+			preparedStatement.setInt(1, WorkflowConstants.STATUS_DENIED);
+			preparedStatement.setLong(2, cpOption.getCPOptionId());
+
+			preparedStatement.executeUpdate();
+		}
+
+		_runUpgrade();
+
+		cpOption = _cpOptionLocalService.getCPOption(cpOption.getCPOptionId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, cpOption.getStatus());
+	}
+
+	@Test
 	public void testUpgradeCPOptionCategory() throws Exception {
 		CPOptionCategory cpOptionCategory = CPTestUtil.addCPOptionCategory(
 			TestPropsValues.getGroupId());
@@ -182,32 +208,6 @@ public class CommerceProductStatusUpgradeProcessTest {
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, cpOptionCategory.getStatus());
-	}
-
-	@Test
-	public void testUpgradeCPOption() throws Exception {
-		CPOption cpOption = CPTestUtil.addCPOption(
-			TestPropsValues.getGroupId(), false);
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement =
-				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-					connection,
-					"update CPOption set status = ? where CPOptionId = ?")) {
-
-			preparedStatement.setInt(1, WorkflowConstants.STATUS_DENIED);
-			preparedStatement.setLong(2, cpOption.getCPOptionId());
-
-			preparedStatement.executeUpdate();
-		}
-
-		_runUpgrade();
-
-		cpOption = _cpOptionLocalService.getCPOption(cpOption.getCPOptionId());
-
-		Assert.assertEquals(
-			WorkflowConstants.STATUS_APPROVED, cpOption.getStatus());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
@@ -225,6 +225,7 @@ public class ContentCoverageResourceTest
 		_addContentObjectEntry(
 			new long[] {awarenessAssetCategory.getCategoryId()},
 			new String[] {assetTagName});
+
 		_addContentObjectEntry(
 			new long[] {awarenessAssetCategory.getCategoryId()},
 			new String[] {"L_CMP_TASK_" + RandomTestUtil.randomString(10)});

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-scan-run-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/seo-studio-scan-run-object-definition.json
@@ -47,6 +47,19 @@
 		},
 		{
 			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "SCHEDULED_SCAN_KEY",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Scheduled Scan Key"
+			},
+			"name": "scheduledScanKey",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
 			"businessType": "Picklist",
 			"defaultValue": "running",
 			"externalReferenceCode": "STATE",

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CalculateSEOStudioScanMetricsObjectActionExecutorTest.java
@@ -11,11 +11,8 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -26,6 +23,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -44,7 +42,7 @@ import org.junit.runner.RunWith;
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
 public class CalculateSEOStudioScanMetricsObjectActionExecutorTest
-	extends BaseObjectActionExecutorTestCase {
+	extends BaseSEOStudioTestCase {
 
 	@Before
 	@Override
@@ -336,7 +334,7 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest
 
 	private void _addSEOStudioScanRunObjectEntry() throws Exception {
 		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
-			RandomTestUtil.randomString(), null);
+			false, RandomTestUtil.randomString(), null);
 
 		_seoStudioScanRunObjectEntry = addObjectEntry(
 			_seoStudioScanRunObjectDefinition,
@@ -382,16 +380,9 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest
 			ObjectEntry seoStudioScanRunObjectEntry)
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				_seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-				"seoStudioScanRunToSEOStudioScanMetrics");
-
-		return objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+		return getRelatedObjectEntries(
+			seoStudioScanRunObjectEntry,
+			"seoStudioScanRunToSEOStudioScanMetrics");
 	}
 
 	private String _getState(ObjectEntry objectEntry) throws Exception {
@@ -429,9 +420,6 @@ public class CalculateSEOStudioScanMetricsObjectActionExecutorTest
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	private ObjectDefinition _seoStudioScanObjectDefinition;
 	private ObjectDefinition _seoStudioScanRunObjectDefinition;

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest.java
@@ -6,13 +6,10 @@
 package com.liferay.seo.studio.web.internal.object.action.executor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectEntry;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -29,11 +26,12 @@ import org.junit.runner.RunWith;
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
 public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
-	extends BaseObjectActionExecutorTestCase {
+	extends BaseSEOStudioTestCase {
 
 	@Test
 	public void testExecute() throws Exception {
-		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry();
+		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
+			false, RandomTestUtil.randomString(), null);
 
 		_updateSEOStudioDomainObjectEntry(true);
 
@@ -47,7 +45,8 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 
 	@Test
 	public void testExecuteWithAutoScanDisabled() throws Exception {
-		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry();
+		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
+			false, RandomTestUtil.randomString(), null);
 
 		_updateSEOStudioDomainObjectEntry(false);
 
@@ -57,38 +56,14 @@ public class ComputeSEOStudioDomainNextScanDateObjectActionExecutorTest
 		Assert.assertNull(values.get("nextScanDate"));
 	}
 
-	private ObjectEntry _addSEOStudioDomainObjectEntry() throws Exception {
-		return addObjectEntry(
-			seoStudioDomainObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioDomains_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).put(
-				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				seoStudioInstanceObjectEntry.getObjectEntryId()
-			).build());
-	}
-
 	private void _updateSEOStudioDomainObjectEntry(boolean autoScanEnabled)
 		throws Exception {
 
-		objectEntryLocalService.partialUpdateObjectEntry(
-			TestPropsValues.getUserId(),
-			seoStudioDomainObjectEntry.getObjectEntryId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+		partialUpdateObjectEntry(
+			seoStudioDomainObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"autoScanEnabled", autoScanEnabled
-			).put(
-				"scanFrequency", "daily"
-			).put(
-				"scanTime", "09:00"
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/object/action/executor/test/CreateSEOStudioScansObjectActionExecutorTest.java
@@ -9,19 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -39,7 +36,7 @@ import org.junit.runner.RunWith;
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
 public class CreateSEOStudioScansObjectActionExecutorTest
-	extends BaseObjectActionExecutorTestCase {
+	extends BaseSEOStudioTestCase {
 
 	@Test
 	public void testExecute() throws Exception {
@@ -49,7 +46,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 		String scope = RandomTestUtil.randomString();
 
 		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
-			hostname,
+			false, hostname,
 			JSONUtil.put(
 				"engines",
 				JSONUtil.put(
@@ -75,7 +72,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 		_executeCreateScans();
 
 		ObjectEntry seoStudioScanRunObjectEntry =
-			_fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry);
+			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry);
 
 		Map<String, Serializable> scanRunValues =
 			objectEntryLocalService.getValues(
@@ -95,7 +92,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 			MapUtil.getLong(scanRunValues, "triggeringUserId"));
 
 		List<ObjectEntry> seoStudioScanObjectEntries =
-			_getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
+			getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
 
 		Assert.assertEquals(
 			seoStudioScanObjectEntries.toString(), 3,
@@ -138,7 +135,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 	@Test
 	public void testExecuteWithNoEnabledEngines() throws Exception {
 		seoStudioDomainObjectEntry = addSEOStudioDomainObjectEntry(
-			RandomTestUtil.randomString(),
+			false, RandomTestUtil.randomString(),
 			JSONUtil.put(
 				"engines",
 				JSONUtil.put(
@@ -155,7 +152,7 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 		_executeCreateScans();
 
 		Assert.assertNull(
-			_fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
+			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
 	}
 
 	private void _executeCreateScans() throws Exception {
@@ -173,45 +170,6 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 				).build()
 			),
 			TestPropsValues.getUserId());
-	}
-
-	private ObjectEntry _fetchSEOStudioScanRunObjectEntry(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScanRuns");
-
-		List<ObjectEntry> seoStudioScanRunObjectEntries =
-			objectEntryLocalService.getOneToManyObjectEntries(
-				seoStudioDomainObjectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null, true,
-				seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		if (ListUtil.isEmpty(seoStudioScanRunObjectEntries)) {
-			return null;
-		}
-
-		return seoStudioScanRunObjectEntries.get(0);
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioScanRunObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				seoStudioScanRunObjectEntry.getObjectDefinitionId(),
-				"seoStudioScanRunToSEOStudioScans");
-
-		return objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 	}
 
 	private Map<String, ObjectEntry> _getSEOStudioScanObjectEntryMap(
@@ -237,8 +195,5 @@ public class CreateSEOStudioScansObjectActionExecutorTest
 
 	@Inject
 	private ObjectActionEngine _objectActionEngine;
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
@@ -1,0 +1,290 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scheduler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.seo.studio.web.internal.object.action.executor.test.BaseObjectActionExecutorTestCase;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@FeatureFlag("LPD-44511")
+@RunWith(Arquillian.class)
+public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
+	extends BaseObjectActionExecutorTestCase {
+
+	@Test
+	public void testCheckSEOStudioDomains() throws Exception {
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(true);
+
+		Date nextScanDate = new Date(System.currentTimeMillis() - Time.MINUTE);
+
+		_setNextScanDate(nextScanDate, seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		List<ObjectEntry> seoStudioScanRunObjectEntries =
+			_getSEOStudioScanRunObjectEntries(seoStudioDomainObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanRunObjectEntries.toString(), 1,
+			seoStudioScanRunObjectEntries.size());
+
+		ObjectEntry seoStudioScanRunObjectEntry =
+			seoStudioScanRunObjectEntries.get(0);
+
+		Map<String, Serializable> scanRunValues =
+			objectEntryLocalService.getValues(
+				seoStudioScanRunObjectEntry.getObjectEntryId());
+
+		Assert.assertTrue(
+			Validator.isNotNull(
+				MapUtil.getString(scanRunValues, "scheduledScanKey")));
+		Assert.assertEquals(
+			"running", MapUtil.getString(scanRunValues, "state"));
+		Assert.assertEquals(
+			"scheduled", MapUtil.getString(scanRunValues, "triggeredBy"));
+
+		List<ObjectEntry> seoStudioScanObjectEntries =
+			_getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanObjectEntries.toString(), 2,
+			seoStudioScanObjectEntries.size());
+
+		for (ObjectEntry seoStudioScanObjectEntry :
+				seoStudioScanObjectEntries) {
+
+			Assert.assertEquals(
+				"queued",
+				MapUtil.getString(
+					objectEntryLocalService.getValues(
+						seoStudioScanObjectEntry.getObjectEntryId()),
+					"state"));
+		}
+
+		Map<String, Serializable> domainValues =
+			objectEntryLocalService.getValues(
+				seoStudioDomainObjectEntry.getObjectEntryId());
+
+		Date updatedNextScanDate = (Date)domainValues.get("nextScanDate");
+
+		Assert.assertTrue(updatedNextScanDate.after(new Date()));
+
+		_setNextScanDate(nextScanDate, seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		seoStudioScanRunObjectEntries = _getSEOStudioScanRunObjectEntries(
+			seoStudioDomainObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanRunObjectEntries.toString(), 1,
+			seoStudioScanRunObjectEntries.size());
+
+		seoStudioScanObjectEntries = _getSEOStudioScanObjectEntries(
+			seoStudioScanRunObjectEntry);
+
+		Assert.assertEquals(
+			seoStudioScanObjectEntries.toString(), 2,
+			seoStudioScanObjectEntries.size());
+
+		for (ObjectEntry seoStudioScanObjectEntry :
+				seoStudioScanObjectEntries) {
+
+			_updateSEOStudioScanState(seoStudioScanObjectEntry, "running");
+			_updateSEOStudioScanState(seoStudioScanObjectEntry, "completed");
+		}
+
+		_runJob();
+
+		Assert.assertEquals(
+			"completed",
+			MapUtil.getString(
+				objectEntryLocalService.getValues(
+					seoStudioScanRunObjectEntry.getObjectEntryId()),
+				"state"));
+	}
+
+	@Test
+	public void testCheckSEOStudioDomainsDoesNotCreateScanRun()
+		throws Exception {
+
+		_testCheckSEOStudioDomainsDoesNotCreateScanRun(
+			false, new Date(System.currentTimeMillis() - Time.MINUTE));
+		_testCheckSEOStudioDomainsDoesNotCreateScanRun(
+			true, new Date(System.currentTimeMillis() + Time.MINUTE));
+	}
+
+	private ObjectEntry _addSEOStudioDomainObjectEntry(boolean autoScanEnabled)
+		throws Exception {
+
+		return addObjectEntry(
+			seoStudioDomainObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"autoScanEnabled", autoScanEnabled
+			).put(
+				"hostname", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_accountToSEOStudioDomains_accountEntryId",
+				accountEntry.getAccountEntryId()
+			).put(
+				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
+				seoStudioInstanceObjectEntry.getObjectEntryId()
+			).put(
+				"scanConfig",
+				JSONUtil.put(
+					"engines",
+					JSONUtil.put(
+						"crawler", JSONUtil.put("enabled", true)
+					).put(
+						"pageSpeed", JSONUtil.put("enabled", true)
+					)
+				).toString()
+			).put(
+				"scanFrequency", "daily"
+			).put(
+				"scanTime", "09:00"
+			).build());
+	}
+
+	private ObjectEntry _fetchSEOStudioScanRunObjectEntry(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		List<ObjectEntry> seoStudioScanRunObjectEntries =
+			_getSEOStudioScanRunObjectEntries(seoStudioDomainObjectEntry);
+
+		if (ListUtil.isEmpty(seoStudioScanRunObjectEntries)) {
+			return null;
+		}
+
+		return seoStudioScanRunObjectEntries.get(0);
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioScanRunObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				seoStudioScanRunObjectEntry.getObjectDefinitionId(),
+				"seoStudioScanRunToSEOStudioScans");
+
+		return objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioScanRunObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private List<ObjectEntry> _getSEOStudioScanRunObjectEntries(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				seoStudioDomainObjectDefinition.getObjectDefinitionId(),
+				"seoStudioDomainToSEOStudioScanRuns");
+
+		return objectEntryLocalService.getOneToManyObjectEntries(
+			seoStudioDomainObjectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	private void _runJob() throws Exception {
+		UnsafeRunnable<Exception> unsafeRunnable =
+			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
+
+		unsafeRunnable.run();
+	}
+
+	private void _setNextScanDate(
+			Date nextScanDate, ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(),
+			seoStudioDomainObjectEntry.getObjectEntryId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate", nextScanDate
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _testCheckSEOStudioDomainsDoesNotCreateScanRun(
+			boolean autoScanEnabled, Date nextScanDate)
+		throws Exception {
+
+		seoStudioDomainObjectEntry = _addSEOStudioDomainObjectEntry(
+			autoScanEnabled);
+
+		_setNextScanDate(nextScanDate, seoStudioDomainObjectEntry);
+
+		_runJob();
+
+		Assert.assertNull(
+			_fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
+	}
+
+	private void _updateSEOStudioScanState(
+			ObjectEntry seoStudioScanObjectEntry, String state)
+		throws Exception {
+
+		objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(),
+			seoStudioScanObjectEntry.getObjectEntryId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"state", state
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.seo.studio.web.internal.scheduler.CheckSEOStudioDomainsSchedulerJobConfiguration"
+	)
+	private SchedulerJobConfiguration _schedulerJobConfiguration;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/scheduler/test/CheckSEOStudioDomainsSchedulerJobConfigurationTest.java
@@ -6,25 +6,18 @@
 package com.liferay.seo.studio.web.internal.scheduler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.seo.studio.web.internal.object.action.executor.test.BaseObjectActionExecutorTestCase;
+import com.liferay.seo.studio.web.internal.test.BaseSEOStudioTestCase;
 
 import java.io.Serializable;
 
@@ -42,7 +35,7 @@ import org.junit.runner.RunWith;
 @FeatureFlag("LPD-44511")
 @RunWith(Arquillian.class)
 public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
-	extends BaseObjectActionExecutorTestCase {
+	extends BaseSEOStudioTestCase {
 
 	@Test
 	public void testCheckSEOStudioDomains() throws Exception {
@@ -77,7 +70,7 @@ public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
 			"scheduled", MapUtil.getString(scanRunValues, "triggeredBy"));
 
 		List<ObjectEntry> seoStudioScanObjectEntries =
-			_getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
+			getSEOStudioScanObjectEntries(seoStudioScanRunObjectEntry);
 
 		Assert.assertEquals(
 			seoStudioScanObjectEntries.toString(), 2,
@@ -113,7 +106,7 @@ public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
 			seoStudioScanRunObjectEntries.toString(), 1,
 			seoStudioScanRunObjectEntries.size());
 
-		seoStudioScanObjectEntries = _getSEOStudioScanObjectEntries(
+		seoStudioScanObjectEntries = getSEOStudioScanObjectEntries(
 			seoStudioScanRunObjectEntry);
 
 		Assert.assertEquals(
@@ -150,81 +143,24 @@ public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
 	private ObjectEntry _addSEOStudioDomainObjectEntry(boolean autoScanEnabled)
 		throws Exception {
 
-		return addObjectEntry(
-			seoStudioDomainObjectDefinition,
-			HashMapBuilder.<String, Serializable>put(
-				"autoScanEnabled", autoScanEnabled
-			).put(
-				"hostname", RandomTestUtil.randomString()
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"r_accountToSEOStudioDomains_accountEntryId",
-				accountEntry.getAccountEntryId()
-			).put(
-				"r_seoStudioInstanceToSEOStudioDomains_seoStudioInstanceId",
-				seoStudioInstanceObjectEntry.getObjectEntryId()
-			).put(
-				"scanConfig",
+		return addSEOStudioDomainObjectEntry(
+			autoScanEnabled, RandomTestUtil.randomString(),
+			JSONUtil.put(
+				"engines",
 				JSONUtil.put(
-					"engines",
-					JSONUtil.put(
-						"crawler", JSONUtil.put("enabled", true)
-					).put(
-						"pageSpeed", JSONUtil.put("enabled", true)
-					)
-				).toString()
-			).put(
-				"scanFrequency", "daily"
-			).put(
-				"scanTime", "09:00"
-			).build());
-	}
-
-	private ObjectEntry _fetchSEOStudioScanRunObjectEntry(
-			ObjectEntry seoStudioDomainObjectEntry)
-		throws Exception {
-
-		List<ObjectEntry> seoStudioScanRunObjectEntries =
-			_getSEOStudioScanRunObjectEntries(seoStudioDomainObjectEntry);
-
-		if (ListUtil.isEmpty(seoStudioScanRunObjectEntries)) {
-			return null;
-		}
-
-		return seoStudioScanRunObjectEntries.get(0);
-	}
-
-	private List<ObjectEntry> _getSEOStudioScanObjectEntries(
-			ObjectEntry seoStudioScanRunObjectEntry)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				seoStudioScanRunObjectEntry.getObjectDefinitionId(),
-				"seoStudioScanRunToSEOStudioScans");
-
-		return objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioScanRunObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioScanRunObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+					"crawler", JSONUtil.put("enabled", true)
+				).put(
+					"pageSpeed", JSONUtil.put("enabled", true)
+				)
+			).toString());
 	}
 
 	private List<ObjectEntry> _getSEOStudioScanRunObjectEntries(
 			ObjectEntry seoStudioDomainObjectEntry)
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				seoStudioDomainObjectDefinition.getObjectDefinitionId(),
-				"seoStudioDomainToSEOStudioScanRuns");
-
-		return objectEntryLocalService.getOneToManyObjectEntries(
-			seoStudioDomainObjectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), null, true,
-			seoStudioDomainObjectEntry.getObjectEntryId(), true, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+		return getRelatedObjectEntries(
+			seoStudioDomainObjectEntry, "seoStudioDomainToSEOStudioScanRuns");
 	}
 
 	private void _runJob() throws Exception {
@@ -238,15 +174,11 @@ public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
 			Date nextScanDate, ObjectEntry seoStudioDomainObjectEntry)
 		throws Exception {
 
-		objectEntryLocalService.partialUpdateObjectEntry(
-			TestPropsValues.getUserId(),
-			seoStudioDomainObjectEntry.getObjectEntryId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+		partialUpdateObjectEntry(
+			seoStudioDomainObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"nextScanDate", nextScanDate
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
 
 	private void _testCheckSEOStudioDomainsDoesNotCreateScanRun(
@@ -261,26 +193,19 @@ public class CheckSEOStudioDomainsSchedulerJobConfigurationTest
 		_runJob();
 
 		Assert.assertNull(
-			_fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
+			fetchSEOStudioScanRunObjectEntry(seoStudioDomainObjectEntry));
 	}
 
 	private void _updateSEOStudioScanState(
 			ObjectEntry seoStudioScanObjectEntry, String state)
 		throws Exception {
 
-		objectEntryLocalService.partialUpdateObjectEntry(
-			TestPropsValues.getUserId(),
-			seoStudioScanObjectEntry.getObjectEntryId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+		partialUpdateObjectEntry(
+			seoStudioScanObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"state", state
-			).build(),
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), TestPropsValues.getUserId()));
+			).build());
 	}
-
-	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.seo.studio.web.internal.scheduler.CheckSEOStudioDomainsSchedulerJobConfiguration"

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseSEOStudioTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.seo.studio.web.internal.object.action.executor.test;
+package com.liferay.seo.studio.web.internal.test;
 
 import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
@@ -12,9 +12,12 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -27,6 +30,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -48,7 +52,7 @@ import org.junit.Rule;
 /**
  * @author Jonathan McCann
  */
-public abstract class BaseObjectActionExecutorTestCase {
+public abstract class BaseSEOStudioTestCase {
 
 	@ClassRule
 	@Rule
@@ -127,12 +131,14 @@ public abstract class BaseObjectActionExecutorTestCase {
 	}
 
 	protected ObjectEntry addSEOStudioDomainObjectEntry(
-			String hostname, String scanConfigJSON)
+			boolean autoScanEnabled, String hostname, String scanConfigJSON)
 		throws Exception {
 
 		return addObjectEntry(
 			seoStudioDomainObjectDefinition,
 			HashMapBuilder.<String, Serializable>put(
+				"autoScanEnabled", autoScanEnabled
+			).put(
 				"hostname", hostname
 			).put(
 				"name", RandomTestUtil.randomString()
@@ -144,7 +150,54 @@ public abstract class BaseObjectActionExecutorTestCase {
 				seoStudioInstanceObjectEntry.getObjectEntryId()
 			).put(
 				"scanConfig", scanConfigJSON
+			).put(
+				"scanFrequency", "daily"
+			).put(
+				"scanTime", "09:00"
 			).build());
+	}
+
+	protected ObjectEntry fetchSEOStudioScanRunObjectEntry(
+			ObjectEntry seoStudioDomainObjectEntry)
+		throws Exception {
+
+		return _fetchRelatedObjectEntry(
+			seoStudioDomainObjectEntry, "seoStudioDomainToSEOStudioScanRuns");
+	}
+
+	protected List<ObjectEntry> getRelatedObjectEntries(
+			ObjectEntry objectEntry, String objectRelationshipName)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectEntry.getObjectDefinitionId(), objectRelationshipName);
+
+		return objectEntryLocalService.getOneToManyObjectEntries(
+			objectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(), null, true,
+			objectEntry.getObjectEntryId(), true, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	protected List<ObjectEntry> getSEOStudioScanObjectEntries(
+			ObjectEntry seoStudioScanRunObjectEntry)
+		throws Exception {
+
+		return getRelatedObjectEntries(
+			seoStudioScanRunObjectEntry, "seoStudioScanRunToSEOStudioScans");
+	}
+
+	protected ObjectEntry partialUpdateObjectEntry(
+			ObjectEntry objectEntry, Map<String, Serializable> values)
+		throws Exception {
+
+		return objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			values,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	protected static Group group;
@@ -200,6 +253,20 @@ public abstract class BaseObjectActionExecutorTestCase {
 			).build());
 	}
 
+	private ObjectEntry _fetchRelatedObjectEntry(
+			ObjectEntry objectEntry, String objectRelationshipName)
+		throws Exception {
+
+		List<ObjectEntry> objectEntries = getRelatedObjectEntries(
+			objectEntry, objectRelationshipName);
+
+		if (ListUtil.isEmpty(objectEntries)) {
+			return null;
+		}
+
+		return objectEntries.get(0);
+	}
+
 	@Inject
 	private static ObjectActionLocalService _objectActionLocalService;
 
@@ -218,5 +285,8 @@ public abstract class BaseObjectActionExecutorTestCase {
 
 	@DeleteAfterTestRun
 	private List<ObjectEntry> _objectEntries = new ArrayList<>();
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
@@ -7,27 +7,12 @@ package com.liferay.seo.studio.web.internal.object.action.executor;
 
 import com.liferay.object.action.executor.BaseObjectActionExecutor;
 import com.liferay.object.action.executor.ObjectActionExecutor;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.scope.ObjectDefinitionScoped;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.seo.studio.web.internal.scan.SEOStudioScanCreator;
 
-import java.io.Serializable;
-
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -56,129 +41,11 @@ public class CreateSEOStudioScansObjectActionExecutorImpl
 			JSONObject payloadJSONObject, long userId)
 		throws Exception {
 
-		long seoStudioDomainId = payloadJSONObject.getLong("classPK");
-
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			seoStudioDomainId);
-
-		String scanConfigJSON = GetterUtil.getString(values.get("scanConfig"));
-
-		if (Validator.isNull(scanConfigJSON)) {
-			return;
-		}
-
-		JSONObject scanConfigJSONObject = _jsonFactory.createJSONObject(
-			scanConfigJSON);
-
-		JSONObject enginesJSONObject = scanConfigJSONObject.getJSONObject(
-			"engines");
-
-		if (enginesJSONObject == null) {
-			return;
-		}
-
-		List<String> enabledEngineKeys = TransformUtil.transform(
-			enginesJSONObject.keySet(),
-			engineKey -> {
-				JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
-					engineKey);
-
-				if ((engineJSONObject != null) &&
-					engineJSONObject.getBoolean("enabled")) {
-
-					return engineKey;
-				}
-
-				return null;
-			});
-
-		if (ListUtil.isEmpty(enabledEngineKeys)) {
-			return;
-		}
-
-		long accountEntryId = GetterUtil.getLong(
-			values.get("r_accountToSEOStudioDomains_accountEntryId"));
-		ObjectDefinition seoStudioScanRunObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN_RUN", companyId);
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setCompanyId(companyId);
-		serviceContext.setUserId(userId);
-
-		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-			0, userId, seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"name", GetterUtil.getString(values.get("hostname"))
-			).put(
-				"r_accountToSEOStudioScanRuns_accountEntryId", accountEntryId
-			).put(
-				"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId",
-				seoStudioDomainId
-			).put(
-				"requestDate", new Date()
-			).put(
-				"state", "running"
-			).put(
-				"triggeredBy", "manual"
-			).put(
-				"triggeringUserId", userId
-			).build(),
-			serviceContext);
-
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", companyId);
-
-		for (String engineKey : enabledEngineKeys) {
-			JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
-				engineKey);
-
-			_objectEntryLocalService.addObjectEntry(
-				0, userId,
-				seoStudioScanObjectDefinition.getObjectDefinitionId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"r_accountToSEOStudioScans_accountEntryId", accountEntryId
-				).put(
-					"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
-					objectEntry.getObjectEntryId()
-				).put(
-					"scanRange", "full"
-				).put(
-					"scanScope", "entireDomain"
-				).put(
-					"scanType", engineKey
-				).put(
-					"scopeConfig",
-					() -> {
-						JSONObject scopeConfigJSONObject =
-							_jsonFactory.createJSONObject(
-								engineJSONObject.toString());
-
-						scopeConfigJSONObject.remove("enabled");
-
-						return scopeConfigJSONObject.toString();
-					}
-				).build(),
-				serviceContext);
-		}
+		_seoStudioScanCreator.createScans(
+			payloadJSONObject.getLong("classPK"), "manual", userId);
 	}
 
 	@Reference
-	private JSONFactory _jsonFactory;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
+	private SEOStudioScanCreator _seoStudioScanCreator;
 
 }

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/object/action/executor/CreateSEOStudioScansObjectActionExecutorImpl.java
@@ -42,7 +42,7 @@ public class CreateSEOStudioScansObjectActionExecutorImpl
 		throws Exception {
 
 		_seoStudioScanCreator.createScans(
-			payloadJSONObject.getLong("classPK"), "manual", userId);
+			null, payloadJSONObject.getLong("classPK"), "manual", userId);
 	}
 
 	@Reference

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
@@ -1,0 +1,174 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scan;
+
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = SEOStudioScanCreator.class)
+public class SEOStudioScanCreator {
+
+	public void createScans(
+			long seoStudioDomainId, String triggeredBy, long userId)
+		throws Exception {
+
+		ObjectEntry seoStudioDomainObjectEntry =
+			_objectEntryLocalService.getObjectEntry(seoStudioDomainId);
+
+		Map<String, Serializable> values =
+			seoStudioDomainObjectEntry.getValues();
+
+		String scanConfigJSON = GetterUtil.getString(values.get("scanConfig"));
+
+		if (Validator.isNull(scanConfigJSON)) {
+			return;
+		}
+
+		JSONObject scanConfigJSONObject = _jsonFactory.createJSONObject(
+			scanConfigJSON);
+
+		JSONObject enginesJSONObject = scanConfigJSONObject.getJSONObject(
+			"engines");
+
+		if (enginesJSONObject == null) {
+			return;
+		}
+
+		List<String> enabledEngineKeys = TransformUtil.transform(
+			enginesJSONObject.keySet(),
+			engineKey -> {
+				JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
+					engineKey);
+
+				if ((engineJSONObject != null) &&
+					engineJSONObject.getBoolean("enabled")) {
+
+					return engineKey;
+				}
+
+				return null;
+			});
+
+		if (ListUtil.isEmpty(enabledEngineKeys)) {
+			return;
+		}
+
+		long companyId = seoStudioDomainObjectEntry.getCompanyId();
+
+		long accountEntryId = GetterUtil.getLong(
+			values.get("r_accountToSEOStudioDomains_accountEntryId"));
+
+		ObjectDefinition seoStudioScanRunObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_RUN", companyId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		ObjectEntry seoStudioScanRunObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				0, userId,
+				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"name", GetterUtil.getString(values.get("hostname"))
+				).put(
+					"r_accountToSEOStudioScanRuns_accountEntryId",
+					accountEntryId
+				).put(
+					"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId",
+					seoStudioDomainId
+				).put(
+					"requestDate", new Date()
+				).put(
+					"state", "running"
+				).put(
+					"triggeredBy", triggeredBy
+				).put(
+					"triggeringUserId", userId
+				).build(),
+				serviceContext);
+
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", companyId);
+
+		for (String engineKey : enabledEngineKeys) {
+			JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
+				engineKey);
+
+			_objectEntryLocalService.addObjectEntry(
+				0, userId,
+				seoStudioScanObjectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"r_accountToSEOStudioScans_accountEntryId", accountEntryId
+				).put(
+					"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
+					seoStudioScanRunObjectEntry.getObjectEntryId()
+				).put(
+					"scanRange", "full"
+				).put(
+					"scanScope", "entireDomain"
+				).put(
+					"scanType", engineKey
+				).put(
+					"scopeConfig",
+					() -> {
+						JSONObject scopeConfigJSONObject =
+							_jsonFactory.createJSONObject(
+								engineJSONObject.toString());
+
+						scopeConfigJSONObject.remove("enabled");
+
+						return scopeConfigJSONObject.toString();
+					}
+				).build(),
+				serviceContext);
+		}
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java
@@ -5,21 +5,34 @@
 
 package com.liferay.seo.studio.web.internal.scan;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
+
+import java.text.Format;
 
 import java.util.Date;
 import java.util.List;
@@ -35,7 +48,8 @@ import org.osgi.service.component.annotations.Reference;
 public class SEOStudioScanCreator {
 
 	public void createScans(
-			long seoStudioDomainId, String triggeredBy, long userId)
+			Date scheduledScanDate, long seoStudioDomainId, String triggeredBy,
+			long userId)
 		throws Exception {
 
 		ObjectEntry seoStudioDomainObjectEntry =
@@ -81,86 +95,182 @@ public class SEOStudioScanCreator {
 
 		long companyId = seoStudioDomainObjectEntry.getCompanyId();
 
-		long accountEntryId = GetterUtil.getLong(
-			values.get("r_accountToSEOStudioDomains_accountEntryId"));
+		String scheduledScanKey = _getScheduledScanKey(
+			scheduledScanDate, seoStudioDomainId);
 
 		ObjectDefinition seoStudioScanRunObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_SEO_STUDIO_SCAN_RUN", companyId);
 
-		ServiceContext serviceContext = new ServiceContext();
+		if (scheduledScanKey != null) {
+			long seoStudioScanRunId = _fetchSEOStudioScanRunId(
+				companyId, scheduledScanKey, seoStudioScanRunObjectDefinition);
 
-		serviceContext.setCompanyId(companyId);
-		serviceContext.setUserId(userId);
+			if (seoStudioScanRunId != 0) {
+				return;
+			}
+		}
 
-		ObjectEntry seoStudioScanRunObjectEntry =
-			_objectEntryLocalService.addObjectEntry(
-				0, userId,
-				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"name", GetterUtil.getString(values.get("hostname"))
-				).put(
-					"r_accountToSEOStudioScanRuns_accountEntryId",
-					accountEntryId
-				).put(
-					"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId",
-					seoStudioDomainId
-				).put(
-					"requestDate", new Date()
-				).put(
-					"state", "running"
-				).put(
-					"triggeredBy", triggeredBy
-				).put(
-					"triggeringUserId", userId
-				).build(),
-				serviceContext);
+		try {
+			long accountEntryId = GetterUtil.getLong(
+				values.get("r_accountToSEOStudioDomains_accountEntryId"));
 
-		ObjectDefinition seoStudioScanObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_SEO_STUDIO_SCAN", companyId);
+			ServiceContext serviceContext = new ServiceContext();
 
-		for (String engineKey : enabledEngineKeys) {
-			JSONObject engineJSONObject = enginesJSONObject.getJSONObject(
-				engineKey);
+			serviceContext.setCompanyId(companyId);
+			serviceContext.setUserId(userId);
 
-			_objectEntryLocalService.addObjectEntry(
-				0, userId,
-				seoStudioScanObjectDefinition.getObjectDefinitionId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"r_accountToSEOStudioScans_accountEntryId", accountEntryId
-				).put(
-					"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
-					seoStudioScanRunObjectEntry.getObjectEntryId()
-				).put(
-					"scanRange", "full"
-				).put(
-					"scanScope", "entireDomain"
-				).put(
-					"scanType", engineKey
-				).put(
-					"scopeConfig",
-					() -> {
-						JSONObject scopeConfigJSONObject =
-							_jsonFactory.createJSONObject(
-								engineJSONObject.toString());
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					ObjectDefinition seoStudioScanObjectDefinition =
+						_objectDefinitionLocalService.
+							getObjectDefinitionByExternalReferenceCode(
+								"L_SEO_STUDIO_SCAN", companyId);
 
-						scopeConfigJSONObject.remove("enabled");
+					ObjectEntry seoStudioScanRunObjectEntry =
+						_addSEOStudioScanRunObjectEntry(
+							accountEntryId, scheduledScanKey,
+							seoStudioDomainObjectEntry,
+							seoStudioScanRunObjectDefinition, serviceContext,
+							triggeredBy, userId);
 
-						return scopeConfigJSONObject.toString();
+					long seoStudioScanRunId =
+						seoStudioScanRunObjectEntry.getObjectEntryId();
+
+					for (String engineKey : enabledEngineKeys) {
+						_addSEOStudioScanObjectEntry(
+							accountEntryId,
+							enginesJSONObject.getJSONObject(engineKey),
+							engineKey, seoStudioScanObjectDefinition,
+							seoStudioScanRunId, serviceContext, userId);
 					}
-				).build(),
-				serviceContext);
+
+					return null;
+				});
+		}
+		catch (Throwable throwable) {
+			throw new Exception(throwable);
 		}
 	}
+
+	private ObjectEntry _addSEOStudioScanObjectEntry(
+			long accountEntryId, JSONObject engineJSONObject, String engineKey,
+			ObjectDefinition seoStudioScanObjectDefinition,
+			long seoStudioScanRunId, ServiceContext serviceContext, long userId)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, userId, seoStudioScanObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"r_accountToSEOStudioScans_accountEntryId", accountEntryId
+			).put(
+				"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId",
+				seoStudioScanRunId
+			).put(
+				"scanRange", "full"
+			).put(
+				"scanScope", "entireDomain"
+			).put(
+				"scanType", engineKey
+			).put(
+				"scopeConfig",
+				() -> {
+					JSONObject scopeConfigJSONObject =
+						_jsonFactory.createJSONObject(
+							engineJSONObject.toString());
+
+					scopeConfigJSONObject.remove("enabled");
+
+					return scopeConfigJSONObject.toString();
+				}
+			).build(),
+			serviceContext);
+	}
+
+	private ObjectEntry _addSEOStudioScanRunObjectEntry(
+			long accountEntryId, String scheduledScanKey,
+			ObjectEntry seoStudioDomainObjectEntry,
+			ObjectDefinition seoStudioScanRunObjectDefinition,
+			ServiceContext serviceContext, String triggeredBy, long userId)
+		throws Exception {
+
+		Map<String, Serializable> values =
+			seoStudioDomainObjectEntry.getValues();
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, userId, seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"name", GetterUtil.getString(values.get("hostname"))
+			).put(
+				"r_accountToSEOStudioScanRuns_accountEntryId", accountEntryId
+			).put(
+				"r_seoStudioDomainToSEOStudioScanRuns_seoStudioDomainId",
+				seoStudioDomainObjectEntry.getObjectEntryId()
+			).put(
+				"requestDate", new Date()
+			).put(
+				"scheduledScanKey", scheduledScanKey
+			).put(
+				"state", "running"
+			).put(
+				"triggeredBy", triggeredBy
+			).put(
+				"triggeringUserId", userId
+			).build(),
+			serviceContext);
+	}
+
+	private long _fetchSEOStudioScanRunId(
+			long companyId, String scheduledScanKey,
+			ObjectDefinition seoStudioScanRunObjectDefinition)
+		throws Exception {
+
+		List<Long> seoStudioScanRunIds =
+			_objectEntryLocalService.getPrimaryKeys(
+				new Long[] {0L}, companyId, 0,
+				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				_filterFactory.create(
+					StringBundler.concat(
+						"scheduledScanKey eq '", scheduledScanKey, "'"),
+					seoStudioScanRunObjectDefinition),
+				false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (ListUtil.isEmpty(seoStudioScanRunIds)) {
+			return 0;
+		}
+
+		return seoStudioScanRunIds.get(0);
+	}
+
+	private String _getScheduledScanKey(
+		Date scheduledScanDate, long seoStudioDomainId) {
+
+		if (scheduledScanDate == null) {
+			return null;
+		}
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddHHmm", TimeZoneUtil.getTimeZone("UTC"));
+
+		return StringBundler.concat(
+			seoStudioDomainId, StringPool.UNDERLINE,
+			format.format(scheduledScanDate));
+	}
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
@@ -12,9 +12,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
-import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -69,6 +67,14 @@ public class CheckSEOStudioDomainsSchedulerJobConfiguration
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-44511")) {
 			return;
 		}
+
+		_createScheduledSEOStudioScans(companyId);
+
+		_finalizeSEOStudioScanRuns(companyId);
+	}
+
+	private void _createScheduledSEOStudioScans(long companyId)
+		throws Exception {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
@@ -146,6 +152,126 @@ public class CheckSEOStudioDomainsSchedulerJobConfiguration
 			serviceContext);
 	}
 
+	private void _finalizeSEOStudioScanRun(
+			ObjectDefinition seoStudioScanObjectDefinition,
+			long seoStudioScanRunId)
+		throws Exception {
+
+		long scanCount = _getSEOStudioScanCount(
+			seoStudioScanObjectDefinition, seoStudioScanRunId, null);
+
+		if (scanCount == 0) {
+			return;
+		}
+
+		long terminalScanCount = _getSEOStudioScanCount(
+			seoStudioScanObjectDefinition, seoStudioScanRunId,
+			"state in ('cancelled', 'completed', 'failed')");
+
+		if (terminalScanCount < scanCount) {
+			return;
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			seoStudioScanRunId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(objectEntry.getCompanyId());
+		serviceContext.setUserId(objectEntry.getUserId());
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			objectEntry.getUserId(), seoStudioScanRunId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"state",
+				_getSEOStudioScanRunState(
+					seoStudioScanObjectDefinition, seoStudioScanRunId)
+			).build(),
+			serviceContext);
+	}
+
+	private void _finalizeSEOStudioScanRuns(long companyId) throws Exception {
+		ObjectDefinition seoStudioScanObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN", companyId);
+		ObjectDefinition seoStudioScanRunObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_SCAN_RUN", companyId);
+
+		if ((seoStudioScanObjectDefinition == null) ||
+			(seoStudioScanRunObjectDefinition == null)) {
+
+			return;
+		}
+
+		List<Long> seoStudioScanRunIds =
+			_objectEntryLocalService.getPrimaryKeys(
+				new Long[] {0L}, companyId, 0,
+				seoStudioScanRunObjectDefinition.getObjectDefinitionId(),
+				_filterFactory.create(
+					"state eq 'running'", seoStudioScanRunObjectDefinition),
+				false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (long seoStudioScanRunId : seoStudioScanRunIds) {
+			try {
+				_finalizeSEOStudioScanRun(
+					seoStudioScanObjectDefinition, seoStudioScanRunId);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to finalize SEO Studio scan run " +
+						seoStudioScanRunId,
+					exception);
+			}
+		}
+	}
+
+	private long _getSEOStudioScanCount(
+			ObjectDefinition seoStudioScanObjectDefinition,
+			long seoStudioScanRunId, String stateFilterString)
+		throws Exception {
+
+		String filterString = StringBundler.concat(
+			"r_seoStudioScanRunToSEOStudioScans_seoStudioScanRunId eq '",
+			seoStudioScanRunId, "'");
+
+		if (stateFilterString != null) {
+			filterString = StringBundler.concat(
+				"(", filterString, ") and (", stateFilterString, ")");
+		}
+
+		return _objectEntryLocalService.getObjectEntriesCount(
+			0, null, seoStudioScanObjectDefinition,
+			_filterFactory.create(filterString, seoStudioScanObjectDefinition));
+	}
+
+	private String _getSEOStudioScanRunState(
+			ObjectDefinition seoStudioScanObjectDefinition,
+			long seoStudioScanRunId)
+		throws Exception {
+
+		long failedScanCount = _getSEOStudioScanCount(
+			seoStudioScanObjectDefinition, seoStudioScanRunId,
+			"state eq 'failed'");
+
+		if (failedScanCount > 0) {
+			return "failed";
+		}
+
+		long completedScanCount = _getSEOStudioScanCount(
+			seoStudioScanObjectDefinition, seoStudioScanRunId,
+			"state eq 'completed'");
+
+		if (completedScanCount > 0) {
+			return "completed";
+		}
+
+		return "cancelled";
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CheckSEOStudioDomainsSchedulerJobConfiguration.class);
 
@@ -162,9 +288,6 @@ public class CheckSEOStudioDomainsSchedulerJobConfiguration
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Reference
-	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private SEOStudioScanCreator _seoStudioScanCreator;

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scheduler/CheckSEOStudioDomainsSchedulerJobConfiguration.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.web.internal.scheduler;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.seo.studio.web.internal.scan.SEOStudioScanCreator;
+import com.liferay.seo.studio.web.internal.util.SEOStudioScanScheduleUtil;
+
+import java.io.Serializable;
+
+import java.text.Format;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = SchedulerJobConfiguration.class)
+public class CheckSEOStudioDomainsSchedulerJobConfiguration
+	implements SchedulerJobConfiguration {
+
+	@Override
+	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
+		return () -> _companyLocalService.forEachCompanyId(
+			this::_checkSEOStudioDomains);
+	}
+
+	@Override
+	public TriggerConfiguration getTriggerConfiguration() {
+		return TriggerConfiguration.createTriggerConfiguration(
+			5, TimeUnit.MINUTE);
+	}
+
+	private void _checkSEOStudioDomains(long companyId) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-44511")) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_SEO_STUDIO_DOMAIN", companyId);
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZoneUtil.getTimeZone("UTC"));
+
+		List<Long> seoStudioDomainIds = _objectEntryLocalService.getPrimaryKeys(
+			new Long[] {0L}, companyId, 0,
+			objectDefinition.getObjectDefinitionId(),
+			_filterFactory.create(
+				StringBundler.concat(
+					"(autoScanEnabled eq true) and (nextScanDate le ",
+					format.format(new Date()), ")"),
+				objectDefinition),
+			false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (long seoStudioDomainId : seoStudioDomainIds) {
+			try {
+				_createSEOStudioScans(seoStudioDomainId);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to create scans for SEO Studio domain " +
+						seoStudioDomainId,
+					exception);
+			}
+		}
+	}
+
+	private void _createSEOStudioScans(long seoStudioDomainId)
+		throws Exception {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			seoStudioDomainId);
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long userId = objectEntry.getUserId();
+
+		_seoStudioScanCreator.createScans(
+			(Date)values.get("nextScanDate"), seoStudioDomainId, "scheduled",
+			userId);
+
+		Date nextScanDate = SEOStudioScanScheduleUtil.getNextScanDate(
+			Instant.now(), GetterUtil.getInteger(values.get("scanDayOfMonth")),
+			GetterUtil.getString(values.get("scanDayOfWeek")),
+			GetterUtil.getString(values.get("scanFrequency")),
+			GetterUtil.getString(values.get("scanTime")),
+			GetterUtil.getString(values.get("scanTimeZone")));
+
+		if ((nextScanDate == null) && _log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to compute the next scan date for SEO Studio domain " +
+					seoStudioDomainId);
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(objectEntry.getCompanyId());
+		serviceContext.setUserId(userId);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			userId, seoStudioDomainId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"nextScanDate", nextScanDate
+			).build(),
+			serviceContext);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CheckSEOStudioDomainsSchedulerJobConfiguration.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private SEOStudioScanCreator _seoStudioScanCreator;
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1197,6 +1197,7 @@
         modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal,\
         modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java,\
         modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal,\
+        modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/scan/SEOStudioScanCreator.java,\
         modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository,\
         modules/extender/internal/resolution/BrowserModulesResolver.java,\
         modules/extender/internal/servlet/JSResolveModulesServlet.java,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93368

## What Is Being Fixed

Auto Scan lets a user configure a scan schedule on an SEO Studio domain, but nothing acted on those schedules — a schedule coming due never produced any scans on its own. There was also no guard against creating the same scheduled scan twice, and scan runs were left open indefinitely because they were never finalized once their scans finished.

## How It Is Being Fixed

A periodic scheduler job, CheckSEOStudioDomainsSchedulerJobConfiguration, runs every five minutes, iterates each company gated by the LPD-44511 feature flag, and creates scans for the domains whose schedule is due. The scan creation logic that previously lived in CreateSEOStudioScansObjectActionExecutorImpl is extracted into a reusable SEOStudioScanCreator so the object action and the scheduler share a single code path.

A new scheduledScanKey field on the scan run object records which scheduled window produced a run, and the sweeper skips a domain when a run already exists for that key, preventing duplicate scheduled scans. The job also finalizes a scan run, marking it terminal once all of its scans have reached a terminal state.

Integration tests cover the sweeper, and the SEO Studio integration test base class is generalized (in the same vein as `BaseDLAppTestCase` and `BaseDDMServiceTestCase`) so that all tests can reuse it.

## PR Check

**pr-check: PASS** — tested on `d31ca98015af4e1dae2e99de2cdedfcfef438698`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d31ca98015af4e1dae2e99de2cdedfcfef438698"} -->
