### PR TITLE
LPD-48016 Assert the collection is deleted using its collection ID

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTProcessLocalServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTProcessLocalServiceTest.java
@@ -150,7 +150,7 @@ public class CTProcessLocalServiceTest {
 				ctProcess.getCtProcessId());
 
 			ctCollection = _ctCollectionLocalService.fetchCTCollection(
-				ctProcess.getCtProcessId());
+				ctProcess.getCtCollectionId());
 
 			Assert.assertNull(ctCollection);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-48016

## What Is Being Fixed

`CTProcessLocalServiceTest.testDeleteCTCollectionWithCTProcess` failed intermittently with `AssertionError: expected null, but was:<{...}>`. After deleting a successfully published `CTProcess`, the test fetched the collection with `fetchCTCollection(ctProcess.getCtProcessId())`, passing a process ID where a collection ID is required. The `assertNull` therefore held only while no `CTCollection` happened to own an ID numerically equal to that process ID, and failed as soon as one did — the reported failure returned an unrelated collection named `CTCollectionLocalServiceTest`.

## How It Is Being Fixed

The assertion now fetches by `ctProcess.getCtCollectionId()`, so it checks the collection the process actually published. `CTProcessLocalServiceImpl.deleteCTProcess` deletes the collection when its background task completed successfully, which is the state the test reaches, so `assertNull` is the correct expectation and no longer depends on an ID coincidence. Verified by mutation: the corrected assertion passes, and temporarily flipping it to `assertNotNull` fails, confirming the collection is genuinely deleted rather than the assertion passing vacuously.

## Why Are There No Tests?

The change is itself the test correction; no product code changed. The behavior is already covered by this test, which previously asserted nothing meaningful.

## PR Check

**pr-check: PASS** — tested on `9cae2fafc5a9483a2b5c9f2e5d19092f89ed22cb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9cae2fafc5a9483a2b5c9f2e5d19092f89ed22cb"} -->
