### PR TITLE
LPD-101684 Switch the item selector view through the shared helper

### DIFF
--- a/modules/test/playwright/tests/site-navigation-admin-web/main/keyboardAccessibility.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/keyboardAccessibility.spec.ts
@@ -11,6 +11,7 @@ import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {pageSelectorPagesTest} from '../../../fixtures/pageSelectorPagesTest';
 import {createCategories} from '../../../helpers/CreateCategories';
+import {changeManagementToolbarView} from '../../../utils/changeManagementToolbarView';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {navigationMenusPagesTest} from './fixtures/navigationMenusPagesTest';
@@ -460,13 +461,7 @@ test('The navigation menu creator could add sibling item via keyboard', async ({
 		.getByRole('menuitem', {exact: true, name: 'Blogs Entry'})
 		.press('Enter');
 
-	await navigationMenusPage.blogsModal
-		.getByLabel('Select View, Currently')
-		.click();
-
-	await navigationMenusPage.blogsModal
-		.getByRole('menuitem', {name: 'Cards'})
-		.click();
+	await changeManagementToolbarView(navigationMenusPage.blogsModal, 'Cards');
 
 	await navigationMenusPage.blogsModal
 		.getByRole('button', {name: `Select ${blog.headline}`})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101684

## What Is Being Fixed

The Playwright test "The navigation menu creator could add sibling item via keyboard" timed out after 90 seconds while selecting the Cards view in the Select Blogs Entry item selector. The display style menu item is a floating link that never satisfies Playwright's actionability check, and because Playwright leaves actionTimeout unset, the click had no bound of its own and hung until the whole test timed out instead of being retried. The Blogs item selector already opens in the Cards view, so the click that hung was not changing anything.

## How It Is Being Fixed

The two hand written clicks that opened the display style menu and selected Cards are replaced with a single call to changeManagementToolbarView, the shared utility that already drives this control everywhere else. It accepts the item selector's FrameLocator directly, returns early when the requested view is the one already selected, retries opening the menu through clickAndExpectToBeVisible rather than clicking blindly, and asserts the resulting view label. Since the Blogs item selector opens in Cards, the early return makes the step deterministic rather than merely retried.

## Why Are There No Tests?

The change is confined to a Playwright test and adds no production code, so there is nothing for a new test to cover. The fixed test was run twenty consecutive times to confirm the timeout no longer occurs.

## PR Check

**pr-check: PASS** — tested on `3eba2a747c22cc1f98f437a59e0649ad42a17151`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "3eba2a747c22cc1f98f437a59e0649ad42a17151"} -->
