### PR TITLE
LPD-100658 Stabilize the 404 URL ordering test

### DIFF
--- a/modules/test/playwright/pages/redirect-web/RedirectPage.ts
+++ b/modules/test/playwright/pages/redirect-web/RedirectPage.ts
@@ -15,6 +15,7 @@ export class RedirectPage {
 	readonly destinationURL: Locator;
 	readonly destinationURLErrorMessage: Locator;
 	readonly expirationDate: Locator;
+	readonly notFoundURLsColumns: Locator;
 	readonly page: Page;
 	readonly pattern: Locator;
 	readonly patternLink: Locator;
@@ -31,6 +32,7 @@ export class RedirectPage {
 			'This URL is not supported'
 		);
 		this.expirationDate = page.getByLabel('Expiration Date');
+		this.notFoundURLsColumns = page.locator('td.lfr-not-found-urls-column');
 		this.page = page;
 		this.pattern = page.getByLabel('Pattern', {exact: true});
 		this.patternLink = page.getByRole('link', {name: 'Patterns'});
@@ -84,6 +86,19 @@ export class RedirectPage {
 		await this.createButton.click();
 
 		await expect(this.destinationURLErrorMessage).toBeVisible();
+	}
+
+	async assertNotFoundURLsOrder(expectedURLs: string[]) {
+		await expect(async () => {
+			await this.page.reload();
+
+			for (let i = 0; i < expectedURLs.length; i++) {
+				await expect(this.notFoundURLsColumns.nth(i)).toContainText(
+					expectedURLs[i],
+					{timeout: 5000}
+				);
+			}
+		}).toPass({timeout: 30000});
 	}
 
 	async configureRedirectNotFound(enabled: boolean) {
@@ -164,6 +179,24 @@ export class RedirectPage {
 		await this.page.goto(
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.redirect}`
 		);
+	}
+
+	async orderBy(name: string) {
+		const menuItem = this.page.getByRole('menuitem', {exact: true, name});
+
+		await clickAndExpectToBeVisible({
+			target: menuItem,
+			timeout: 1000,
+			trigger: this.page.getByLabel('Order', {exact: true}),
+		});
+
+		if ((await menuItem.getAttribute('aria-selected')) === 'true') {
+			await this.page.keyboard.press('Escape');
+
+			return;
+		}
+
+		await menuItem.click();
 	}
 
 	async updateReferences(updateReferences: boolean = true) {

--- a/modules/test/playwright/tests/redirect-web/main/redirectNotFound.spec.ts
+++ b/modules/test/playwright/tests/redirect-web/main/redirectNotFound.spec.ts
@@ -182,54 +182,25 @@ test('Ensure that 404 URLs can be ordered by number of requests', async ({
 
 	await page.goto(`/web/${site.name}/non-existing-url`);
 	await page.goto(`/web/${site.name}/non-existing-url`);
+	await page.goto(`/web/${site.name}/non-existing-url`);
 
 	await redirectPage.goto(site.friendlyUrlPath);
 
 	await page.getByRole('link', {name: 'URLs'}).click();
 
-	await page.getByLabel('Order', {exact: true}).click();
+	await redirectPage.orderBy('Requests');
 
-	await page.getByRole('menuitem', {name: 'Ascending'}).click();
+	await redirectPage.orderBy('Ascending');
 
-	await page.waitForTimeout(500);
+	await redirectPage.assertNotFoundURLsOrder([
+		'non-existing-url',
+		'invalid-page',
+	]);
 
-	const tableRows = page.locator('table > tbody tr');
+	await redirectPage.orderBy('Descending');
 
-	let expectedTexts = ['non-existing-url', 'invalid-page'];
-
-	for (let i = 0; i < expectedTexts.length; i++) {
-		const row = tableRows.nth(i);
-
-		await expect(row).toBeVisible();
-
-		const secondColumn = row.locator('td').nth(1);
-
-		await expect(secondColumn).toBeVisible();
-
-		const text = await secondColumn.innerText();
-
-		expect(text).toContain(expectedTexts[i]);
-	}
-
-	await page.getByLabel('Order', {exact: true}).click();
-
-	await page.getByRole('menuitem', {name: 'Descending'}).click();
-
-	await page.waitForTimeout(500);
-
-	expectedTexts = ['invalid-page', 'non-existing-url'];
-
-	for (let i = 0; i < expectedTexts.length; i++) {
-		const row = tableRows.nth(i);
-
-		await expect(row).toBeVisible();
-
-		const secondColumn = row.locator('td').nth(1);
-
-		await expect(secondColumn).toBeVisible();
-
-		const text = await secondColumn.innerText();
-
-		expect(text).toContain(expectedTexts[i]);
-	}
+	await redirectPage.assertNotFoundURLsOrder([
+		'invalid-page',
+		'non-existing-url',
+	]);
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100658

The management toolbar renders the active order option as a button with no href, so clicking "Ascending" while it is already selected never advances the test and the click times out. Ascending is the default direction, and the direction is persisted per user in the portal preferences, so the test only failed where no preference had been stored yet.

Ordering reads the request count from the search index while the table displays it live, and the indexed value trails the counter, so two URLs whose counts differ by a single request are not ordered deterministically