### PR TITLE
LPD-99893 Fix the flaky XML sitemap regeneration assertions

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/sitemap/web/internal/portlet/action/test/SaveCompanyConfigurationMVCActionCommandTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/sitemap/web/internal/portlet/action/test/SaveCompanyConfigurationMVCActionCommandTest.java
@@ -539,13 +539,10 @@ public class SaveCompanyConfigurationMVCActionCommandTest {
 		mockLiferayPortletActionRequest.addParameter(
 			"cachedGenerationEnabled", String.valueOf(cachedGenerationEnabled));
 		mockLiferayPortletActionRequest.addParameter(
-			"includeCategories",
-			String.valueOf(RandomTestUtil.randomBoolean()));
+			"includeCategories", "true");
+		mockLiferayPortletActionRequest.addParameter("includePages", "true");
 		mockLiferayPortletActionRequest.addParameter(
-			"includePages", String.valueOf(RandomTestUtil.randomBoolean()));
-		mockLiferayPortletActionRequest.addParameter(
-			"includeWebContent",
-			String.valueOf(RandomTestUtil.randomBoolean()));
+			"includeWebContent", "true");
 		mockLiferayPortletActionRequest.addParameter(
 			"saveAndGenerate", String.valueOf(saveAndGenerate));
 		mockLiferayPortletActionRequest.addParameter(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99893

## What Is Being Fixed

`SaveCompanyConfigurationMVCActionCommandTest.testSaveCompanyConfigurationSaveAndGenerateRegenerates` failed intermittently. It asserts that saving the company sitemap configuration with "Save and Generate" schedules at least one regeneration job, but it periodically found none.

The test randomized the `includeCategories`, `includePages`, and `includeWebContent` request parameters. Those flags are not incidental input — they are the precondition that decides whether anything is scheduled at all. `SitemapManagerImpl._scheduleGroupRegenerateSitemap` returns early unless the asset type's `SitemapURLProvider.isInclude` is true, and each provider gates on the company flag that was just saved: the layout provider on `includePages`, the journal article provider on `includeWebContent`, and the asset category provider on `includeCategories`. The object entry provider is always excluded because the test never selects an object definition. So roughly one run in eight drew false for all three flags, scheduled nothing, and failed the assertion. `scheduleRegenerateSitemap` swallows its outcome into a log statement, so nothing surfaced to explain the empty job list.

## How It Is Being Fixed

The three include parameters are pinned to `true` instead of randomized, so at least one asset type is always included and the regeneration path stays reachable on every run. No caller of the helper asserts anything about these flags — callers either assert that regeneration happened, assert that it did not for reasons independent of the flags (cached generation disabled, or sitemap files already present), or assert unrelated configuration properties — so pinning the value changes no test's intent.

This was confirmed rather than inferred. Forcing all three flags to false reproduces the failure deterministically, in both regeneration tests and at exactly the reported line. A probe over all eight flag combinations showed that zero jobs are scheduled only when all three are false, and that every configuration read back matches what was just written, which rules out an asynchronous configuration propagation race. With the fix the full test class passes repeatedly.

## Why Are There No Tests?

This change is confined to test code. It removes nondeterminism from an existing integration test by pinning a precondition that was previously randomized; there is no production behavior change to cover. The fix was verified by forcing the failing input to reproduce the failure deterministically, then confirming the full test class passes repeatedly.

## PR Check

**pr-check: PASS** — tested on `3e55c97f76ff1e920ec314dafceece2aa544868a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3e55c97f76ff1e920ec314dafceece2aa544868a"} -->
