### PR TITLE
LPD-100025 Select the Site Administrator role by name

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/pages/MembershipsPage.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/pages/MembershipsPage.ts
@@ -51,21 +51,15 @@ export class MembershipsPage {
 	}
 
 	async assignSiteAdministratorRole() {
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('button', {name: 'Assign Roles'}),
-			timeout: 500,
-			trigger: this.page.getByLabel('Select All Items on the Page'),
-		});
+		await this.page.getByLabel('Select All Items on the Page').check();
+
+		await this.page.getByRole('button', {name: 'Assign Roles'}).click();
 
 		await this.page
 			.frameLocator('iframe[title="Assign Roles"]')
-			.locator(
-				'[id="_com_liferay_site_memberships_web_portlet_SiteMembershipsPortlet_roles_1"] svg'
-			)
-			.click();
-
-		await this.page.waitForTimeout(500);
+			.locator('.file-card', {hasText: 'Site Administrator'})
+			.getByRole('checkbox')
+			.check();
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
 
@@ -90,6 +84,10 @@ export class MembershipsPage {
 				this.page.getByRole('heading', {name: 'Search Results'})
 			).toBeVisible({timeout: 1000});
 		}).toPass();
+
+		await expect(
+			this.page.getByLabel('Select All Items on the Page')
+		).toBeVisible();
 	}
 
 	async goto() {
@@ -130,14 +128,11 @@ export class MembershipsPage {
 			dialog.accept();
 		});
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('button', {
-				name: 'Remove Role: Site Administrator',
-			}),
-			timeout: 500,
-			trigger: this.page.getByLabel('Select All Items on the Page'),
-		});
+		await this.page.getByLabel('Select All Items on the Page').check();
+
+		await this.page
+			.getByRole('button', {name: 'Remove Role: Site Administrator'})
+			.click();
 
 		await waitForAlert(this.page);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100025

## What Is Being Fixed

The two `@LPD-41737` bulk role removal tests in `memberships.spec.ts` have been failing consistently. Both timed out after 90 seconds waiting for the "Select All Items on the Page" checkbox, which made them look like flakes.

They were not. `MembershipsPage` selected the role in the Assign Roles dialog through the search container row id, and that id falls back to the row index when the row has no id property, so the locator resolved to whatever site role sorted first by title. LPD-97613 removed the LPD-66359 feature flag from the DSR site initializer, which now always runs and creates the DSR Content Contributor and DSR Room Collaborator site roles. Both sort before Site Administrator, so the tests assigned the wrong role, the filter that follows returned no members, and an empty result set makes the management toolbar render no select all checkbox. The failure surfaced two steps after its cause.

## How It Is Being Fixed

The role is now selected by name, which removes the dependency on how many site roles exist and how they sort.

Two related changes keep the next regression legible. The select all checkbox is checked rather than clicked through a retry loop, because re-firing a click on a toggle deselects everything, and because `check()` is idempotent and verifies that the box ended up checked. Filtering now asserts that the result set is not empty, so a future break fails at the assignment rather than in an unrelated helper.

## Why Are There No Tests?

The change is confined to test code and adds no production behavior. It repairs two existing tests, so those tests are the verification: both were failing before the change and pass after it, including 10 runs each and a full pass of `memberships.spec.ts` (18/18).

## PR Check

**pr-check: PASS** — tested on `1d04a7f1a9465fe0709d507e7b3f47e8bd3cc59a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1d04a7f1a9465fe0709d507e7b3f47e8bd3cc59a"} -->
