### PR TITLE
LPD-101174 Enable LPS-178052 at the bundle level for navigation tests

### DIFF
--- a/modules/test/playwright/tests/site-navigation-admin-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/env/portal-ext.properties
@@ -1,0 +1,1 @@
+feature.flag.LPS-178052=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101174

## What Is Being Fixed

The `site-navigation-admin-web.main` Playwright specs failed in U152 when creating their test pages: `POST /o/headless-delivery/v1.0/sites/{siteId}/site-pages` returned `400 BAD_REQUEST` with `UnsupportedOperationException`. That endpoint is gated behind the `LPS-178052` feature flag — `SitePageResourceImpl.postSiteSitePage` throws `UnsupportedOperationException` when the flag is off — so the failure means the flag was not in effect when the API helper ran, not that the endpoint regressed. The three specs that failed are the ones with the most `createSitePage` calls (`itemAddition` 13, `keyboardAccessibility` 8, `navigationMenu` 6); the specs with a single call were unaffected.

## How It Is Being Fixed

Pin `LPS-178052` at the bundle level for this project by adding `env/portal-ext.properties`, so the flag is on from app-server startup rather than depending on the `featureFlagsTest` fixture toggling it at runtime. `update_portal_ext_properties` combines that file into the bundle's `portal-ext.properties` before `start_default_app_server`, and `tests/frontend-js-item-selector-web/main` and `tests/portal-security-content-security-policy/main` already pin this same flag the same way. The per-spec `featureFlagsTest` declarations are left in place so the specs still work against a bundle without the env file.

The branch also adds a `page-management-site.main` project dependency. That commit is included here, but the bundle-level flag is the change that addresses the 400.

## Why Are There No Tests?

This PR only changes Playwright test configuration — `itemAddition.spec.ts` and its siblings already provide the coverage, so no new test applies. The CI failure was not reproduced locally; with the flag defaulted off the test passes, so this change removes the test's dependence on runtime feature-flag toggling rather than fixing a confirmed root cause.

## PR Check

**pr-check: PASS** — tested on `26ca3202af5a8863cec9902da37dcff3c3e463bf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff but had nothing to execute: `modules/test/playwright` has no `bnd.bnd`, so it is not an OSGi bundle and has no `deploy` task, and its `package.json` `test` script is `playwright test`, whose execution is out of scope for pr-check.

<!-- pr-check {"result": "success", "sha": "26ca3202af5a8863cec9902da37dcff3c3e463bf"} -->
