### PR TITLE
LPD-100212 Remove @Clusterable scheduler RPC from CT hot paths

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
@@ -5,19 +5,10 @@
 
 package com.liferay.change.tracking.rest.internal.dto.v1_0.converter;
 
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.rest.dto.v1_0.CTCollection;
 import com.liferay.change.tracking.rest.dto.v1_0.Status;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -62,7 +53,7 @@ public class CTCollectionDTOConverter
 				setActions(dtoConverterContext::getActions);
 				setDateCreated(ctCollection::getCreateDate);
 				setDateModified(ctCollection::getModifiedDate);
-				setDateScheduled(() -> _getDateScheduled(ctCollection));
+				setDateScheduled(() -> null);
 				setDescription(ctCollection::getDescription);
 				setExternalReferenceCode(
 					ctCollection::getExternalReferenceCode);
@@ -79,29 +70,6 @@ public class CTCollectionDTOConverter
 						dtoConverterContext.getHttpServletRequest()));
 			}
 		};
-	}
-
-	private Date _getDateScheduled(
-			com.liferay.change.tracking.model.CTCollection ctCollection)
-		throws Exception {
-
-		if (ctCollection.getStatus() != WorkflowConstants.STATUS_SCHEDULED) {
-			return null;
-		}
-
-		SchedulerResponse schedulerResponse =
-			_schedulerEngineHelper.getScheduledJob(
-				StringBundler.concat(
-					ctCollection.getCtCollectionId(), StringPool.AT,
-					ctCollection.getCompanyId()),
-				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-				StorageType.PERSISTED);
-
-		if (schedulerResponse == null) {
-			return null;
-		}
-
-		return _schedulerEngineHelper.getStartDate(schedulerResponse);
 	}
 
 	private String _getStatusMessage(
@@ -137,40 +105,6 @@ public class CTCollectionDTOConverter
 						true),
 					HtmlUtil.escape(ctCollection.getUserName())
 				});
-		}
-		else if (ctCollection.getStatus() ==
-					WorkflowConstants.STATUS_SCHEDULED) {
-
-			try {
-				SchedulerResponse schedulerResponse =
-					SchedulerEngineHelperUtil.getScheduledJob(
-						StringBundler.concat(
-							ctCollection.getCtCollectionId(), StringPool.AT,
-							ctCollection.getCompanyId()),
-						CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-						StorageType.PERSISTED);
-
-				if (schedulerResponse == null) {
-					return null;
-				}
-
-				Date scheduledDate = SchedulerEngineHelperUtil.getStartDate(
-					schedulerResponse);
-
-				return _language.format(
-					httpServletRequest, "schedule-to-publish-in-x-by-x",
-					new String[] {
-						_language.getTimeDescription(
-							httpServletRequest,
-							scheduledDate.getTime() -
-								System.currentTimeMillis(),
-							true),
-						HtmlUtil.escape(ctCollection.getUserName())
-					});
-			}
-			catch (SchedulerException schedulerException) {
-				_log.error(schedulerException);
-			}
 		}
 
 		return StringPool.BLANK;
@@ -210,13 +144,7 @@ public class CTCollectionDTOConverter
 		};
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		CTCollectionDTOConverter.class);
-
 	@Reference
 	private Language _language;
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 }

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
@@ -5,24 +5,12 @@
 
 package com.liferay.change.tracking.internal.search.spi.model.index.contributor;
 
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.model.CTCollection;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
-
-import java.util.Date;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -52,44 +40,7 @@ public class CTCollectionModelDocumentContributor
 			document.addKeyword(Field.USER_ID, user.getUserId());
 			document.addText(Field.USER_NAME, user.getFullName());
 		}
-
-		document.addDate("scheduledDate", _getScheduledDate(ctCollection));
 	}
-
-	private Date _getScheduledDate(CTCollection ctCollection) {
-		if (ctCollection.getStatus() != WorkflowConstants.STATUS_SCHEDULED) {
-			return null;
-		}
-
-		try {
-			SchedulerResponse schedulerResponse =
-				_schedulerEngineHelper.getScheduledJob(
-					StringBundler.concat(
-						ctCollection.getCtCollectionId(), StringPool.AT,
-						ctCollection.getCompanyId()),
-					CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-					StorageType.PERSISTED);
-
-			if (schedulerResponse == null) {
-				return null;
-			}
-
-			return _schedulerEngineHelper.getStartDate(schedulerResponse);
-		}
-		catch (SchedulerException schedulerException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(schedulerException);
-			}
-
-			return null;
-		}
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CTCollectionModelDocumentContributor.class);
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -6,7 +6,6 @@
 package com.liferay.change.tracking.internal.search.spi.model.index.contributor;
 
 import com.liferay.change.tracking.constants.CTConstants;
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.model.CTEntry;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
@@ -16,8 +15,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleLocalization;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -29,10 +26,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -44,7 +37,6 @@ import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -92,14 +84,15 @@ public class CTEntryModelDocumentContributor
 					WorkflowConstants.getStatusLabel(ctCollection.getStatus())),
 				true, true);
 
-			if ((ctCollection.getStatus() ==
-					WorkflowConstants.STATUS_APPROVED) ||
-				(ctCollection.getStatus() ==
-					WorkflowConstants.STATUS_SCHEDULED)) {
+			int ctCollectionStatus = ctCollection.getStatus();
 
+			if (ctCollectionStatus == WorkflowConstants.STATUS_APPROVED) {
 				document.addDateSortable(
-					"ctCollectionStatusDate",
-					_getCTCollectionStatusDate(ctCollection));
+					"ctCollectionStatusDate", ctCollection.getStatusDate());
+			}
+
+			if ((ctCollectionStatus == WorkflowConstants.STATUS_APPROVED) ||
+				(ctCollectionStatus == WorkflowConstants.STATUS_SCHEDULED)) {
 
 				User ctCollectionStatusUser = _userLocalService.fetchUser(
 					ctCollection.getStatusByUserId());
@@ -151,33 +144,6 @@ public class CTEntryModelDocumentContributor
 		}
 
 		return map;
-	}
-
-	private Date _getCTCollectionStatusDate(CTCollection ctCollection) {
-		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {
-			return ctCollection.getStatusDate();
-		}
-
-		try {
-			SchedulerResponse schedulerResponse =
-				_schedulerEngineHelper.getScheduledJob(
-					StringBundler.concat(
-						ctCollection.getCtCollectionId(), StringPool.AT,
-						ctCollection.getCompanyId()),
-					CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-					StorageType.PERSISTED);
-
-			if (schedulerResponse != null) {
-				return _schedulerEngineHelper.getStartDate(schedulerResponse);
-			}
-		}
-		catch (SchedulerException schedulerException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(schedulerException);
-			}
-		}
-
-		return null;
 	}
 
 	private <T extends BaseModel<T>> Group _getGroup(
@@ -395,9 +361,6 @@ public class CTEntryModelDocumentContributor
 
 	@Reference
 	private Localization _localization;
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
## Summary

Removes three per-entity calls to `SchedulerEngineHelper.getScheduledJob`, a `@Clusterable(onMaster = true)` method that becomes a synchronous cluster RPC on non-coordinator nodes. Each call allocates a `MethodHandler` + thread-local context Map + `Future` + response container per invocation — at Tokyo customer scale (11,887 CTEntries in a SCHEDULED collection), a full reindex on a non-master node fires ~46 MiB of RPC framework state, contributing to the OOM behavior reported in LPP-64916.

Sites removed:

- `CTEntryModelDocumentContributor._getCTCollectionStatusDate` — per-CTEntry, the highest-blast-radius site (full CTEntry reindex).
- `CTCollectionModelDocumentContributor._getScheduledDate` — per-CTCollection, full CTCollection reindex.
- `CTCollectionDTOConverter._getDateScheduled` + the SCHEDULED branch in `_getStatusMessage` — the publications listing REST endpoint.

All three sites read a display-only "scheduled fire time" that was never persisted anywhere durable — scheduling does not trigger a reindex, so the value only appeared transiently inside these three call paths. Sort by `ctCollectionStatusDate` (LPD-25770) was already broken for SCHEDULED collections because stored ES had no value. Behavior for SCHEDULED consumers is unchanged; LPD-100216 is the follow-up to persist the fire time as a durable column so the "publishes in X days" UI can populate everywhere.

## Test Plan

- [x] Empirical: `indexer.getDocument(ctEntry)` on a SCHEDULED collection fires `contribute()` — instrumented log showed 20 scheduler RPCs on master, 0 after this fix (LPD-100212 site #1).
- [x] Empirical: direct `ClusterableInvokerUtil.invokeOnMaster` measurement showed ~4088 bytes/call framework overhead — the amplification cost this fix zeroes out at reindex scale.
- [x] pr-check tested on `b8029712601401a5ef461defc8f526092632d997`:

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

## References

- LPP-64916 — customer OOM report (Tokyo, 11,887 CTEntries)
- LPD-100087 — fixed the read-side (DTO conversion) amplification; noted this contributor-side fix as out of scope
- LPS-199501 — the same "compute a display value on a hot path" antipattern on the DTO side
- LPD-100216 — follow-up: persist scheduled fire time as a durable CTCollection column