### PR TITLE
LPD-95623 Treat an unset active flag as active for system groups

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -1069,7 +1069,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 			if ((group.isCompany() || group.isControlPanel() ||
 				 group.isGuest()) &&
-				(site.getActive() == false)) {
+				!_isActive(site.getActive())) {
 
 				throw new RequiredGroupException.MustNotDeactivateSystemGroup(
 					site.getExternalReferenceCode());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -273,6 +273,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.testPutSiteSiteInitializer();
 
 		_testPutSiteSiteInitializerPreservesFriendlyUrlPath();
+		_testPutSiteSiteInitializerSystemSite();
 	}
 
 	@Override
@@ -1661,6 +1662,57 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		Assert.assertEquals(
 			originalFriendlyUrlPath, getSite.getFriendlyUrlPath());
+	}
+
+	private void _testPutSiteSiteInitializerSystemSite() throws Exception {
+		Group guestGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+		try {
+			Site site = new Site() {
+				{
+					externalReferenceCode =
+						guestGroup.getExternalReferenceCode();
+					name = GroupConstants.GUEST;
+				}
+			};
+
+			Site putSite = siteResource.putSiteSiteInitializer(
+				guestGroup.getExternalReferenceCode(), site,
+				getMultipartFiles());
+
+			Assert.assertTrue(putSite.getActive());
+
+			site.setActive(false);
+
+			try {
+				siteResource.putSiteSiteInitializer(
+					guestGroup.getExternalReferenceCode(), site,
+					getMultipartFiles());
+
+				Assert.fail();
+			}
+			catch (Problem.ProblemException problemException) {
+				Problem problem = problemException.getProblem();
+
+				Assert.assertEquals("METHOD_NOT_ALLOWED", problem.getStatus());
+				Assert.assertEquals(
+					String.format(
+						"Site %s cannot be deactivated because it is a " +
+							"system required site",
+						guestGroup.getExternalReferenceCode()),
+					problem.getTitle());
+			}
+		}
+		finally {
+			Group group = _groupLocalService.getGroup(guestGroup.getGroupId());
+
+			group.setType(guestGroup.getType());
+			group.setTypeSettings(guestGroup.getTypeSettings());
+			group.setManualMembership(guestGroup.isManualMembership());
+
+			_groupLocalService.updateGroup(group);
+		}
 	}
 
 	private void _testPutSiteWithExcludedTypeSettings() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95623

## What Is Being Fixed

`HeadlessAdminSiteResourceImpl.putSiteSiteInitializer` (and `postSiteSiteInitializer`) threw a `NullPointerException` when the target site already existed and was a system group (Global, Guest, or Control Panel) and the `Site` payload did not set `active`. Site initializer client extensions never set `active` — their generated `site-initializer.json` only carries `externalReferenceCode` and `name` — so deploying one against a system group always failed.

## How It Is Being Fixed

The guard in `_updateGroup` that prevents deactivating a system group unboxed `Site.getActive()` without a null check (`site.getActive() == false`). It now uses the null-safe `_isActive` helper the method already uses for the `updateGroup` call, so an unspecified `active` is treated as active and the update proceeds, while an explicit `active: false` on a system group still fails with `MustNotDeactivateSystemGroup`. A new integration test covers both paths against the Guest group.

## PR Check

**pr-check: PASS** — tested on `029fd236f03d0eb01923e16d030357a4ac8c76bd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "029fd236f03d0eb01923e16d030357a4ac8c76bd"} -->
