### PR TITLE
LPD-101320 Delete the asset vocabulary with its resource permissions

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
@@ -217,7 +217,7 @@ public class AssetVocabularySiteNavigationMenuItemTypeTest {
 		_siteNavigationMenuLocalService.deleteSiteNavigationMenu(
 			siteNavigationMenu);
 
-		_assetVocabularyLocalService.deleteAssetVocabulary(_assetVocabulary);
+		_assetVocabularyLocalService.deleteVocabulary(_assetVocabulary);
 
 		ExportImportConfiguration exportImportConfiguration =
 			_exportImportConfigurationLocalService.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101320

## What Is Being Fixed

`AssetVocabularySiteNavigationMenuItemTypeTest` failed in `classMethod` with a data guard leftover data assertion for `ResourcePermission`.

`testGetAssetVocabularySiteNavigationMenuItemFromExportImport` deleted the vocabulary through the generated `deleteAssetVocabulary`, which is a bare `assetVocabularyPersistence.remove` and is not overridden in `AssetVocabularyLocalServiceImpl`. The vocabulary row disappeared while the individual scope resource permissions it was created with stayed behind. Neither safety net recovers from this on its own: the data guard auto delete deliberately skips individual scope resource permissions whose name is a registered persisted model, on the assumption the owning entity cascades them, and the group delete cascade reaches vocabularies through `findByGroupId`, so it never sees one whose row is already gone. The orphaned permission was therefore never cleaned and always reported.

## How It Is Being Fixed

Switch the call to `deleteVocabulary`, which additionally deletes the model resources and the vocabulary categories. This is also the dominant convention, with 41 test call sites using `deleteVocabulary` against two using the generated form. The vocabulary is not a system vocabulary, so the `MustNotDelete` guard does not apply.

## Why Are There No Tests?

The entire change is a one line fix inside an existing integration test. No production code changed, so the coverage for this change is the repaired test itself: `AssetVocabularySiteNavigationMenuItemTypeTest` now passes with 23 tests, 0 failures and 0 errors, where it previously failed the class scope data guard assertion.

## PR Check

**pr-check: PASS** — tested on `bdce3932d9fcadea47d1bd9e58306ec5d1420241`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bdce3932d9fcadea47d1bd9e58306ec5d1420241"} -->
