### PR TITLE
LPD-99896 Set the skip flag before invoking the breadcrumb tag

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/BreadcrumbTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/BreadcrumbTagTest.java
@@ -60,8 +60,9 @@ public class BreadcrumbTagTest {
 
 		_breadcrumbEntryContributorUtilMockedStatic.clearInvocations();
 
-		breadcrumbTag.setAttributes(mockHttpServletRequest);
 		breadcrumbTag.setSkipEntryContributors(true);
+
+		breadcrumbTag.setAttributes(mockHttpServletRequest);
 
 		_breadcrumbEntryContributorUtilMockedStatic.verifyNoInteractions();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99896

## What Is Being Fixed

`BreadcrumbTagTest.testSetAttributes` fails on every run on master. The LPD-98412 follow-up commit alphabetized two consecutive statements, which moved `setAttributes` ahead of `setSkipEntryContributors`. Since `setAttributes` reads `_skipEntryContributors` at invocation time, the second invocation still contributed entries, and `verifyNoInteractions` found the recorded call and failed.

## How It Is Being Fixed

The skip flag is set before the invocation it configures, with an empty line separating the two. `setAttributes` is the call under test rather than a peer setter, so the two statements are not interchangeable and must not be sorted against each other. The restored file is byte-identical to the originally authored version, and the source formatter accepts it unchanged, which confirms the reorder was applied by hand rather than by SF. Both scenarios stay in a single test method, so the fix adds no CI cost.

## PR Check

**pr-check: PASS** — tested on `9f9f07cdf62927638a11fc784a35852f903fd3df`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9f9f07cdf62927638a11fc784a35852f903fd3df"} -->
