### PR TITLE
LPD-100015 Set the default site name the friendly URL check needs

### DIFF
--- a/modules/test/playwright/tests/friendly-url-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/friendly-url-web/main/env/portal-ext.properties
@@ -1,0 +1,1 @@
+virtual.hosts.default.site.name=Guest


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100015

## What Is Being Fixed

The Playwright test `friendlyURLPublicMappingCheck.spec.ts` > "Run check reports a page that conflicts with a site friendly URL" has failed since it was added in LPD-93388. It waits for a warning alert listing the conflict, but the Friendly URLs tab always rendered the green "No conflicts were found" alert instead.

The gate itself is correct: the check reports pages of the site served at root that would become ambiguous once the public friendly URL mapping is disabled, and which site that is comes from `virtual.hosts.default.site.name`. With no default site at root there is no ambiguity to report. The integration test already forces the property to `Guest` and restores it afterward; the Playwright project had no equivalent.

## How It Is Being Fixed

The `friendly-url-web.main` project now carries an `env/portal-ext.properties` that sets `virtual.hosts.default.site.name=Guest`. The environment loader combines property files from the Playwright base directory down to the project directory with the project file last, so this overrides the blank inherited from the base environment.

## PR Check

**pr-check: PASS** — tested on `f9611be6c32a8b6150ea709063dad74eac2a80cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f9611be6c32a8b6150ea709063dad74eac2a80cf"} -->
