### PR TITLE
LPD-99707 Add object encryption algorithm property to SEO Studio integration tests

### DIFF
--- a/modules/dxp/apps/seo-studio/seo-studio-rest-test/src/testIntegration/java/com/liferay/seo/studio/rest/resource/v1_0/test/CrawlHitResourceTest.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-rest-test/src/testIntegration/java/com/liferay/seo/studio/rest/resource/v1_0/test/CrawlHitResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -22,11 +23,13 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -47,10 +50,14 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.io.Serializable;
 
+import java.security.Key;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.crypto.KeyGenerator;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -82,6 +89,23 @@ public class CrawlHitResourceTest extends BaseCrawlHitResourceTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
 
+		_objectEncryptionAlgorithmSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ALGORITHM", "AES");
+		_objectEncryptionEnabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ENABLED", true);
+
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+
+		keyGenerator.init(128);
+
+		Key key = keyGenerator.generateKey();
+
+		_objectEncryptionKeySafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_KEY", Base64.encode(key.getEncoded()));
+
 		SiteInitializer siteInitializer =
 			_siteInitializerRegistry.getSiteInitializer(
 				"com.liferay.seo.studio.site.initializer");
@@ -94,6 +118,10 @@ public class CrawlHitResourceTest extends BaseCrawlHitResourceTestCase {
 		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 
 		PrincipalThreadLocal.setName(_originalName);
+
+		_objectEncryptionAlgorithmSafeCloseable.close();
+		_objectEncryptionEnabledSafeCloseable.close();
+		_objectEncryptionKeySafeCloseable.close();
 
 		ServiceContextThreadLocal.popServiceContext();
 	}
@@ -449,6 +477,9 @@ public class CrawlHitResourceTest extends BaseCrawlHitResourceTestCase {
 		Assert.assertEquals(url, crawlHit.getUrl());
 	}
 
+	private static SafeCloseable _objectEncryptionAlgorithmSafeCloseable;
+	private static SafeCloseable _objectEncryptionEnabledSafeCloseable;
+	private static SafeCloseable _objectEncryptionKeySafeCloseable;
 	private static String _originalName;
 	private static PermissionChecker _originalPermissionChecker;
 

--- a/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseTestCase.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-test/src/testIntegration/java/com/liferay/seo/studio/web/internal/test/BaseTestCase.java
@@ -17,6 +17,7 @@ import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -26,9 +27,11 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -39,9 +42,13 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.io.Serializable;
 
+import java.security.Key;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import javax.crypto.KeyGenerator;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -70,6 +77,23 @@ public abstract class BaseTestCase {
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		_objectEncryptionAlgorithmSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ALGORITHM", "AES");
+		_objectEncryptionEnabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ENABLED", true);
+
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+
+		keyGenerator.init(128);
+
+		Key key = keyGenerator.generateKey();
+
+		_objectEncryptionKeySafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_KEY", Base64.encode(key.getEncoded()));
 
 		_group = GroupTestUtil.addGroup();
 
@@ -100,6 +124,10 @@ public abstract class BaseTestCase {
 		_updateSEOStudioScanObjectActions(true);
 
 		ServiceContextThreadLocal.popServiceContext();
+
+		_objectEncryptionAlgorithmSafeCloseable.close();
+		_objectEncryptionEnabledSafeCloseable.close();
+		_objectEncryptionKeySafeCloseable.close();
 
 		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 
@@ -267,6 +295,9 @@ public abstract class BaseTestCase {
 	@Inject
 	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	private static SafeCloseable _objectEncryptionAlgorithmSafeCloseable;
+	private static SafeCloseable _objectEncryptionEnabledSafeCloseable;
+	private static SafeCloseable _objectEncryptionKeySafeCloseable;
 	private static String _originalName;
 	private static PermissionChecker _originalPermissionChecker;
 	private static ObjectDefinition _seoStudioInstanceObjectDefinition;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99707

## What Is Being Fixed

`CrawlHitResourceTest` and the SEO Studio object action executor tests fail because the SEO Studio site initializer they bootstrap in `@BeforeClass` defines object fields with the `Encrypted` business type — one in `seo-studio-instance-object-definition.json` and three in `seo-studio-gsc-credentials-object-definition.json`. `ObjectFieldLocalServiceImpl` refuses to create an encrypted field unless `OBJECT_ENCRYPTION_ENABLED` is set, so `siteInitializer.initialize(...)` fails and every test in the class fails with it.

## How It Is Being Fixed

Both test classes now swap the three object encryption portal properties for the lifetime of the test class before initializing the site initializer. `OBJECT_ENCRYPTION_ALGORITHM` is set to `AES` and `OBJECT_ENCRYPTION_ENABLED` to `true`, and a fresh AES key is generated per run and installed as a Base64 encoded `OBJECT_ENCRYPTION_KEY`, so nothing depends on a key committed to the repository. Each swap is held as a `SafeCloseable` and closed in `tearDownClass`, unwinding the class level state in the reverse of the order `setUpClass` acquired it. This follows the pattern already established in `BatchEngineBrokerTest`.

## Why Are There No Tests?

Every change in this pull request is to test code — two integration test classes gain the object encryption setup they need to run. There is no production code change to cover.

## PR Check

**pr-check: PASS** — tested on `d81d439be531ff01a6f14af59461fbed1f309beb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d81d439be531ff01a6f14af59461fbed1f309beb"} -->
