### PR TITLE
LPD-99798 Stop requiring every click-to-chat configuration field

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
+++ b/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.events.LifecycleEvent;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -105,8 +107,9 @@ public class LogoutPreActionTest {
 						"enabled", true
 					).build())) {
 
-			AuthenticatedSessionManagerUtil.logout(
-				_mockHttpServletRequest, new MockHttpServletResponse());
+			_logoutPreAction.processLifecycleEvent(
+				new LifecycleEvent(
+					_mockHttpServletRequest, new MockHttpServletResponse()));
 		}
 
 		Assert.assertNull(
@@ -151,6 +154,11 @@ public class LogoutPreActionTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.click.to.chat.web.internal.events.LogoutPreAction"
+	)
+	private LifecycleAction _logoutPreAction;
 
 	private final MockHttpServletRequest _mockHttpServletRequest =
 		new MockHttpServletRequest();

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/configuration/ClickToChatConfiguration.java
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/configuration/ClickToChatConfiguration.java
@@ -28,7 +28,7 @@ public interface ClickToChatConfiguration {
 
 	public String chatProviderKeyId();
 
-	@Meta.AD(type = Meta.Type.Password)
+	@Meta.AD(required = false, type = Meta.Type.Password)
 	public String chatProviderSecretKey();
 
 	public boolean enabled();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99798

## What Is Being Fixed

LPD-88886 added a metatype annotation to one click-to-chat credential field so the configuration UI masks its value. `Meta.AD#required` defaults to true, so that field silently became a required attribute, and `SettingsLocatorHelperImpl` only registers a system scoped configuration bean once every required key is present in the saved properties. A click-to-chat configuration that left the field empty was therefore discarded, the settings lookup fell back to `portal.properties`, and `LogoutPreAction` stopped deleting the Intercom cookies on logout. A configuration file deployed to `osgi/configs` without that field was ignored wholesale rather than partially applied, and `LogoutPreActionTest#testLogoutWithClickToChatEnabled` and `#testLogoutWithoutThemeDisplay` failed.

Separately, `testLogoutWithoutThemeDisplay` removes the theme display to cover the lockout code path, and it drove the logout through the portal logout helper. That fires every `logout.events.pre` action, and the analytics reports, layout reports, and segments experiment actions all reach the theme display through `SessionClicks`, which caught and logged a `NullPointerException` for each of them. The test passed while writing three stack traces to the log on every run.

## How It Is Being Fixed

The configuration field is annotated with `required = false` alongside the masked input type, which is what the rest of the codebase does for masked credential fields and what LPD-88886 itself preserved on the LDAP field it touched. That restores the system scoped configuration bean registration, so a configuration is honored whether or not that field is set.

The lockout test now resolves the action as a `LifecycleAction` by component name and invokes it directly, so it exercises only the code it covers instead of every registered logout action. `testLogoutWithClickToChatEnabled` still goes through the full logout, which keeps the `logout.events.pre` registration covered.

## Why Are There No Tests?

`LogoutPreActionTest` already covered this regression. `testLogoutWithClickToChatEnabled` and `testLogoutWithoutThemeDisplay` failed before the fix and pass after it, verified locally in both directions by reverting the annotation change and confirming the failures return.

## PR Check

**pr-check: PASS** — tested on `ed9090f04f91368469a77fa8d0e68c87bd474c7b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ed9090f04f91368469a77fa8d0e68c87bd474c7b"} -->
