### PR TITLE
LPD-101688 Stop the membership tests waiting on unactionable clicks

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
@@ -17,6 +17,7 @@ import performLogin, {
 	performLogout,
 	userData,
 } from '../../../utils/performLogin';
+import {closeProductMenu} from '../../../utils/productMenu';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {membershipsPagesTest} from './fixtures/membershipsPagesTest';
 
@@ -452,7 +453,7 @@ test(
 				.getByTitle('Go to Memberships')
 		).toBeVisible();
 
-		await page.getByLabel('Close Product Menu').click();
+		await closeProductMenu(page);
 
 		await page.waitForTimeout(300);
 
@@ -481,6 +482,8 @@ test(
 				.locator('.control-menu-nav-item')
 				.getByTitle('Go to Membership Requests')
 		).toBeVisible();
+
+		await closeProductMenu(page);
 
 		await page.waitForTimeout(300);
 
@@ -511,6 +514,8 @@ test(
 		).toBeVisible();
 
 		await page.reload();
+
+		await closeProductMenu(page);
 
 		await page.waitForTimeout(300);
 

--- a/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/memberships.spec.ts
@@ -634,7 +634,7 @@ test(
 			true
 		);
 
-		await page.getByLabel('Publish', {exact: true}).click();
+		await pageEditorPage.publishPage();
 
 		await performLogout(page);
 
@@ -644,14 +644,15 @@ test(
 
 		await page.getByRole('link', {name: 'Available Sites'}).click();
 
-		await page
-			.locator(
-				`[id="_com_liferay_site_my_sites_web_portlet_MySitesPortlet_ocerSearchContainer_-${site2.name}"]`
-			)
-			.getByLabel('Show Actions')
-			.click();
-
-		await page.getByRole('menuitem', {name: 'Request Membership'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Request Membership'}),
+			trigger: page
+				.locator(
+					`[id="_com_liferay_site_my_sites_web_portlet_MySitesPortlet_ocerSearchContainer_-${site2.name}"]`
+				)
+				.getByLabel('Show Actions'),
+		});
 
 		await page
 			.getByLabel('Characters Maximum')
@@ -675,9 +676,11 @@ test(
 			trigger: page.getByLabel('Options', {exact: true}),
 		});
 
-		await page.getByLabel('More actions').click();
-
-		await page.getByRole('menuitem', {name: 'Reply'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Reply'}),
+			trigger: page.getByLabel('More actions'),
+		});
 
 		await page
 			.getByLabel('Characters Maximum')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101688

## What Is Being Fixed

Two tests in memberships.spec.ts timed out after 90 seconds rather than failing on an assertion. Playwright leaves actionTimeout unset, so a click on an element that never becomes actionable has no bound of its own and waits until the whole test times out instead of being retried.

The first, "Assert no pop up when viewing membership request detail", opened two dropdowns with a bare click on the trigger followed by a bare click on the menu item, and the reported failure was the More actions menu item resolving without ever accepting the click. It also published the page through a bare click rather than waiting for the editor to confirm the page was published.

The second, "Confirm that, using Keyboard Navigation, it is possible to access the back button of Reply Membership, Membership Request, and Approved users", pressed Tab a fixed number of times and then asserted which element held focus. An expanded Product Menu contributes its own tab stops ahead of the control menu, so those presses landed on the menu's close button and the focus assertion timed out. The menu is collapsed once before the first tab sequence, but that click was never confirmed, so the collapsed state did not always survive the navigation to the reply form. This test failed on two runs out of twenty.

## How It Is Being Fixed

Both dropdowns now open through clickAndExpectToBeVisible, which reopens the menu on each attempt until the menu item is visible and only then clicks it, matching the four sibling dropdowns already written that way in this file. Publishing goes through publishPage, so the editor is given the chance to report success before the test logs out.

The keyboard test collapses the Product Menu through closeProductMenu before each of its three tab sequences. That utility reads the expanded state from the menu element itself rather than from a label, retries the click, and does nothing when the menu is already collapsed, so the tab stops ahead of the control menu are the same every run. The bare click that collapsed the menu once is replaced by the same call. The fixed tab counts are kept, so the test still asserts how far the back button sits from the start of the tab order.

## Why Are There No Tests?

The change is confined to two Playwright tests and adds no production code, so there is nothing for a new test to cover. The membership request test was run twenty consecutive times, and the keyboard test thirty consecutive times against a measured failure rate of two in twenty before the change.

## PR Check

**pr-check: PASS** — tested on `8543f5e7057e8ebfe7541bd0bd4e0d4631073bee`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "8543f5e7057e8ebfe7541bd0bd4e0d4631073bee"} -->
