### PR TITLE
LPD-98971 Add the Add to Launch action for CMS 2.0 content entries

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2640,6 +2640,29 @@ public class DefaultObjectEntryManagerImpl
 			actions = HashMapBuilder.create(
 				actions
 			).<String, Map<String, String>>put(
+				"addToLaunch",
+				() -> {
+					if (!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-17564") ||
+						!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-72278") ||
+						!objectEntryVersion.isApproved()) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.UPDATE,
+						new String[] {
+							"getByExternalReferenceCodeByVersion",
+							"getScopeScopeKeyByExternalReferenceCodeByVersion"
+						},
+						objectDefinition, serviceBuilderObjectEntry,
+						templateParameterMap, dtoConverterContext.getUriInfo());
+				}
+			).put(
 				"copy",
 				() -> {
 					if (!FeatureFlagManagerUtil.isEnabled(
@@ -3534,6 +3557,25 @@ public class DefaultObjectEntryManagerImpl
 			actions = HashMapBuilder.create(
 				actions
 			).<String, Map<String, String>>put(
+				"addToLaunch",
+				() -> {
+					if (!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-17564") ||
+						!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-72278") ||
+						!serviceBuilderObjectEntry.isDraft()) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.UPDATE, "getObjectEntry",
+						serviceBuilderObjectEntry,
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
 				"copy",
 				() -> {
 					if (!FeatureFlagManagerUtil.isEnabled(

--- a/modules/apps/site/site-cms-site-initializer/package.json
+++ b/modules/apps/site/site-cms-site-initializer/package.json
@@ -40,6 +40,7 @@
 		"@liferay/frontend-js-item-selector-web": "*",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",
+		"@liferay/launch-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"@liferay/object-js-components-web": "*",
 		"classnames": "2.3.1",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -305,7 +305,25 @@ public class SectionDisplayContextUtil {
 	public static List<FDSActionDropdownItem> getContentsFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
-		return getFDSActionDropdownItems(httpServletRequest);
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems(httpServletRequest);
+
+		fdsActionDropdownItems.add(
+			FDSActionDropdownItemBuilder.setHref(
+				"{actions.addToLaunch.href}"
+			).setIcon(
+				"rocket"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "add-to-launch")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"addToLaunch"
+			).build(
+				"addToLaunch"
+			));
+
+		return fdsActionDropdownItems;
 	}
 
 	public static String getContentViewURL(ThemeDisplay themeDisplay) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -108,6 +108,10 @@ public class ViewVersionHistoryDisplayContext {
 				StringPool.BLANK, "view", "view-file",
 				_language.get(_httpServletRequest, "view"), null, null, null),
 			new FDSActionDropdownItem(
+				"{actions.addToLaunch.href}", "rocket", "addToLaunch",
+				_language.get(_httpServletRequest, "add-to-launch"), "get",
+				"addToLaunch", null),
+			new FDSActionDropdownItem(
 				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore-version"), "put",
 				"restore", null),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -7,6 +7,8 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend-data-set" prefix="frontend-data-set" %><%@
@@ -15,7 +17,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.EditCategoryDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.EditVocabularyDisplayContext" %><%@

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
@@ -5,6 +5,7 @@
 
 export const OBJECT_DEFINITION_CLASS_NAME =
 	'com.liferay.object.model.ObjectDefinition';
+export const OBJECT_ENTRY_CLASS_NAME = 'com.liferay.object.model.ObjectEntry';
 export const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../common/types/AssetType';
 import {
 	CMSSiteInitializerFDSNames,
+	OBJECT_ENTRY_CLASS_NAME,
 	OBJECT_ENTRY_FOLDER_CLASS_NAME,
 } from '../../common/utils/constants';
 import {getFormattedLabel} from '../../common/utils/getFormattedText';
@@ -460,7 +461,21 @@ export default function AssetsFDSPropsTransformer({
 			items: any;
 			loadData: () => {};
 		}) {
-			if (action?.data?.id === 'copy' || action?.data?.id === 'move') {
+			if (action?.data?.id === 'addToLaunch') {
+				event?.preventDefault();
+
+				Liferay.fire('addToLaunch', {
+					className: OBJECT_ENTRY_CLASS_NAME,
+					classPK: itemData.embedded.id,
+					classVersion: String(
+						itemData.embedded.systemProperties.version.number
+					),
+				});
+			}
+			else if (
+				action?.data?.id === 'copy' ||
+				action?.data?.id === 'move'
+			) {
 				openFolderItemSelectorAction(
 					action?.data?.id,
 					additionalProps.assetLibraries,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -109,7 +109,18 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 			};
 			loadData: () => {};
 		}) {
-			if (action.data.id === 'copy') {
+			if (action.data.id === 'addToLaunch') {
+				event?.preventDefault();
+
+				Liferay.fire('addToLaunch', {
+					className: additionalProps.className,
+					classPK: additionalProps.classPK,
+					classVersion: String(
+						itemData.systemProperties.version.number
+					),
+				});
+			}
+			else if (action.data.id === 'copy') {
 				event?.preventDefault();
 
 				executeAsyncItemAction({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b095e92daaa9a792ac735c49cd2693ff5872ebb8",
+	"@generated": "8efa99be1e94946d7d882c7c4c3e9284d0d2deff",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -40,6 +40,9 @@
 			],
 			"@liferay/frontend-js-state-web/react": [
 				"../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/react/index.ts"
+			],
+			"@liferay/launch-web": [
+				"../../../../../../../launch/launch-web/src/main/resources/META-INF/resources/js/Launches.tsx"
 			],
 			"@liferay/layout-js-components-web": [
 				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
@@ -108,6 +111,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../launch/launch-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
@@ -37,3 +37,12 @@ ViewContentsSectionDisplayContext viewContentsSectionDisplayContext = (ViewConte
 		/>
 	</div>
 </div>
+
+<c:if test='<%= FeatureFlagManagerUtil.isEnabled(themeDisplay.getCompanyId(), "LPD-72278") %>'>
+	<div id="<portlet:namespace />addToLaunchModal">
+		<react:component
+			componentId="addToLaunchModal"
+			module="{AddToLaunchModal} from launch-web"
+		/>
+	</div>
+</c:if>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
@@ -33,4 +33,13 @@ ViewVersionHistoryDisplayContext viewVersionHistoryDisplayContext = (ViewVersion
 		selectionType="multiple"
 		showSelectAll="<%= true %>"
 	/>
+
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled(themeDisplay.getCompanyId(), "LPD-72278") %>'>
+		<div id="<portlet:namespace />addToLaunchModal">
+			<react:component
+				componentId="addToLaunchModal"
+				module="{AddToLaunchModal} from launch-web"
+			/>
+		</div>
+	</c:if>
 </div>

--- a/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "7faff4d11fa831a146b25ebc320377eac4b53d8d",
+	"@generated": "620c99b0e83b15961d1a06408bbd749874694555",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -40,6 +40,9 @@
 			],
 			"@liferay/frontend-js-state-web/react": [
 				"../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/react/index.ts"
+			],
+			"@liferay/launch-web": [
+				"../../../launch/launch-web/src/main/resources/META-INF/resources/js/Launches.tsx"
 			],
 			"@liferay/layout-js-components-web": [
 				"../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
@@ -110,6 +113,9 @@
 		},
 		{
 			"path": "../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../launch/launch-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98971

## What Is Being Fixed

CMS 2.0 content entries (Object Definitions/headless REST-based content, served through site-cms-site-initializer) had no way to be added to a Launch — the "Add to Launch" action only existed for the legacy Web Content admin (journal-web) surface, covered by LPD-97651.

## How It Is Being Fixed

Wires an "Add to Launch" FDS action into the CMS 2.0 content entry assets and version history views (site-cms-site-initializer), backed by a new addToLaunch HAL action link emitted by object-rest-impl's DefaultObjectEntryManagerImpl. This reuses the shared Add to Launch modal and API already delivered by LPD-97651: the click handlers fire the `addToLaunch` event through `Liferay.fire` (matching what the shared modal listens for via `Liferay.on`), and `view_contents.jsp`/`view_version_history.jsp` mount the shared `AddToLaunchModal` component behind the same `LPD-72278` feature flag gate journal-web uses, with the same `id="<portlet:namespace />addToLaunchModal"` / `componentId="addToLaunchModal"` wiring journal-web uses. Verified manually end-to-end: clicking "Add to Launch" on an approved version in Version History opens the modal, and submitting it creates the launch and launch entry successfully.

## Why Are There No Tests?

Proof of concept — test coverage is intentionally skipped for now.

## PR Check

**pr-check: PASS** — tested on `f8f900803f2e15f1e3715a67f3f5bbcb617b084e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f8f900803f2e15f1e3715a67f3f5bbcb617b084e"} -->
