### PR TITLE
LPD-101686 Delete the scheduled jobs the sitemap tests leave behind

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
@@ -115,6 +115,9 @@ public class SitemapStrutsActionTest {
 
 	@After
 	public void tearDown() throws Exception {
+		_sitemapManager.deleteRegenerateSitemapScheduledJobs(
+			TestPropsValues.getCompanyId());
+
 		if (_group != null) {
 			_sitemapStorageHelper.deleteSitemaps(
 				TestPropsValues.getCompanyId(), _group.getGroupId());

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -181,6 +181,9 @@ public class SitemapManagerTest {
 
 	@After
 	public void tearDown() throws Exception {
+		_sitemapManager.deleteRegenerateSitemapScheduledJobs(
+			TestPropsValues.getCompanyId());
+
 		if (_group != null) {
 			_sitemapStorageHelper.deleteSitemaps(
 				TestPropsValues.getCompanyId(), _group.getGroupId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101686

## What Is Being Fixed

SitemapRegenerationSchedulerTest.testGetNextRegenerateSitemapDate failed in suite runs and passed when run on its own, reporting the end of the current day where it expected the date of the job it had scheduled. Sitemap regeneration is only scheduled while a company enables cached generation, which is off by default, so SitemapManagerTest and SitemapStrutsActionTest turn it on and then create the sites, articles, and layouts that make the model listeners schedule a regeneration job. Those jobs are persisted and carry the default daily delay, which lands a second short of midnight, and both classes deleted only the stored sitemaps when they finished, so the jobs outlived the class and stayed in the scheduler for whichever class ran next. SitemapRegenerationSchedulerTest was the class that noticed, because a next regeneration date belongs to the company rather than to a single group, so its first test compared the date of its own job against a leftover one that fired sooner.

## How It Is Being Fixed

Both classes now delete their scheduled regeneration jobs when they finish, in the same tear down that already deletes the sitemaps those jobs accompany, so each class leaves the scheduler as it found it. The fix is applied where the jobs are created rather than in the class that observed the failure, since the leftover jobs reach every class that runs afterwards and not only this one. SitemapRegenerationSchedulerTest is left untouched, as its own tear down was already correct.

## Why Are There No Tests?

The change only adds cleanup to the tear down of two existing integration tests and adds no production code, so there is nothing for a new test to cover. The failure was reproduced by running a leaking class and then the affected test in separate invocations, which fails before the change and passes after it.

## PR Check

**pr-check: PASS** — tested on `48db1aab0451c65680a64d3fbeb093d137979dee`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "48db1aab0451c65680a64d3fbeb093d137979dee"} -->
