### PR TITLE
LPD-66508 Use the public pages spritemap for navigation menu icons

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-admin-web/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:client-extension:client-extension-api")
+	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:expando:expando-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
@@ -5,6 +5,11 @@
 
 package com.liferay.site.navigation.admin.web.internal.display.context;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
+import com.liferay.client.extension.type.ThemeSpritemapCET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.dynamic.data.mapping.constants.DDMTemplateConstants;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil;
@@ -12,6 +17,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -21,6 +27,8 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -30,6 +38,7 @@ import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.theme.NavItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -73,7 +82,7 @@ import java.util.Objects;
 public class SiteNavigationAdminDisplayContext {
 
 	public SiteNavigationAdminDisplayContext(
-		HttpServletRequest httpServletRequest,
+		CETManager cetManager, HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		PortletDisplayTemplate portletDisplayTemplate,
@@ -81,6 +90,7 @@ public class SiteNavigationAdminDisplayContext {
 		SiteNavigationMenuLocalService siteNavigationMenuLocalService,
 		SiteNavigationMenuService siteNavigationMenuService) {
 
+		_cetManager = cetManager;
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
@@ -301,6 +311,8 @@ public class SiteNavigationAdminDisplayContext {
 				_siteNavigationMenuItemTypeRegistry, _themeDisplay)
 		).put(
 			"siteNavigationMenuName", getSiteNavigationMenuName()
+		).put(
+			"spritemap", getSpritemap()
 		).build();
 	}
 
@@ -340,6 +352,16 @@ public class SiteNavigationAdminDisplayContext {
 		_siteNavigationMenuName = siteNavigationMenu.getName();
 
 		return _siteNavigationMenuName;
+	}
+
+	public String getSpritemap() {
+		if (_spritemap != null) {
+			return _spritemap;
+		}
+
+		_spritemap = _getSpritemap();
+
+		return _spritemap;
 	}
 
 	public boolean hasEditPermission() {
@@ -531,9 +553,48 @@ public class SiteNavigationAdminDisplayContext {
 		return liferayPortletURL.toString();
 	}
 
+	private String _getSpritemap() {
+		LayoutSet layoutSet = LayoutSetLocalServiceUtil.fetchLayoutSet(
+			_themeDisplay.getScopeGroupId(), false);
+
+		if (layoutSet == null) {
+			return _themeDisplay.getPathThemeSpritemap();
+		}
+
+		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layoutSet);
+
+		if (themeSpritemapCET != null) {
+			return themeSpritemapCET.getURL();
+		}
+
+		Theme theme = layoutSet.getTheme();
+
+		return StringBundler.concat(
+			_themeDisplay.getCDNBaseURL(), theme.getStaticResourcePath(),
+			theme.getImagesPath(), "/clay/icons.svg");
+	}
+
+	private ThemeSpritemapCET _getThemeSpritemapCET(LayoutSet layoutSet) {
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			ClientExtensionEntryRelLocalServiceUtil.
+				fetchClientExtensionEntryRel(
+					PortalUtil.getClassNameId(LayoutSet.class),
+					layoutSet.getLayoutSetId(),
+					ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP);
+
+		if (clientExtensionEntryRel == null) {
+			return null;
+		}
+
+		return (ThemeSpritemapCET)_cetManager.getCET(
+			layoutSet.getCompanyId(),
+			clientExtensionEntryRel.getCETExternalReferenceCode());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SiteNavigationAdminDisplayContext.class);
 
+	private final CETManager _cetManager;
 	private String _ddmTemplateKey;
 	private String _displayStyle;
 	private final HttpServletRequest _httpServletRequest;
@@ -551,6 +612,7 @@ public class SiteNavigationAdminDisplayContext {
 		_siteNavigationMenuLocalService;
 	private String _siteNavigationMenuName;
 	private final SiteNavigationMenuService _siteNavigationMenuService;
+	private String _spritemap;
 	private final ThemeDisplay _themeDisplay;
 	private Boolean _updatePermission;
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/portlet/SiteNavigationAdminPortlet.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/portlet/SiteNavigationAdminPortlet.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.navigation.admin.web.internal.portlet;
 
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
@@ -60,7 +61,7 @@ public class SiteNavigationAdminPortlet extends MVCPortlet {
 
 		SiteNavigationAdminDisplayContext siteNavigationAdminDisplayContext =
 			new SiteNavigationAdminDisplayContext(
-				_portal.getHttpServletRequest(renderRequest),
+				_cetManager, _portal.getHttpServletRequest(renderRequest),
 				_portal.getLiferayPortletRequest(renderRequest),
 				_portal.getLiferayPortletResponse(renderResponse),
 				_portletDisplayTemplate, _siteNavigationMenuItemTypeRegistry,
@@ -73,6 +74,9 @@ public class SiteNavigationAdminPortlet extends MVCPortlet {
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
+
+	@Reference
+	private CETManager _cetManager;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu_item.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu_item.jsp
@@ -50,6 +50,8 @@ SiteNavigationMenuItem siteNavigationMenuItem = SiteNavigationMenuItemLocalServi
 						props='<%=
 							HashMapBuilder.<String, Object>put(
 								"selectedIcon", siteNavigationMenuItemType.getDisplayIcon(siteNavigationMenuItem)
+							).put(
+								"spritemap", siteNavigationAdminDisplayContext.getSpritemap()
 							).build()
 						%>'
 					/>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/components/MenuItem.js
@@ -35,7 +35,7 @@ export function MenuItem({item, onMenuItemRemoved, sidebarPanelRef}) {
 	const setItems = useSetItems();
 	const setSelectedMenuItemId = useSetSelectedMenuItemId();
 	const setSidebarPanelId = useSetSidebarPanelId();
-	const {editSiteNavigationMenuItemParentURL, portletNamespace} =
+	const {editSiteNavigationMenuItemParentURL, portletNamespace, spritemap} =
 		useConstants();
 
 	const items = useItems();
@@ -323,6 +323,7 @@ export function MenuItem({item, onMenuItemRemoved, sidebarPanelRef}) {
 									<ClayLayout.ContentCol gutters>
 										<ClayIcon
 											className="lfr-portal-tooltip mr-3"
+											spritemap={spritemap}
 											style={{
 												height: '1.5rem',
 												width: '1.5rem',

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/contexts/ConstantsContext.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/contexts/ConstantsContext.js
@@ -38,5 +38,6 @@ ConstantsProvider.propTypes = {
 			}).isRequired
 		),
 		siteNavigationMenuName: PropTypes.string,
+		spritemap: PropTypes.string,
 	}),
 };

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/js/components/NavigationMenuIconSelector.js
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/js/components/NavigationMenuIconSelector.js
@@ -4,11 +4,13 @@
  */
 
 import {IconSelector} from '@clayui/core';
+import {ClayIconSpriteContext} from '@clayui/icon';
 import React, {useState} from 'react';
 
 export default function NavigationMenuIconSelector({
 	portletNamespace,
 	selectedIcon,
+	spritemap,
 }) {
 	const [icon, setIcon] = useState(selectedIcon);
 
@@ -22,11 +24,13 @@ export default function NavigationMenuIconSelector({
 				value={icon}
 			/>
 
-			<IconSelector
-				onIconChange={setIcon}
-				selectedIcon={icon}
-				spritemap={Liferay.Icons.spritemap}
-			/>
+			<ClayIconSpriteContext.Provider value={spritemap}>
+				<IconSelector
+					onIconChange={setIcon}
+					selectedIcon={icon}
+					spritemap={spritemap}
+				/>
+			</ClayIconSpriteContext.Provider>
 		</div>
 	);
 }

--- a/modules/test/playwright/tests/site-navigation-admin-web/main/iconSelector.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/iconSelector.spec.ts
@@ -12,6 +12,9 @@ import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
 import {navigationMenusPagesTest} from './fixtures/navigationMenusPagesTest';
 
+const SITE_ACCESSIBILITY_ICON_PATTERN =
+	/\/o\/classic-theme\/images\/clay\/icons\.svg#accessibility$/;
+
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
@@ -25,7 +28,7 @@ const test = mergeTests(
 test(
 	'Ensure that the IconSelector component can add, edit and delete an icon in a navigation menu item',
 	{
-		tag: '@LPD-44978',
+		tag: ['@LPD-44978', '@LPD-66508'],
 	},
 	async ({apiHelpers, navigationMenusPage, page, site}) => {
 
@@ -53,13 +56,30 @@ test(
 			.getByText(pageName)
 			.click();
 
+		// Assert that the icon selector offers the icons of the spritemap of
+		// the public pages of the site instead of the ones of the
+		// administration theme
+
+		await page.getByLabel('Select an Icon').click();
+
+		await expect(
+			page.getByLabel('Select accessibility icon').locator('use')
+		).toHaveAttribute('href', SITE_ACCESSIBILITY_ICON_PATTERN);
+
+		await page.keyboard.press('Escape');
+
 		await navigationMenusPage.addOrChangeIcon('accessibility');
 
-		// Assert that the icon is being displayed in the page menu item
+		// Assert that the icon is being displayed in the page menu item with
+		// the spritemap of the public pages of the site
 
 		await expect(
 			page.locator('.autofit-col-gutters .lexicon-icon-accessibility')
 		).toBeVisible();
+
+		await expect(
+			page.locator('.autofit-col-gutters .lexicon-icon-accessibility use')
+		).toHaveAttribute('href', SITE_ACCESSIBILITY_ICON_PATTERN);
 
 		// Select a different icon for the page item
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-66508

## What Is Being Fixed

The icon selector in the navigation menu editor, and the icon rendered next to each menu item, both read from the spritemap of the administration theme. A navigation menu is rendered on the pages of the site, where icons come from the spritemap of the theme, or of the theme spritemap client extension, applied to the public pages. The icons offered while configuring the menu therefore did not match the icons the site actually renders, and an icon that exists only in the site's spritemap could not be selected at all.

## How It Is Being Fixed

`SiteNavigationAdminDisplayContext` now resolves the spritemap of the site's public pages rather than relying on the request's theme display. It fetches the public `LayoutSet` for the scope group and first looks for a theme spritemap client extension bound to that layout set, returning the client extension URL when one is applied. Otherwise it falls back to the icon path of the layout set's own theme, and to the current theme display's spritemap when no public layout set exists. The resolved value is memoized on the display context and exposed through `getSpritemap`.

That value is passed into the two places that render icons. The menu editor publishes it as a `spritemap` constant so `MenuItem` can hand it to `ClayIcon`, and `edit_site_navigation_menu_item.jsp` passes it as a prop to `NavigationMenuIconSelector`. The selector previously read `Liferay.Icons.spritemap`, which is the administration spritemap; it now uses the prop and also wraps the Clay `IconSelector` in a `ClayIconSpriteContext.Provider` so the icons rendered inside the selector's own list resolve against the same spritemap.

The existing Playwright test for the icon selector is extended to assert that both the icon offered in the selector and the icon rendered on the menu item resolve their `href` against the site's spritemap rather than the administration theme's.

## PR Check

**pr-check: PASS** — tested on `34577629668e9ea9c5c77dfc9a04c1f6a350580e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "34577629668e9ea9c5c77dfc9a04c1f6a350580e"} -->
