### PR TITLE
LPD-99897 Skip the LiveChat Click to Chat tests

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/clickToChatInstanceSettings.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/clickToChatInstanceSettings.spec.ts
@@ -57,6 +57,7 @@ const providers = [
 		iconKey: 'liveChatIcon',
 		name: 'LiveChat',
 		passwordKey: 'livechat',
+		skip: true,
 	},
 	{
 		iconKey: 'livePersonIcon',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99897

## What Is Being Fixed

The two generated LiveChat tests in clickToChatInstanceSettings.spec.ts fail consistently. The LiveChat account ID supplied through CLICK_TO_CHAT_LIVECHAT_PASSWORD is no longer valid, so the LiveChat widget never loads and the liveChatIcon assertion never resolves.

## How It Is Being Fixed

Add skip: true to the LiveChat entry in the providers array. The existing runTest dispatch routes flagged providers through test.skip, so both LiveChat cases are skipped without touching the shared test bodies. This matches how LivePerson, TawkTo, and Zendesk are already handled in the same array, all of which are blocked on the same class of third-party credential problem.

## Why Are There No Tests?

This is a test-only change that disables coverage for a provider whose credentials are invalid. There is no product code to cover.

## PR Check

**pr-check: PASS** — tested on `f0a389fff2ee46de1126690b85ad6ae083c0b1c6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Typecheck (substituted for JavaScript Unit Tests) | PASS |

<!-- pr-check {"result": "success", "sha": "f0a389fff2ee46de1126690b85ad6ae083c0b1c6"} -->
