### PR TITLE
LPD-99877 Fix the flaky Add Site modal close click

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/pages/SitesAdminPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/pages/SitesAdminPage.ts
@@ -43,7 +43,12 @@ export class SitesAdminPage {
 		).toBeVisible();
 
 		if (closeModal) {
-			await this.page.locator('.modal').getByLabel('Close').click();
+			await this.page
+				.locator('.modal')
+				.getByRole('button', {exact: true, name: 'Close'})
+				.click({force: true});
+
+			await expect(this.page.locator('.modal')).toBeHidden();
 
 			await expect(
 				this.page.getByRole('heading', {name: 'Provided by Liferay'})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99877

## What Is Being Fixed

The Playwright test `site-admin-web/main/sites.spec.ts > Site is still created even if modal window is closed` fails intermittently with a 90 second test timeout while clicking the Add Site modal's Close button.

The Add Site modal closes itself as soon as site creation returns. `AddGroup.js` fires `closeModal` with a redirect, and `Modal.tsx` responds by fading the modal out and navigating the parent page to the new site's Site Settings, so the test has only the duration of the creation request in which to click Close. A trace of a failing run shows the click starting 15 milliseconds after the form was submitted and then spending the entire remaining 157 millisecond window inside Playwright's actionability loop without ever attempting a click, because the page still laying out behind the modal shifts the vertically centered dialog down by 8 pixels and keeps failing the stability check. Once creation returned, the button detached and never came back, so the click waited out the full test timeout.

## How It Is Being Fixed

The close now clicks with `force`, which skips the visible, stable, and enabled checks that were consuming the window. The click lands roughly 30 milliseconds after the form is submitted regardless of how fast the server responds, and creating a site never returns that quickly, so the margin does not depend on machine speed. In a fresh trace the click completes in 49 milliseconds instead of timing out.

The locator also moves from `getByLabel('Close')` to `getByRole('button', {exact: true, name: 'Close'})`. The unqualified label match is a case insensitive substring match, and the page carries other controls labelled "Close Product Menu" and "Close Search", so only the `.modal` scope was keeping it unambiguous.

Finally, the close is now asserted directly with `toBeHidden`, because the existing check on the "Provided by Liferay" heading proves nothing about the modal. Playwright's visibility check requires only a non empty bounding box and ignores occlusion, so that heading passes while the modal is still open on top of it, which means the test could previously have gone green having closed nothing.

## PR Check

**pr-check: PASS** — tested on `27d0f9665fd21c06589bcf104d3868fb429a6699`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched on path shape but do not apply to this diff. `modules/test/playwright` has no `bnd.bnd` and no `.lfrbuild-portal` marker, so it has no `deploy` task and no bundle to compile. It also has no Jest configuration; its `test` script is `playwright test`, and Playwright execution is out of pr-check's scope. TypeScript type checking did run, as part of Source Format.

<!-- pr-check {"result": "success", "sha": "27d0f9665fd21c06589bcf104d3868fb429a6699"} -->
