### PR TITLE
LPD-101150 Stop assuming the Custom Site Templates tab is empty

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/siteInitializerSelection.spec.ts
@@ -11,6 +11,7 @@ import {sitesPageTest} from '../../../fixtures/sitesPageTest';
 import {LayoutSetPrototype} from '../../../helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
+import {getResultsTotal, nextPage} from '../../../utils/pagination';
 import {selectSiteInitializerPagesTest} from './fixtures/selectSiteInitializerPagesTest';
 import {sitesAdminPagesTest} from './fixtures/sitesAdminPagesTest';
 
@@ -70,8 +71,20 @@ test(
 
 		await sitesPage.customSiteTemplatesItem.click();
 
+		const total = await getResultsTotal(page);
+
+		expect(total).toBeGreaterThan(20);
+
 		await expect(
-			page.getByText('Showing 1 to 20 of 21 entries.')
+			page.getByText(`Showing 1 to 20 of ${total} entries.`)
+		).toBeVisible();
+
+		await nextPage(page);
+
+		await expect(
+			page.getByText(
+				`Showing 21 to ${Math.min(40, total)} of ${total} entries.`
+			)
 		).toBeVisible();
 
 		await expect(
@@ -96,7 +109,12 @@ test('Ensure that the site administrator can select custom site template via key
 	selectSiteInitializerPage,
 	sitesPage,
 }) => {
-	let layoutSetPrototype: LayoutSetPrototype;
+	const layoutSetPrototype: LayoutSetPrototype =
+		await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+			{
+				name: getRandomString(),
+			}
+		);
 
 	try {
 		await selectSiteInitializerPage.goto();
@@ -104,15 +122,10 @@ test('Ensure that the site administrator can select custom site template via key
 		await sitesPage.customSiteTemplatesItem.click();
 
 		await expect(
-			page.getByText('There are no site templates.')
+			page.getByRole('button', {
+				name: layoutSetPrototype.nameCurrentValue,
+			})
 		).toBeVisible();
-
-		layoutSetPrototype =
-			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
-				{
-					name: getRandomString(),
-				}
-			);
 
 		await selectSiteInitializerPage.goto();
 
@@ -129,9 +142,7 @@ test('Ensure that the site administrator can select custom site template via key
 		await sitesPage.customSiteTemplatesItem.press('Tab');
 
 		await expect(
-			page.getByRole('button', {
-				name: layoutSetPrototype.nameCurrentValue,
-			})
+			page.locator('.add-site-action-card').first()
 		).toBeFocused();
 
 		await page.keyboard.press('Enter');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101150

## What Is Being Fixed

Two tests in `siteInitializerSelection.spec.ts` fail on any instance whose license enables the Digital Sales Room. Since LPD-97613 removed the `LPD-66359` feature flag, `DSRInitialRequestPortalInstanceLifecycleListener` runs on the first request and creates the `L_DSR_ROOM` object definition, which makes `ObjectDefinitionDeployerImpl` add an active layout set prototype named DSR. The Custom Site Templates tab is therefore never empty: the pagination test's hardcoded `Showing 1 to 20 of 21 entries.` sees 22, and the keyboard test's `There are no site templates.` never appears. The keyboard test then masked its own failure with a `TypeError`, because its `finally` dereferenced a template it had not created yet.

## How It Is Being Fixed

The pagination test reads the total off the paginator with `getResultsTotal` from `utils/pagination.ts`, asserts it is greater than twenty, and then checks page two through `nextPage`. This follows `itemSelectorPagination.spec.ts`, which faces the same problem of a company-global list that cannot be scoped, since this screen has no search or filter. Every other pagination assertion in the suite hardcodes its total, which works only because those lists are scoped to a resource the test owns.

The keyboard test creates its template before the `try` so cleanup can no longer throw, and asserts that Tab reaches the first card instead of the template it created. `SiteInitializerNameComparator` sorts with `compareToIgnoreCase` ascending, so a UUID name beginning with `e` or `f` sorts after DSR, meaning the old assertion would have flaked even with the empty-state check removed.

Verified with five repeats of the spec file: 20 of 20 passed.

## PR Check

**pr-check: PASS** — tested on `f89166a4fb0f0849fdbc8e3167d51631b62bdef4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

JavaScript Unit Tests ran the affected spec file with five repeats (20/20) rather than the module's `test` script, since that script is `playwright test` and pr-check declares Playwright out of scope. Per-Module Compile matched the diff but has an empty deploy set — `modules/test/playwright` has no `deploy` task or `bnd.bnd` — so it is omitted.

<!-- pr-check {"result": "success", "sha": "f89166a4fb0f0849fdbc8e3167d51631b62bdef4"} -->
