### PR TITLE
LPD-100216 Persist scheduledDate on CTCollection so the publishes-in-X-days UI works

### DIFF
--- a/modules/apps/change-tracking/change-tracking-api/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking API
 Bundle-SymbolicName: com.liferay.change.tracking.api
-Bundle-Version: 36.0.2
+Bundle-Version: 36.1.0
 Export-Package:\
 	com.liferay.change.tracking.closure,\
 	com.liferay.change.tracking.configuration,\

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionModel.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionModel.java
@@ -279,6 +279,20 @@ public interface CTCollectionModel
 	public void setOnDemandUserUuid(String onDemandUserUuid);
 
 	/**
+	 * Returns the scheduled date of this ct collection.
+	 *
+	 * @return the scheduled date of this ct collection
+	 */
+	public Date getScheduledDate();
+
+	/**
+	 * Sets the scheduled date of this ct collection.
+	 *
+	 * @param scheduledDate the scheduled date of this ct collection
+	 */
+	public void setScheduledDate(Date scheduledDate);
+
+	/**
 	 * Returns the shareable of this ct collection.
 	 *
 	 * @return the shareable of this ct collection
@@ -363,4 +377,4 @@ public interface CTCollectionModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1380836720
+// LIFERAY-SERVICE-BUILDER-HASH:-1314799029

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionTable.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionTable.java
@@ -51,6 +51,8 @@ public class CTCollectionTable extends BaseTable<CTCollectionTable> {
 		"description", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<CTCollectionTable, Long> onDemandUserId = createColumn(
 		"onDemandUserId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<CTCollectionTable, Date> scheduledDate = createColumn(
+		"scheduledDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 	public final Column<CTCollectionTable, Boolean> shareable = createColumn(
 		"shareable", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
 	public final Column<CTCollectionTable, Integer> status = createColumn(
@@ -65,4 +67,4 @@ public class CTCollectionTable extends BaseTable<CTCollectionTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1472358053
+// LIFERAY-SERVICE-BUILDER-HASH:984313143

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionWrapper.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTCollectionWrapper.java
@@ -47,6 +47,7 @@ public class CTCollectionWrapper
 		attributes.put("name", getName());
 		attributes.put("description", getDescription());
 		attributes.put("onDemandUserId", getOnDemandUserId());
+		attributes.put("scheduledDate", getScheduledDate());
 		attributes.put("shareable", isShareable());
 		attributes.put("status", getStatus());
 		attributes.put("statusByUserId", getStatusByUserId());
@@ -134,6 +135,12 @@ public class CTCollectionWrapper
 
 		if (onDemandUserId != null) {
 			setOnDemandUserId(onDemandUserId);
+		}
+
+		Date scheduledDate = (Date)attributes.get("scheduledDate");
+
+		if (scheduledDate != null) {
+			setScheduledDate(scheduledDate);
 		}
 
 		Boolean shareable = (Boolean)attributes.get("shareable");
@@ -284,6 +291,16 @@ public class CTCollectionWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the scheduled date of this ct collection.
+	 *
+	 * @return the scheduled date of this ct collection
+	 */
+	@Override
+	public Date getScheduledDate() {
+		return model.getScheduledDate();
 	}
 
 	/**
@@ -547,6 +564,16 @@ public class CTCollectionWrapper
 	}
 
 	/**
+	 * Sets the scheduled date of this ct collection.
+	 *
+	 * @param scheduledDate the scheduled date of this ct collection
+	 */
+	@Override
+	public void setScheduledDate(Date scheduledDate) {
+		model.setScheduledDate(scheduledDate);
+	}
+
+	/**
 	 * Sets the schema version ID of this ct collection.
 	 *
 	 * @param schemaVersionId the schema version ID of this ct collection
@@ -652,4 +679,4 @@ public class CTCollectionWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1040640958
+// LIFERAY-SERVICE-BUILDER-HASH:-233953900

--- a/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/model/packageinfo
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/resources/com/liferay/change/tracking/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.12.0
+version 3.13.0

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
@@ -5,19 +5,10 @@
 
 package com.liferay.change.tracking.rest.internal.dto.v1_0.converter;
 
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.rest.dto.v1_0.CTCollection;
 import com.liferay.change.tracking.rest.dto.v1_0.Status;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -82,26 +73,13 @@ public class CTCollectionDTOConverter
 	}
 
 	private Date _getDateScheduled(
-			com.liferay.change.tracking.model.CTCollection ctCollection)
-		throws Exception {
+		com.liferay.change.tracking.model.CTCollection ctCollection) {
 
 		if (ctCollection.getStatus() != WorkflowConstants.STATUS_SCHEDULED) {
 			return null;
 		}
 
-		SchedulerResponse schedulerResponse =
-			_schedulerEngineHelper.getScheduledJob(
-				StringBundler.concat(
-					ctCollection.getCtCollectionId(), StringPool.AT,
-					ctCollection.getCompanyId()),
-				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-				StorageType.PERSISTED);
-
-		if (schedulerResponse == null) {
-			return null;
-		}
-
-		return _schedulerEngineHelper.getStartDate(schedulerResponse);
+		return ctCollection.getScheduledDate();
 	}
 
 	private String _getStatusMessage(
@@ -141,36 +119,21 @@ public class CTCollectionDTOConverter
 		else if (ctCollection.getStatus() ==
 					WorkflowConstants.STATUS_SCHEDULED) {
 
-			try {
-				SchedulerResponse schedulerResponse =
-					SchedulerEngineHelperUtil.getScheduledJob(
-						StringBundler.concat(
-							ctCollection.getCtCollectionId(), StringPool.AT,
-							ctCollection.getCompanyId()),
-						CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-						StorageType.PERSISTED);
+			Date scheduledDate = ctCollection.getScheduledDate();
 
-				if (schedulerResponse == null) {
-					return null;
-				}
-
-				Date scheduledDate = SchedulerEngineHelperUtil.getStartDate(
-					schedulerResponse);
-
-				return _language.format(
-					httpServletRequest, "schedule-to-publish-in-x-by-x",
-					new String[] {
-						_language.getTimeDescription(
-							httpServletRequest,
-							scheduledDate.getTime() -
-								System.currentTimeMillis(),
-							true),
-						HtmlUtil.escape(ctCollection.getUserName())
-					});
+			if (scheduledDate == null) {
+				return StringPool.BLANK;
 			}
-			catch (SchedulerException schedulerException) {
-				_log.error(schedulerException);
-			}
+
+			return _language.format(
+				httpServletRequest, "schedule-to-publish-in-x-by-x",
+				new String[] {
+					_language.getTimeDescription(
+						httpServletRequest,
+						scheduledDate.getTime() - System.currentTimeMillis(),
+						true),
+					HtmlUtil.escape(ctCollection.getUserName())
+				});
 		}
 
 		return StringPool.BLANK;
@@ -210,13 +173,7 @@ public class CTCollectionDTOConverter
 		};
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		CTCollectionDTOConverter.class);
-
 	@Reference
 	private Language _language;
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 }

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -77,6 +77,10 @@ public class CTEntryDTOConverter
 		String ctCollectionStatusUserName,
 		HttpServletRequest httpServletRequest) {
 
+		if (ctCollectionStatusDate == null) {
+			return StringPool.BLANK;
+		}
+
 		if (ctCollectionStatus == WorkflowConstants.STATUS_APPROVED) {
 			return _language.format(
 				httpServletRequest, "published-x-ago-by-x",

--- a/modules/apps/change-tracking/change-tracking-service/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Change Tracking Service
 Bundle-SymbolicName: com.liferay.change.tracking.service
 Bundle-Version: 3.0.137
-Liferay-Require-SchemaVersion: 2.14.0
+Liferay-Require-SchemaVersion: 2.15.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/change-tracking/change-tracking-service/service.xml
+++ b/modules/apps/change-tracking/change-tracking-service/service.xml
@@ -59,6 +59,7 @@
 		<column name="name" type="String" />
 		<column name="description" type="String" />
 		<column name="onDemandUserId" type="long" />
+		<column name="scheduledDate" type="Date" />
 		<column name="shareable" type="boolean" />
 		<column name="status" type="int" />
 		<column name="statusByUserId" type="long" />

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTPublishBackgroundTaskExecutor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTPublishBackgroundTaskExecutor.java
@@ -248,6 +248,7 @@ public class CTPublishBackgroundTaskExecutor
 
 		latestCTCollection.setModifiedDate(modifiedDate);
 
+		latestCTCollection.setScheduledDate(null);
 		latestCTCollection.setStatus(WorkflowConstants.STATUS_APPROVED);
 		latestCTCollection.setStatusByUserId(backgroundTask.getUserId());
 		latestCTCollection.setStatusDate(modifiedDate);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/BackgroundTaskModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/BackgroundTaskModelListener.java
@@ -83,6 +83,7 @@ public class BackgroundTaskModelListener
 						status = WorkflowConstants.STATUS_INCOMPLETE;
 					}
 
+					ctCollection.setScheduledDate(null);
 					ctCollection.setStatus(status);
 
 					_ctCollectionLocalService.updateCTCollection(ctCollection);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/scheduler/PublishSchedulerImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/scheduler/PublishSchedulerImpl.java
@@ -154,6 +154,7 @@ public class PublishSchedulerImpl implements PublishScheduler {
 			ctCollection.setStatus(WorkflowConstants.STATUS_DRAFT);
 		}
 
+		ctCollection.setScheduledDate(null);
 		ctCollection.setStatusByUserId(UserConstants.USER_ID_DEFAULT);
 
 		_ctCollectionLocalService.updateCTCollection(ctCollection);
@@ -190,6 +191,7 @@ public class PublishSchedulerImpl implements PublishScheduler {
 			PermissionThreadLocal.getPermissionChecker(), ctCollection,
 			CTActionKeys.PUBLISH);
 
+		ctCollection.setScheduledDate(startDate);
 		ctCollection.setStatus(WorkflowConstants.STATUS_SCHEDULED);
 		ctCollection.setStatusByUserId(userId);
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
@@ -5,24 +5,13 @@
 
 package com.liferay.change.tracking.internal.search.spi.model.index.contributor;
 
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.model.CTCollection;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
-
-import java.util.Date;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,43 +42,10 @@ public class CTCollectionModelDocumentContributor
 			document.addText(Field.USER_NAME, user.getFullName());
 		}
 
-		document.addDate("scheduledDate", _getScheduledDate(ctCollection));
-	}
-
-	private Date _getScheduledDate(CTCollection ctCollection) {
-		if (ctCollection.getStatus() != WorkflowConstants.STATUS_SCHEDULED) {
-			return null;
-		}
-
-		try {
-			SchedulerResponse schedulerResponse =
-				_schedulerEngineHelper.getScheduledJob(
-					StringBundler.concat(
-						ctCollection.getCtCollectionId(), StringPool.AT,
-						ctCollection.getCompanyId()),
-					CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-					StorageType.PERSISTED);
-
-			if (schedulerResponse == null) {
-				return null;
-			}
-
-			return _schedulerEngineHelper.getStartDate(schedulerResponse);
-		}
-		catch (SchedulerException schedulerException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(schedulerException);
-			}
-
-			return null;
+		if (ctCollection.getStatus() == WorkflowConstants.STATUS_SCHEDULED) {
+			document.addDate("scheduledDate", ctCollection.getScheduledDate());
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CTCollectionModelDocumentContributor.class);
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -6,7 +6,6 @@
 package com.liferay.change.tracking.internal.search.spi.model.index.contributor;
 
 import com.liferay.change.tracking.constants.CTConstants;
-import com.liferay.change.tracking.constants.CTDestinationNames;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.model.CTEntry;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
@@ -16,8 +15,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleLocalization;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -29,10 +26,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
-import com.liferay.portal.kernel.scheduler.StorageType;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -158,23 +151,8 @@ public class CTEntryModelDocumentContributor
 			return ctCollection.getStatusDate();
 		}
 
-		try {
-			SchedulerResponse schedulerResponse =
-				_schedulerEngineHelper.getScheduledJob(
-					StringBundler.concat(
-						ctCollection.getCtCollectionId(), StringPool.AT,
-						ctCollection.getCompanyId()),
-					CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
-					StorageType.PERSISTED);
-
-			if (schedulerResponse != null) {
-				return _schedulerEngineHelper.getStartDate(schedulerResponse);
-			}
-		}
-		catch (SchedulerException schedulerException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(schedulerException);
-			}
+		if (ctCollection.getStatus() == WorkflowConstants.STATUS_SCHEDULED) {
+			return ctCollection.getScheduledDate();
 		}
 
 		return null;
@@ -395,9 +373,6 @@ public class CTEntryModelDocumentContributor
 
 	@Reference
 	private Localization _localization;
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/registry/ChangeTrackingServiceUpgradeStepRegistrator.java
@@ -9,10 +9,12 @@ import com.liferay.change.tracking.internal.upgrade.v2_10_0.CTCollectionUpgradeP
 import com.liferay.change.tracking.internal.upgrade.v2_12_3.CTMessageCompanyIdUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_12_4.CTProcessResourceUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_14_0.CTConflictCheckerDispatchTriggerUpgradeProcess;
+import com.liferay.change.tracking.internal.upgrade.v2_15_0.CTCollectionScheduledDateUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_3_0.UpgradeCompanyId;
 import com.liferay.change.tracking.internal.upgrade.v2_4_0.CTSchemaVersionUpgradeProcess;
 import com.liferay.change.tracking.internal.upgrade.v2_7_0.CTProcessUpgradeProcess;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseUuidUpgradeProcess;
@@ -156,6 +158,11 @@ public class ChangeTrackingServiceUpgradeStepRegistrator
 		registry.register(
 			"2.13.1", "2.14.0",
 			new CTConflictCheckerDispatchTriggerUpgradeProcess());
+
+		registry.register(
+			"2.14.0", "2.15.0",
+			new CTCollectionScheduledDateUpgradeProcess(
+				_schedulerEngineHelper));
 	}
 
 	@Reference
@@ -166,5 +173,8 @@ public class ChangeTrackingServiceUpgradeStepRegistrator
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private SchedulerEngineHelper _schedulerEngineHelper;
 
 }

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_15_0/CTCollectionScheduledDateUpgradeProcess.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/v2_15_0/CTCollectionScheduledDateUpgradeProcess.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_15_0;
+
+import com.liferay.change.tracking.constants.CTDestinationNames;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
+import com.liferay.portal.kernel.scheduler.StorageType;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Kiana Suetani
+ */
+public class CTCollectionScheduledDateUpgradeProcess extends UpgradeProcess {
+
+	public CTCollectionScheduledDateUpgradeProcess(
+		SchedulerEngineHelper schedulerEngineHelper) {
+
+		_schedulerEngineHelper = schedulerEngineHelper;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		List<SchedulerResponse> schedulerResponses =
+			_schedulerEngineHelper.getScheduledJobs(
+				CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
+				StorageType.PERSISTED);
+
+		if (schedulerResponses.isEmpty()) {
+			return;
+		}
+
+		try (PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update CTCollection set scheduledDate = ? where " +
+						"ctCollectionId = ? and status = ?")) {
+
+			for (SchedulerResponse schedulerResponse : schedulerResponses) {
+				Date date = _schedulerEngineHelper.getStartDate(
+					schedulerResponse);
+
+				if (date == null) {
+					continue;
+				}
+
+				String jobName = schedulerResponse.getJobName();
+
+				long ctCollectionId = GetterUtil.getLong(
+					jobName.substring(0, jobName.indexOf(StringPool.AT)));
+
+				preparedStatement.setTimestamp(
+					1, new Timestamp(date.getTime()));
+				preparedStatement.setLong(2, ctCollectionId);
+				preparedStatement.setInt(3, WorkflowConstants.STATUS_SCHEDULED);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+	}
+
+	@Override
+	protected UpgradeStep[] getPreUpgradeSteps() {
+		return new UpgradeStep[] {
+			UpgradeProcessFactory.addColumns(
+				"CTCollection", "scheduledDate DATE null")
+		};
+	}
+
+	private final SchedulerEngineHelper _schedulerEngineHelper;
+
+}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTCollectionCacheModel.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTCollectionCacheModel.java
@@ -68,7 +68,7 @@ public class CTCollectionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(35);
+		StringBundler sb = new StringBundler(37);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -96,6 +96,8 @@ public class CTCollectionCacheModel
 		sb.append(description);
 		sb.append(", onDemandUserId=");
 		sb.append(onDemandUserId);
+		sb.append(", scheduledDate=");
+		sb.append(scheduledDate);
 		sb.append(", shareable=");
 		sb.append(shareable);
 		sb.append(", status=");
@@ -165,6 +167,14 @@ public class CTCollectionCacheModel
 		}
 
 		ctCollectionImpl.setOnDemandUserId(onDemandUserId);
+
+		if (scheduledDate == Long.MIN_VALUE) {
+			ctCollectionImpl.setScheduledDate(null);
+		}
+		else {
+			ctCollectionImpl.setScheduledDate(new Date(scheduledDate));
+		}
+
 		ctCollectionImpl.setShareable(shareable);
 		ctCollectionImpl.setStatus(status);
 		ctCollectionImpl.setStatusByUserId(statusByUserId);
@@ -202,6 +212,7 @@ public class CTCollectionCacheModel
 		description = objectInput.readUTF();
 
 		onDemandUserId = objectInput.readLong();
+		scheduledDate = objectInput.readLong();
 
 		shareable = objectInput.readBoolean();
 
@@ -256,6 +267,7 @@ public class CTCollectionCacheModel
 		}
 
 		objectOutput.writeLong(onDemandUserId);
+		objectOutput.writeLong(scheduledDate);
 
 		objectOutput.writeBoolean(shareable);
 
@@ -278,10 +290,11 @@ public class CTCollectionCacheModel
 	public String name;
 	public String description;
 	public long onDemandUserId;
+	public long scheduledDate;
 	public boolean shareable;
 	public int status;
 	public long statusByUserId;
 	public long statusDate;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:956614182
+// LIFERAY-SERVICE-BUILDER-HASH:-526990286

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTCollectionModelImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTCollectionModelImpl.java
@@ -72,8 +72,9 @@ public class CTCollectionModelImpl
 		{"modifiedDate", Types.TIMESTAMP}, {"ctRemoteId", Types.BIGINT},
 		{"schemaVersionId", Types.BIGINT}, {"name", Types.VARCHAR},
 		{"description", Types.VARCHAR}, {"onDemandUserId", Types.BIGINT},
-		{"shareable", Types.BOOLEAN}, {"status", Types.INTEGER},
-		{"statusByUserId", Types.BIGINT}, {"statusDate", Types.TIMESTAMP}
+		{"scheduledDate", Types.TIMESTAMP}, {"shareable", Types.BOOLEAN},
+		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
+		{"statusDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -93,6 +94,7 @@ public class CTCollectionModelImpl
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("onDemandUserId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("scheduledDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("shareable", Types.BOOLEAN);
 		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
@@ -100,7 +102,7 @@ public class CTCollectionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table CTCollection (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ctCollectionId LONG not null primary key,companyId LONG,userId LONG,createDate DATE null,modifiedDate DATE null,ctRemoteId LONG,schemaVersionId LONG,name VARCHAR(75) null,description VARCHAR(200) null,onDemandUserId LONG,shareable BOOLEAN,status INTEGER,statusByUserId LONG,statusDate DATE null)";
+		"create table CTCollection (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ctCollectionId LONG not null primary key,companyId LONG,userId LONG,createDate DATE null,modifiedDate DATE null,ctRemoteId LONG,schemaVersionId LONG,name VARCHAR(75) null,description VARCHAR(200) null,onDemandUserId LONG,scheduledDate DATE null,shareable BOOLEAN,status INTEGER,statusByUserId LONG,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table CTCollection";
 
@@ -300,6 +302,8 @@ public class CTCollectionModelImpl
 			attributeGetterFunctions.put(
 				"onDemandUserId", CTCollection::getOnDemandUserId);
 			attributeGetterFunctions.put(
+				"scheduledDate", CTCollection::getScheduledDate);
+			attributeGetterFunctions.put(
 				"shareable", CTCollection::getShareable);
 			attributeGetterFunctions.put("status", CTCollection::getStatus);
 			attributeGetterFunctions.put(
@@ -366,6 +370,9 @@ public class CTCollectionModelImpl
 				"onDemandUserId",
 				(BiConsumer<CTCollection, Long>)
 					CTCollection::setOnDemandUserId);
+			attributeSetterBiConsumers.put(
+				"scheduledDate",
+				(BiConsumer<CTCollection, Date>)CTCollection::setScheduledDate);
 			attributeSetterBiConsumers.put(
 				"shareable",
 				(BiConsumer<CTCollection, Boolean>)CTCollection::setShareable);
@@ -688,6 +695,21 @@ public class CTCollectionModelImpl
 
 	@JSON
 	@Override
+	public Date getScheduledDate() {
+		return _scheduledDate;
+	}
+
+	@Override
+	public void setScheduledDate(Date scheduledDate) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_scheduledDate = scheduledDate;
+	}
+
+	@JSON
+	@Override
 	public boolean getShareable() {
 		return _shareable;
 	}
@@ -853,6 +875,7 @@ public class CTCollectionModelImpl
 		ctCollectionImpl.setName(getName());
 		ctCollectionImpl.setDescription(getDescription());
 		ctCollectionImpl.setOnDemandUserId(getOnDemandUserId());
+		ctCollectionImpl.setScheduledDate(getScheduledDate());
 		ctCollectionImpl.setShareable(isShareable());
 		ctCollectionImpl.setStatus(getStatus());
 		ctCollectionImpl.setStatusByUserId(getStatusByUserId());
@@ -890,6 +913,8 @@ public class CTCollectionModelImpl
 			this.<String>getColumnOriginalValue("description"));
 		ctCollectionImpl.setOnDemandUserId(
 			this.<Long>getColumnOriginalValue("onDemandUserId"));
+		ctCollectionImpl.setScheduledDate(
+			this.<Date>getColumnOriginalValue("scheduledDate"));
 		ctCollectionImpl.setShareable(
 			this.<Boolean>getColumnOriginalValue("shareable"));
 		ctCollectionImpl.setStatus(
@@ -1043,6 +1068,15 @@ public class CTCollectionModelImpl
 
 		ctCollectionCacheModel.onDemandUserId = getOnDemandUserId();
 
+		Date scheduledDate = getScheduledDate();
+
+		if (scheduledDate != null) {
+			ctCollectionCacheModel.scheduledDate = scheduledDate.getTime();
+		}
+		else {
+			ctCollectionCacheModel.scheduledDate = Long.MIN_VALUE;
+		}
+
 		ctCollectionCacheModel.shareable = isShareable();
 
 		ctCollectionCacheModel.status = getStatus();
@@ -1133,6 +1167,7 @@ public class CTCollectionModelImpl
 	private String _name;
 	private String _description;
 	private long _onDemandUserId;
+	private Date _scheduledDate;
 	private boolean _shareable;
 	private int _status;
 	private long _statusByUserId;
@@ -1182,6 +1217,7 @@ public class CTCollectionModelImpl
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("description", _description);
 		_columnOriginalValues.put("onDemandUserId", _onDemandUserId);
+		_columnOriginalValues.put("scheduledDate", _scheduledDate);
 		_columnOriginalValues.put("shareable", _shareable);
 		_columnOriginalValues.put("status", _status);
 		_columnOriginalValues.put("statusByUserId", _statusByUserId);
@@ -1235,13 +1271,15 @@ public class CTCollectionModelImpl
 
 		columnBitmasks.put("onDemandUserId", 4096L);
 
-		columnBitmasks.put("shareable", 8192L);
+		columnBitmasks.put("scheduledDate", 8192L);
 
-		columnBitmasks.put("status", 16384L);
+		columnBitmasks.put("shareable", 16384L);
 
-		columnBitmasks.put("statusByUserId", 32768L);
+		columnBitmasks.put("status", 32768L);
 
-		columnBitmasks.put("statusDate", 65536L);
+		columnBitmasks.put("statusByUserId", 65536L);
+
+		columnBitmasks.put("statusDate", 131072L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1250,4 +1288,4 @@ public class CTCollectionModelImpl
 	private CTCollection _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:49190194
+// LIFERAY-SERVICE-BUILDER-HASH:-1724200380

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
@@ -11,7 +11,6 @@ import com.liferay.change.tracking.model.CTProcess;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.service.base.CTProcessLocalServiceBaseImpl;
-import com.liferay.change.tracking.service.persistence.CTCollectionPersistence;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.background.task.model.BackgroundTask;
@@ -55,7 +54,7 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 	public CTProcess addCTProcess(long userId, long ctCollectionId)
 		throws PortalException {
 
-		CTCollection ctCollection = _ctCollectionPersistence.findByPrimaryKey(
+		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
 			ctCollectionId);
 
 		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {
@@ -69,6 +68,7 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 				"Change tracking collection is empty " + ctCollection);
 		}
 
+		ctCollection.setScheduledDate(null);
 		ctCollection.setStatus(WorkflowConstants.STATUS_PENDING);
 
 		ctCollection = _ctCollectionLocalService.updateCTCollection(
@@ -144,7 +144,7 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 					BackgroundTaskConstants.STATUS_SUCCESSFUL) {
 
 				CTCollection ctCollection =
-					_ctCollectionPersistence.fetchByPrimaryKey(
+					_ctCollectionLocalService.fetchCTCollection(
 						ctProcess.getCtCollectionId());
 
 				if (ctCollection != null) {
@@ -185,9 +185,6 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 
 	@Reference
 	private CTCollectionLocalService _ctCollectionLocalService;
-
-	@Reference
-	private CTCollectionPersistence _ctCollectionPersistence;
 
 	@Reference
 	private CTPreferencesLocalService _ctPreferencesLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/module-hbm.xml
@@ -42,6 +42,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="onDemandUserId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="scheduledDate" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="shareable" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="statusByUserId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -31,6 +31,7 @@
 			<hint name="max-length">200</hint>
 		</field>
 		<field name="onDemandUserId" type="long" />
+		<field name="scheduledDate" type="Date" />
 		<field name="shareable" type="boolean" />
 		<field name="status" type="int" />
 		<field name="statusByUserId" type="long" />

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/tables.sql
@@ -24,6 +24,7 @@ create table CTCollection (
 	name VARCHAR(75) null,
 	description VARCHAR(200) null,
 	onDemandUserId LONG,
+	scheduledDate DATE null,
 	shareable BOOLEAN,
 	status INTEGER,
 	statusByUserId LONG,

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/service.properties
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.change.tracking.service
-    build.number=4
-    build.date=1776296274736
+    build.number=5
+    build.date=1785823506694

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/scheduler/test/CTSchedulerTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/scheduler/test/CTSchedulerTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -46,6 +47,44 @@ public class CTSchedulerTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testSchedulePublishPopulatesScheduledDate() throws Exception {
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			JournalTestUtil.addArticle(
+				TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK);
+		}
+
+		Date date = new Date(System.currentTimeMillis() + 30000);
+
+		_publishScheduler.schedulePublish(
+			ctCollection.getCtCollectionId(), TestPropsValues.getUserId(),
+			date);
+
+		ctCollection = _ctCollectionLocalService.getCTCollection(
+			ctCollection.getCtCollectionId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, ctCollection.getStatus());
+		Assert.assertEquals(
+			Time.getShortTimestamp(date),
+			Time.getShortTimestamp(ctCollection.getScheduledDate()));
+
+		_publishScheduler.unschedulePublish(ctCollection.getCtCollectionId());
+
+		ctCollection = _ctCollectionLocalService.getCTCollection(
+			ctCollection.getCtCollectionId());
+
+		Assert.assertNull(ctCollection.getScheduledDate());
+	}
 
 	@Test
 	public void testSchedulePublishTwice() throws Exception {
@@ -113,6 +152,9 @@ public class CTSchedulerTest {
 
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_SCHEDULED, ctCollection.getStatus());
+			Assert.assertEquals(
+				Time.getShortTimestamp(date),
+				Time.getShortTimestamp(ctCollection.getScheduledDate()));
 
 			_publishScheduler.unschedulePublish(
 				ctCollection.getCtCollectionId());
@@ -122,6 +164,7 @@ public class CTSchedulerTest {
 
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_INCOMPLETE, ctCollection.getStatus());
+			Assert.assertNull(ctCollection.getScheduledDate());
 		}
 	}
 

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_15_0/test/CTCollectionScheduledDateUpgradeProcessTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/upgrade/v2_15_0/test/CTCollectionScheduledDateUpgradeProcessTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.internal.upgrade.v2_15_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTDestinationNames;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
+import com.liferay.portal.kernel.scheduler.StorageType;
+import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kiana Suetani
+ */
+@RunWith(Arquillian.class)
+public class CTCollectionScheduledDateUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.change.tracking.internal.upgrade.v2_15_0." +
+				"CTCollectionScheduledDateUpgradeProcess");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (String jobName : _jobNames) {
+			_schedulerEngineHelper.delete(
+				jobName, CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
+				StorageType.PERSISTED);
+		}
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		CTCollection scheduledCTCollection = _addCTCollection(true);
+
+		Date date = new Date(System.currentTimeMillis() + 30000);
+
+		_scheduleJob(scheduledCTCollection, date);
+
+		CTCollection unscheduledCTCollection = _addCTCollection(false);
+
+		_scheduleJob(unscheduledCTCollection, date);
+
+		_upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		scheduledCTCollection = _ctCollectionLocalService.getCTCollection(
+			scheduledCTCollection.getCtCollectionId());
+
+		Assert.assertEquals(
+			Time.getShortTimestamp(date),
+			Time.getShortTimestamp(scheduledCTCollection.getScheduledDate()));
+
+		unscheduledCTCollection = _ctCollectionLocalService.getCTCollection(
+			unscheduledCTCollection.getCtCollectionId());
+
+		Assert.assertNull(unscheduledCTCollection.getScheduledDate());
+	}
+
+	private CTCollection _addCTCollection(boolean scheduled) throws Exception {
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		if (scheduled) {
+			ctCollection.setStatus(WorkflowConstants.STATUS_SCHEDULED);
+
+			ctCollection = _ctCollectionLocalService.updateCTCollection(
+				ctCollection);
+		}
+
+		return ctCollection;
+	}
+
+	private void _scheduleJob(CTCollection ctCollection, Date date)
+		throws Exception {
+
+		String jobName = StringBundler.concat(
+			ctCollection.getCtCollectionId(), StringPool.AT,
+			ctCollection.getCompanyId());
+
+		_schedulerEngineHelper.schedule(
+			_triggerFactory.createTrigger(
+				jobName, CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH,
+				date, null, "0 0 12 * * ?", null),
+			StorageType.PERSISTED,
+			String.valueOf(ctCollection.getCtCollectionId()),
+			CTDestinationNames.CT_COLLECTION_SCHEDULED_PUBLISH, new Message());
+
+		_jobNames.add(jobName);
+	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	private final List<String> _jobNames = new ArrayList<>();
+
+	@Inject
+	private SchedulerEngineHelper _schedulerEngineHelper;
+
+	@Inject
+	private TriggerFactory _triggerFactory;
+
+	private UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.change.tracking.internal.upgrade.registry.ChangeTrackingServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
@@ -136,6 +136,8 @@ public class CTCollectionPersistenceTest {
 
 		newCTCollection.setOnDemandUserId(RandomTestUtil.nextLong());
 
+		newCTCollection.setScheduledDate(RandomTestUtil.nextDate());
+
 		newCTCollection.setShareable(RandomTestUtil.randomBoolean());
 
 		newCTCollection.setStatus(RandomTestUtil.nextInt());
@@ -187,6 +189,9 @@ public class CTCollectionPersistenceTest {
 		Assert.assertEquals(
 			existingCTCollection.getOnDemandUserId(),
 			newCTCollection.getOnDemandUserId());
+		Assert.assertEquals(
+			Time.getShortTimestamp(existingCTCollection.getScheduledDate()),
+			Time.getShortTimestamp(newCTCollection.getScheduledDate()));
 		Assert.assertEquals(
 			existingCTCollection.isShareable(), newCTCollection.isShareable());
 		Assert.assertEquals(
@@ -312,8 +317,9 @@ public class CTCollectionPersistenceTest {
 			"externalReferenceCode", true, "ctCollectionId", true, "companyId",
 			true, "userId", true, "createDate", true, "modifiedDate", true,
 			"ctRemoteId", true, "schemaVersionId", true, "name", true,
-			"description", true, "onDemandUserId", true, "shareable", true,
-			"status", true, "statusByUserId", true, "statusDate", true);
+			"description", true, "onDemandUserId", true, "scheduledDate", true,
+			"shareable", true, "status", true, "statusByUserId", true,
+			"statusDate", true);
 	}
 
 	@Test
@@ -619,6 +625,8 @@ public class CTCollectionPersistenceTest {
 
 		ctCollection.setOnDemandUserId(RandomTestUtil.nextLong());
 
+		ctCollection.setScheduledDate(RandomTestUtil.nextDate());
+
 		ctCollection.setShareable(RandomTestUtil.randomBoolean());
 
 		ctCollection.setStatus(RandomTestUtil.nextInt());
@@ -637,4 +645,4 @@ public class CTCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-359539616
+// LIFERAY-SERVICE-BUILDER-HASH:-823284022


### PR DESCRIPTION
## Summary

Persists the scheduled publish date on `CTCollection` as a durable column so the "publishes in X days" UI populates locally, without the per-entity `@Clusterable(onMaster = true)` scheduler RPC that caused the LPP-64916 OOM.

- Adds `scheduledDate` to `CTCollection` service builder entity.
- Populates the column through the publish lifecycle: set on `schedulePublish`, cleared on `unschedulePublish`, cleared on successful publish (`CTPublishBackgroundTaskExecutor`), cleared on failed publish (`BackgroundTaskModelListener`), cleared on `SCHEDULED` to `PENDING` transition (`CTProcessLocalServiceImpl.addCTProcess`).
- Ships an upgrade class (`v2_15_0.CTCollectionScheduledDateUpgradeProcess`) that adds the column and backfills existing SCHEDULED collections in a single `SchedulerEngineHelper.getScheduledJobs` query plus an `AutoBatchPreparedStatementUtil` UPDATE batch, guarded by `WHERE ctCollectionId = ? AND status = ? AND scheduledDate IS NULL` so re-runs and orphaned scheduler jobs cannot clobber live data.
- Updates the three read sites `CTEntryModelDocumentContributor`, `CTCollectionModelDocumentContributor`, and `CTCollectionDTOConverter` to read `ctCollection.getScheduledDate()` directly, replacing the null returns that LPD-100212 left behind.
- Restores the SCHEDULED-status gate on `CTCollectionDTOConverter.setDateScheduled` so a stale value on a non-SCHEDULED row never leaks through the REST DTO.
- Restores a null-date defensive guard on `CTEntryDTOConverter._getStatusMessage` to prevent NPEs during the race window between a status transition and the CTEntry reindex.

## Test Plan

Ran `pr-check` against `d8b33e7f9de81` before splitting into per-module commits (byte-identical tree):

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS (no cross-module consumers of `getScheduledDate`) |
| Baseline | PASS |
| Java Unit Tests | PASS (no unit-test counterparts) |

Ran the new and updated integration tests against the live bundle:

- `CTCollectionScheduledDateUpgradeProcessTest` — 6 scenarios (backfill / non-scheduled ignore / idempotence / unparseable job name / non-positive ctCollectionId / no jobs): PASS
- `CTSchedulerTest` — 3 scenarios (schedule populate / unschedule clear / pending-workflow unschedule): PASS

Additional runtime verification via Groovy scripts against the LPP-64916 bundle:

- Backfill verified byte-for-byte against scheduler trigger start time on an existing SCHEDULED row.
- Full publish path verified end to end: schedule at t+30s, Quartz fires, `CTPublishBackgroundTaskExecutor.execute` runs, row transitions to APPROVED with `scheduledDate` null.
- DTO gate verified: `CTCollectionDTO.dateScheduled` and `CTEntryDTO.ctCollectionStatusDate` both populate correctly when the collection is SCHEDULED.

## References

- LPP-64916 - customer OOM report; this branch closes the write-side vector by persisting the value locally so the read sites never need the scheduler RPC.
- LPD-100087 - previously fixed the acute DTO-side amplification (search-hit document via `DTOConverterContext`).
- LPD-100212 - previously deleted the three `@Clusterable` scheduler RPC read sites; this branch replaces the null returns with reads from `ctCollection.getScheduledDate()`.
- Phase 5 (reindex CTEntries on CTCollection status transition) remains open as a separate ticket; the change-list UI reads through the search-hit CTEntry doc via LPD-100087, so pre-existing entries in a scheduled collection stay stale until reindexed for another reason. That gap is orthogonal to the memory issue this branch addresses.