### PR TITLE
LPD-100922 Wait for the redirect chain modal submission to complete

### DIFF
--- a/modules/test/playwright/pages/redirect-web/RedirectPage.ts
+++ b/modules/test/playwright/pages/redirect-web/RedirectPage.ts
@@ -178,5 +178,7 @@ export class RedirectPage {
 		await this.redirectChainModal
 			.getByRole('button', {name: 'Create'})
 			.click();
+
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/redirect-web/main/redirectAlias.spec.ts
+++ b/modules/test/playwright/tests/redirect-web/main/redirectAlias.spec.ts
@@ -202,8 +202,8 @@ test('Ensure that a redirect can be added with updating references for redirect 
 	await redirectPage.updateReferences();
 
 	await expect(
-		page.locator('.lfr-destination-url-column', {hasText: 'test-page-2'})
-	).not.toBeVisible();
+		page.locator('.lfr-destination-url-column', {hasText: 'test-page-3'})
+	).toHaveCount(2);
 
 	await page.goto(`/web/${site.name}/test-page-1`);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100922

## What Is Being Fixed

`redirectAlias.spec.ts > Ensure that a redirect can be added with updating references for redirect chain` failed intermittently, landing on `test-page-2` instead of `test-page-3`.

Nothing in the test waited for the redirect chain modal's submission to finish. `RedirectPage.updateReferences` clicked the modal's Create button and returned, but that click only dispatches the `postForm` call in `editRedirectEntry.js` — it does not wait for the resulting form POST. The assertion that followed could not act as a barrier either: it checked that `.lfr-destination-url-column` was not visible, and that class is generated by the search container in `view_redirect_entries.jsp`, so it exists only on the list view. While the browser was still on the edit form the element was absent and the negative assertion passed on its first poll. The `page.goto` that came next then cancelled the in-flight POST, leaving the second redirect uncreated and the first redirect's destination unchanged.

The sibling test that declines to update references never flaked because its assertion on the same column is positive, so it polls until the list view renders and implicitly waits for the POST.

## How It Is Being Fixed

`updateReferences` now waits for the success alert after submitting the modal, which is the point at which the POST has completed and the list view has rendered. Both redirect chain tests inherit the barrier.

The assertion in the updating-references test is also replaced with a positive one. Rather than checking that no destination still points at `test-page-2`, it asserts that both rows now point at `test-page-3`, which is what the reference update actually produces and which cannot pass vacuously.

Verified against a local bundle: both redirect chain tests passed on every run, including two repeats of each on the final tree. A full run of `redirectAlias.spec.ts` shows one unrelated pre-existing failure — `Ensure warning messages are displayed when staging is enabled`, whose bare `page.waitForTimeout(2000)` is not long enough for local staging to finish provisioning. It is untouched by this PR.

## PR Check

**pr-check: PASS** — tested on `6e458ea200d4ce024213e3585d316c573a9eddcf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | N/A |

Per-Module Compile: `modules/test/playwright` is not part of the `modules` Gradle build, so it has no `deploy` target. The equivalent signal was taken from `tsc --noEmit -p tsconfig.json`, which exited 0.

JavaScript Unit Tests: the match fired on the changed `.ts` files, but the module has no Jest suite — its `npm test` script maps to `playwright test`, which is out of pr-check's scope.

<!-- pr-check {"result": "success", "sha": "6e458ea200d4ce024213e3585d316c573a9eddcf"} -->
