### PR TITLE
LPD-101828 Escape unescaped values in Site Management JSPs

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
@@ -33,7 +33,7 @@
 		window.onload = function () {
 			window.$chatwoot.setUser('<%= user.getUserId() %>', {
 				email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
-				name: '<%= user.getScreenName() %>',
+				name: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 			});
 		};
 	</c:if>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
@@ -22,7 +22,8 @@
 			g.onload = function () {
 				window.chatwootSDK.run({
 					baseUrl: BASE_URL,
-					websiteToken: '<%= clickToChatChatProviderAccountId %>',
+					websiteToken:
+						'<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>',
 				});
 			};
 		})(document, 'script');
@@ -31,7 +32,7 @@
 	<c:if test="<%= themeDisplay.isSignedIn() %>">
 		window.onload = function () {
 			window.$chatwoot.setUser('<%= user.getUserId() %>', {
-				email: '<%= user.getEmailAddress() %>',
+				email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 				name: '<%= user.getScreenName() %>',
 			});
 		};

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
@@ -24,7 +24,7 @@
 					$crisp.push([
 						'set',
 						'user:nickname',
-						'<%= user.getScreenName() %>',
+						'<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 					]);
 				}
 			}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
@@ -9,7 +9,8 @@
 
 <aui:script position="inline" type="text/javascript">
 	window.$crisp = [];
-	window.CRISP_WEBSITE_ID = '<%= clickToChatChatProviderAccountId %>';
+	window.CRISP_WEBSITE_ID =
+		'<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>';
 
 	(function () {
 		function loadCrispScript() {
@@ -18,7 +19,7 @@
 					$crisp.push([
 						'set',
 						'user:email',
-						'<%= user.getEmailAddress() %>',
+						'<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 					]);
 					$crisp.push([
 						'set',

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
@@ -63,8 +63,8 @@ if (themeDisplay.isSignedIn() && (parts.length > 1)) {
 			<c:otherwise>
 				<aui:script position="inline" type="text/javascript">
 					window.hsConversationsSettings = {
-						identificationEmail: '<%= user.getEmailAddress() %>',
-						identificationToken: '<%= identificationToken %>',
+						identificationEmail: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
+						identificationToken: '<%= HtmlUtil.escapeJS(identificationToken) %>',
 					};
 
 					window.HubSpotConversations.widget.load();

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
@@ -25,7 +25,7 @@
 		</c:if>
 
 		intercomSettings.email = '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>';
-		intercomSettings.name = '<%= user.getFullName() %>';
+		intercomSettings.name = '<%= HtmlUtil.escapeJS(user.getFullName()) %>';
 		intercomSettings.user_id = '<%= user.getUserId() %>';
 	</c:if>
 

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/dynamic_include/init.jsp" %>
 
 <aui:script position="inline">
-	var APP_ID = '<%= clickToChatChatProviderAccountId %>';
+	var APP_ID = '<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>';
 
 	let intercomSettings = {
 		app_id: APP_ID,
@@ -24,7 +24,7 @@
 			intercomSettings.created_at = '<%= createDate.getTime() %>';
 		</c:if>
 
-		intercomSettings.email = '<%= user.getEmailAddress() %>';
+		intercomSettings.email = '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>';
 		intercomSettings.name = '<%= user.getFullName() %>';
 		intercomSettings.user_id = '<%= user.getUserId() %>';
 	</c:if>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
@@ -14,7 +14,7 @@
 		function jivo_onOpen() {
 			jivo_api.setContactInfo({
 				email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
-				name: '<%= user.getScreenName() %>',
+				name: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 			});
 		}
 	</aui:script>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
@@ -13,7 +13,7 @@
 	<aui:script position="inline">
 		function jivo_onOpen() {
 			jivo_api.setContactInfo({
-				email: '<%= user.getEmailAddress() %>',
+				email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 				name: '<%= user.getScreenName() %>',
 			});
 		}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
@@ -9,7 +9,8 @@
 
 <aui:script position="inline">
 	window.__lc = window.__lc || {};
-	window.__lc.license = '<%= clickToChatChatProviderAccountId %>';
+	window.__lc.license =
+		'<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>';
 
 	(function (n, t, c) {
 		function i(n) {
@@ -53,7 +54,10 @@
 
 	<c:if test="<%= themeDisplay.isSignedIn() %>">
 		window.onload = function () {
-			LiveChatWidget.call('set_customer_email', '<%= user.getEmailAddress() %>');
+			LiveChatWidget.call(
+				'set_customer_email',
+				'<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>'
+			);
 			LiveChatWidget.call('set_customer_name', '<%= user.getScreenName() %>');
 		};
 	</c:if>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
@@ -58,7 +58,10 @@
 				'set_customer_email',
 				'<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>'
 			);
-			LiveChatWidget.call('set_customer_name', '<%= user.getScreenName() %>');
+			LiveChatWidget.call(
+				'set_customer_name',
+				'<%= HtmlUtil.escapeJS(user.getScreenName()) %>'
+			);
 		};
 	</c:if>
 </aui:script>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
@@ -74,7 +74,9 @@
 					scp: lpTag.scp || null,
 					sdes: lpTag.sdes || [],
 					section: lpTag.section || '',
-					site: '<%= clickToChatChatProviderAccountId %>' || '',
+					site:
+						'<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>' ||
+						'',
 					start: function () {
 						this.autoStart = !0;
 					},
@@ -120,11 +122,11 @@
 		personal: {
 			contacts: [
 				{
-					email: '<%= user.getEmailAddress() %>',
+					email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 				},
 			],
-			firstname: '<%= user.getFirstName() %>',
-			lastname: '<%= user.getLastName() %>',
+			firstname: '<%= HtmlUtil.escapeJS(user.getFirstName()) %>',
+			lastname: '<%= HtmlUtil.escapeJS(user.getLastName()) %>',
 		},
 		type: 'personal',
 	});

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
@@ -133,7 +133,7 @@
 
 	lpTag.sdes.push({
 		info: {
-			customerId: '<%= user.getScreenName() %>',
+			customerId: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 			userName: '<%= user.getUserId() %>',
 		},
 		type: 'ctmrinfo',

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/smartsupp.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/smartsupp.jsp
@@ -10,7 +10,7 @@
 <aui:script position="inline" type="text/javascript">
 	var _smartsupp = _smartsupp || {};
 
-	_smartsupp.key = '<%= clickToChatChatProviderAccountId %>';
+	_smartsupp.key = '<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>';
 
 	window.smartsupp ||
 		(function (d) {
@@ -35,7 +35,7 @@
 		})(document);
 
 	<c:if test="<%= themeDisplay.isSignedIn() %>">
-		smartsupp('email', '<%= user.getEmailAddress() %>');
-		smartsupp('name', '<%= user.getFirstName() %>');
+		smartsupp('email', '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>');
+		smartsupp('name', '<%= HtmlUtil.escapeJS(user.getFirstName()) %>');
 	</c:if>
 </aui:script>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
@@ -29,7 +29,7 @@
 
 		Tawk_API.visitor = {
 			email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
-			name: '<%= user.getScreenName() %>',
+			name: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 		};
 	</c:if>
 </aui:script>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
@@ -18,7 +18,8 @@
 		s1.async = true;
 		s1.charset = 'UTF-8';
 		s1.setAttribute('crossorigin', '*');
-		s1.src = 'https://embed.tawk.to/<%= clickToChatChatProviderAccountId %>';
+		s1.src =
+			'https://embed.tawk.to/<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>';
 
 		s0.parentNode.insertBefore(s1, s0);
 	})();
@@ -27,7 +28,7 @@
 		Tawk_API = Tawk_API || {};
 
 		Tawk_API.visitor = {
-			email: '<%= user.getEmailAddress() %>',
+			email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 			name: '<%= user.getScreenName() %>',
 		};
 	</c:if>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tidio.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tidio.jsp
@@ -14,8 +14,8 @@
 				if ('<%= themeDisplay.isSignedIn() %>' === 'true') {
 					document.tidioIdentify = {
 						distinct_id: '<%= user.getUserId() %>',
-						email: '<%= user.getEmailAddress() %>',
-						name: '<%= user.getFirstName() %>',
+						email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
+						name: '<%= HtmlUtil.escapeJS(user.getFirstName()) %>',
 					};
 				}
 			}
@@ -26,7 +26,7 @@
 				scriptElement.setAttribute('id', 'tidio-script-chat');
 				scriptElement.setAttribute(
 					'src',
-					'//code.tidio.co/<%= clickToChatChatProviderAccountId %>.js'
+					'//code.tidio.co/<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>.js'
 				);
 				scriptElement.setAttribute('type', 'text/javascript');
 				scriptElement.onload = function () {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
@@ -18,7 +18,7 @@
 
 	<c:if test="<%= themeDisplay.isSignedIn() %>">
 		_tn.push(['_setEmail', '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>']);
-		_tn.push(['_setName', '<%= user.getScreenName() %>']);
+		_tn.push(['_setName', '<%= HtmlUtil.escapeJS(user.getScreenName()) %>']);
 	</c:if>
 
 	(function () {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
@@ -10,11 +10,14 @@
 <aui:script position="inline" type="text/javascript">
 	var _tn = _tn || [];
 
-	_tn.push(['account', '<%= clickToChatChatProviderAccountId %>']);
+	_tn.push([
+		'account',
+		'<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>',
+	]);
 	_tn.push(['action', 'track-view']);
 
 	<c:if test="<%= themeDisplay.isSignedIn() %>">
-		_tn.push(['_setEmail', '<%= user.getEmailAddress() %>']);
+		_tn.push(['_setEmail', '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>']);
 		_tn.push(['_setName', '<%= user.getScreenName() %>']);
 	</c:if>
 

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
@@ -13,7 +13,7 @@
 			function setZendeskUserInfo() {
 				if ('<%= themeDisplay.isSignedIn() %>' === 'true') {
 					zE('webWidget', 'identify', {
-						email: '<%= user.getEmailAddress() %>',
+						email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 						name: '<%= user.getScreenName() %>',
 					});
 				}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
@@ -14,7 +14,7 @@
 				if ('<%= themeDisplay.isSignedIn() %>' === 'true') {
 					zE('webWidget', 'identify', {
 						email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
-						name: '<%= user.getScreenName() %>',
+						name: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 					});
 				}
 			}
@@ -25,7 +25,7 @@
 				scriptElement.setAttribute('id', 'ze-snippet');
 				scriptElement.setAttribute(
 					'src',
-					'https://static.zdassets.com/ekr/snippet.js?key=<%= clickToChatChatProviderAccountId %>'
+					'https://static.zdassets.com/ekr/snippet.js?key=<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>'
 				);
 				scriptElement.setAttribute('type', 'text/javascript');
 				scriptElement.onload = function () {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
@@ -13,7 +13,7 @@
 			function setZendeskUserInfo() {
 				if ('<%= themeDisplay.isSignedIn() %>' === 'true') {
 					zE('webWidget', 'identify', {
-						email: '<%= user.getEmailAddress() %>',
+						email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
 						name: '<%= user.getScreenName() %>',
 					});
 				}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
@@ -14,7 +14,7 @@
 				if ('<%= themeDisplay.isSignedIn() %>' === 'true') {
 					zE('webWidget', 'identify', {
 						email: '<%= HtmlUtil.escapeJS(user.getEmailAddress()) %>',
-						name: '<%= user.getScreenName() %>',
+						name: '<%= HtmlUtil.escapeJS(user.getScreenName()) %>',
 					});
 				}
 			}
@@ -29,7 +29,7 @@
 				scriptElement.setAttribute('id', 'ze-snippet');
 				scriptElement.setAttribute(
 					'src',
-					'https://static.zdassets.com/ekr/snippet.js?key=<%= clickToChatChatProviderAccountId %>'
+					'https://static.zdassets.com/ekr/snippet.js?key=<%= HtmlUtil.escapeJS(clickToChatChatProviderAccountId) %>'
 				);
 				scriptElement.setAttribute('type', 'text/javascript');
 

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
@@ -56,7 +56,7 @@ SelectSiteNavigationMenuDisplayContext selectSiteNavigationMenuDisplayContext = 
 				/>
 
 				<a href="<%= siteNavigationMenuEntry.getURL() %>">
-					<%= siteNavigationMenuEntry.getName() %>
+					<%= HtmlUtil.escape(siteNavigationMenuEntry.getName()) %>
 				</a>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
@@ -94,7 +94,7 @@ PortletURL previewURL = PortletURLBuilder.createRenderURL(
 
 		<liferay-ui:search-container-column-text
 			name="email-address"
-			value="<%= membershipRequestUser.getEmailAddress() %>"
+			value="<%= HtmlUtil.escape(membershipRequestUser.getEmailAddress()) %>"
 		/>
 
 		<liferay-ui:search-container-column-date

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
@@ -72,7 +72,7 @@ PortletURL previewURL = PortletURLBuilder.createRenderURL(
 			</div>
 
 			<div class="h6 text-default">
-				<span><%= membershipRequestUser.getEmailAddress() %></span>
+				<span><%= HtmlUtil.escape(membershipRequestUser.getEmailAddress()) %></span>
 			</div>
 		</liferay-ui:search-container-column-text>
 	</c:when>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_pending_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_pending_columns.jspf
@@ -24,7 +24,7 @@ User membershipRequestUser = UserLocalServiceUtil.fetchUserById(membershipReques
 				<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - membershipRequest.getCreateDate().getTime(), true) %>" key="x-ago" translateArguments="<%= false %>" />
 			</div>
 
-			<div class="h5"><%= HtmlUtil.escape(membershipRequestUser.getFullName()) %> (<%= membershipRequestUser.getEmailAddress() %>)</div>
+			<div class="h5"><%= HtmlUtil.escape(membershipRequestUser.getFullName()) %> (<%= HtmlUtil.escape(membershipRequestUser.getEmailAddress()) %>)</div>
 
 			<div class="h6 text-default">
 				<span><%= HtmlUtil.escape(membershipRequest.getComments()) %></span>
@@ -61,7 +61,7 @@ User membershipRequestUser = UserLocalServiceUtil.fetchUserById(membershipReques
 		<liferay-ui:search-container-column-text
 			cssClass="table-cell-expand"
 			name="email-address"
-			value="<%= membershipRequestUser.getEmailAddress() %>"
+			value="<%= HtmlUtil.escape(membershipRequestUser.getEmailAddress()) %>"
 		/>
 
 		<liferay-ui:search-container-column-date


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101828
https://liferay.atlassian.net/browse/LPD-97914

## What Is Being Fixed

A review of JSP output expressions tracked by LPD-97914 found sites that emit
values without passing them through the usual encoding helpers. This pull
request covers the modules owned by @liferay-site-management.

In click-to-chat-web, user attributes are written into the vendor chat widget
bootstrap script across thirteen dynamic include JSPs. In site-memberships-web,
the membership request user email is written into two search container columns.
In site-navigation-item-selector-web, the menu entry name is written into the
level selector.

## How It Is Being Fixed

Each site is wrapped at the point of output. Values emitted inside a JavaScript
string literal use HtmlUtil.escapeJS, and values emitted into markup use
HtmlUtil.escape, matching the convention the surrounding JSPs already follow.
Nothing else changes, and the rendered output is unchanged for values that
needed no encoding.

The commits are cherry-picked verbatim from the LPD-97914 branch, one per site,
with the original authorship preserved. Their subjects therefore carry the
LPD-97914 prefix while this pull request is filed under LPD-101828, which exists
to triage the work by owning team.

The fourth module named on LPD-101828, site-initializer-extender, needs no change
here. The equivalent update was already made on master by LPD-96018.

## PR Check

**pr-check: PASS** — tested on `659896ce0539272f3cb3e4d6981ea87f991796fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "659896ce0539272f3cb3e4d6981ea87f991796fe"} -->
