### PR TITLE
LPD-98937 Trigger the invite users autocomplete only after typing

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/manage-collaborators-modal/ManageCollaborators.js
@@ -15,7 +15,7 @@ import ClayTable from '@clayui/table';
 import ClayTabs from '@clayui/tabs';
 import {openConfirmModal, openToast} from 'frontend-js-components-web';
 import {fetch, getOpener, objectToFormData, sub} from 'frontend-js-web';
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import CollaboratorRow from './CollaboratorRow';
 
@@ -45,6 +45,8 @@ const ManageCollaborators = ({
 	verifyEmailAddressURL,
 }) => {
 	const [active, setActive] = useState(false);
+	const [autocompleteActive, setAutocompleteActive] = useState(false);
+	const [autocompleteUsers, setAutocompleteUsers] = useState(null);
 	const [emailAddressErrorMessages, setEmailAddressErrorMessages] = useState(
 		[]
 	);
@@ -127,16 +129,33 @@ const ManageCollaborators = ({
 		fetchRetry: {
 			attempts: 0,
 		},
-		link: autocompleteUserURL,
+		link: multiSelectValue ? autocompleteUserURL : null,
 		onNetworkStatusChange: setNetworkStatus,
 		variables: {
 			[`${namespace}keywords`]: multiSelectValue,
 		},
 	});
 
-	const autocompleteUsers = autocompleteResource;
 	const collaborators = collaboratorsResource;
+
+	const autocompleteFetchRef = useRef(false);
 	const emailValidationInProgressRef = useRef(false);
+
+	useEffect(() => {
+		if (!multiSelectValue) {
+			autocompleteFetchRef.current = false;
+
+			setAutocompleteUsers(null);
+		}
+		else if (networkStatus === 1 || networkStatus === 2) {
+			autocompleteFetchRef.current = true;
+		}
+		else if (autocompleteFetchRef.current) {
+			autocompleteFetchRef.current = false;
+
+			setAutocompleteUsers(autocompleteResource);
+		}
+	}, [autocompleteResource, multiSelectValue, networkStatus]);
 
 	const copyToClipboard = async () => {
 		try {
@@ -771,9 +790,26 @@ const ManageCollaborators = ({
 						<ClayInput.Group>
 							<ClayInput.GroupItem>
 								<ClayMultiSelect
+									active={
+										!!multiSelectValue && autocompleteActive
+									}
 									inputName={`${namespace}userEmailAddress`}
 									items={[]}
 									loadingState={networkStatus}
+									messages={{
+										labelAdded: Liferay.Language.get(
+											'label-x-was-added-to-the-list'
+										),
+										labelRemoved: Liferay.Language.get(
+											'label-x-was-removed-from-the-list'
+										),
+										notFound: autocompleteUsers
+											? Liferay.Language.get(
+													'no-results-found'
+												)
+											: Liferay.Language.get('loading'),
+									}}
+									onActiveChange={setAutocompleteActive}
 									onChange={handleChange}
 									onItemsChange={handleItemsChange}
 									placeholder={Liferay.Language.get(

--- a/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/publicationsUserCollaboration.spec.ts
@@ -172,6 +172,44 @@ test('LPD-89418 Paste email address to automatically add user in Invite Users mo
 	}
 });
 
+test(
+	'LPD-98937 Open the invite users autocomplete only after typing',
+	{tag: '@LPD-98937'},
+	async ({apiHelpers, changeTrackingPage, ctCollection, page}) => {
+		try {
+			const user =
+				await changeTrackingPage.addUserWithPublicationsUserRole();
+
+			await changeTrackingPage.workOnPublication(ctCollection);
+
+			await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+
+			await page.getByLabel('View Collaborators').click();
+
+			const input = page.getByPlaceholder('Enter name or email address.');
+
+			await input.click();
+
+			await expect(page.locator('.dropdown-menu-select')).toBeHidden();
+
+			await input.fill(user.emailAddress);
+
+			await expect(
+				page.getByRole('option', {name: user.name})
+			).toBeVisible();
+
+			await apiHelpers.headlessAdminUser.deleteUserAccount(
+				Number(user.id)
+			);
+		}
+		finally {
+			await apiHelpers.headlessChangeTracking.deleteCTCollection(
+				ctCollection.body.id
+			);
+		}
+	}
+);
+
 test('LPD-65173 Assert that the Share Link tab is hidden for Publication Templates', async ({
 	changeTrackingTemplatesPage,
 	page,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98937

## What Is Being Fixed

The invite users field in the collaborators modal opened its autocomplete dropdown as soon as the empty input was focused, showing a confusing "No results found" message before anything was typed.

## How It Is Being Fixed

The dropdown now opens only once the user starts typing. While a search request is in flight the retained results stay empty and the field shows a loading state, rather than flashing "No results found" with the previous search's items; clearing the field resets the retained results so the next search starts fresh. A Playwright test covers the behavior: clicking the empty input opens no dropdown, and a matching query lists the user as an option.

## PR Check

**pr-check: PASS** — tested on `1c55e069b20507f6cce3fcd8e2f097fe1928f5ae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1c55e069b20507f6cce3fcd8e2f097fe1928f5ae"} -->
