### PR TITLE
LPD-97394 Include CMS content from connected spaces in the XML sitemap

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -5,6 +5,9 @@
 
 package com.liferay.object.internal.site.provider;
 
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -29,6 +32,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -94,12 +98,13 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 
 		if (!siteObjectDefinitionIds.isEmpty()) {
 			modifiedDate = _getLatestModifiedDate(
-				groupId, siteObjectDefinitionIds.toArray(new Long[0]));
+				_getCurrentAndGroupConnectedDepotEntryGroupIds(groupId),
+				siteObjectDefinitionIds.toArray(new Long[0]));
 		}
 
 		if (!companyObjectDefinitionIds.isEmpty()) {
 			Date companyDate = _getLatestModifiedDate(
-				GroupConstants.DEFAULT_PARENT_GROUP_ID,
+				new long[] {GroupConstants.DEFAULT_PARENT_GROUP_ID},
 				companyObjectDefinitionIds.toArray(new Long[0]));
 
 			if ((companyDate != null) &&
@@ -152,13 +157,19 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		}
 
 		_visitObjectEntries(
-			element, layout, layoutSet, objectDefinition, themeDisplay);
+			_getCurrentAndGroupConnectedDepotEntryGroupIds(
+				layoutSet.getGroupId()),
+			element, layout, objectDefinition, themeDisplay);
 	}
 
 	@Override
 	public void visitLayoutSet(
 			Element element, LayoutSet layoutSet, ThemeDisplay themeDisplay)
 		throws PortalException {
+
+		long[] currentAndGroupConnectedDepotEntryGroupIds =
+			_getCurrentAndGroupConnectedDepotEntryGroupIds(
+				layoutSet.getGroupId());
 
 		for (ObjectDefinition objectDefinition :
 				_sitemapConfigurationManager.getCompanySitemapObjectDefinitions(
@@ -188,12 +199,14 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 			}
 
 			_visitObjectEntries(
-				element, layout, layoutSet, objectDefinition, themeDisplay);
+				currentAndGroupConnectedDepotEntryGroupIds, element, layout,
+				objectDefinition, themeDisplay);
 		}
 	}
 
 	private List<ObjectEntry> _getApprovedObjectEntries(
-			long groupId, ObjectDefinition objectDefinition)
+			long[] currentAndGroupConnectedDepotEntryGroupIds,
+			ObjectDefinition objectDefinition)
 		throws PortalException {
 
 		if (Objects.equals(
@@ -207,10 +220,17 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 				QueryUtil.ALL_POS);
 		}
 
-		return _objectEntryService.getObjectEntries(
-			groupId, objectDefinition.getObjectDefinitionId(),
-			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+		List<ObjectEntry> objectEntries = new ArrayList<>();
+
+		for (long groupId : currentAndGroupConnectedDepotEntryGroupIds) {
+			objectEntries.addAll(
+				_objectEntryService.getObjectEntries(
+					groupId, objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS));
+		}
+
+		return objectEntries;
 	}
 
 	private Set<Locale> _getAvailableLocales(
@@ -235,6 +255,18 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		return availableLocales;
 	}
 
+	private long[] _getCurrentAndGroupConnectedDepotEntryGroupIds(long groupId)
+		throws PortalException {
+
+		return ArrayUtil.append(
+			new long[] {groupId},
+			ListUtil.toLongArray(
+				_depotEntryLocalService.getGroupConnectedDepotEntries(
+					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
+				DepotEntry::getGroupId));
+	}
+
 	private String _getFriendlyURL(
 		String languageId, ObjectDefinition objectDefinition,
 		ObjectEntry objectEntry) {
@@ -254,7 +286,11 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	private Date _getLatestModifiedDate(
-		long groupId, Long[] objectDefinitionIds) {
+		long[] groupIds, Long[] objectDefinitionIds) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return null;
+		}
 
 		List<Date> modifiedDates = _objectEntryLocalService.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -262,8 +298,8 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 			).from(
 				ObjectEntryTable.INSTANCE
 			).where(
-				ObjectEntryTable.INSTANCE.groupId.eq(
-					groupId
+				ObjectEntryTable.INSTANCE.groupId.in(
+					ArrayUtil.toArray(groupIds)
 				).and(
 					ObjectEntryTable.INSTANCE.objectDefinitionId.in(
 						objectDefinitionIds)
@@ -313,12 +349,13 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	private void _visitObjectEntries(
-			Element element, Layout layout, LayoutSet layoutSet,
-			ObjectDefinition objectDefinition, ThemeDisplay themeDisplay)
+			long[] currentAndGroupConnectedDepotEntryGroupIds, Element element,
+			Layout layout, ObjectDefinition objectDefinition,
+			ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries = _getApprovedObjectEntries(
-			layoutSet.getGroupId(), objectDefinition);
+			currentAndGroupConnectedDepotEntryGroupIds, objectDefinition);
 
 		if (objectEntries.isEmpty()) {
 			return;
@@ -356,6 +393,9 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
@@ -47,6 +47,15 @@ public class ObjectDefinitionTestUtil {
 	}
 
 	public static ObjectDefinition addCustomObjectDefinition(
+			List<ObjectField> objectFields, String scope)
+		throws Exception {
+
+		return _addCustomObjectDefinition(
+			getRandomName(), objectFields, 0, scope,
+			TestPropsValues.getUserId());
+	}
+
+	public static ObjectDefinition addCustomObjectDefinition(
 			long objectFolderId)
 		throws Exception {
 
@@ -67,17 +76,9 @@ public class ObjectDefinitionTestUtil {
 			long userId)
 		throws Exception {
 
-		return ObjectDefinitionLocalServiceUtil.addCustomObjectDefinition(
-			null, userId, objectFolderId, null, true, false, true, false, true,
-			false, false, false, false,
-			FriendlyURLResolverConstants.URL_SEPARATOR_Y_OBJECT_ENTRY,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			name, null, null,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			true, ObjectDefinitionConstants.SCOPE_COMPANY,
-			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
-			Collections.emptyList(), objectFields, Collections.emptyList(),
-			new ServiceContext());
+		return _addCustomObjectDefinition(
+			name, objectFields, objectFolderId,
+			ObjectDefinitionConstants.SCOPE_COMPANY, userId);
 	}
 
 	public static ObjectDefinition addCustomObjectDefinition(String name)
@@ -320,6 +321,23 @@ public class ObjectDefinitionTestUtil {
 		return ObjectDefinitionLocalServiceUtil.publishSystemObjectDefinition(
 			TestPropsValues.getUserId(),
 			objectDefinition.getObjectDefinitionId());
+	}
+
+	private static ObjectDefinition _addCustomObjectDefinition(
+			String name, List<ObjectField> objectFields, long objectFolderId,
+			String scope, long userId)
+		throws Exception {
+
+		return ObjectDefinitionLocalServiceUtil.addCustomObjectDefinition(
+			null, userId, objectFolderId, null, true, false, true, false, true,
+			false, false, false, false,
+			FriendlyURLResolverConstants.URL_SEPARATOR_Y_OBJECT_ENTRY,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			name, null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			true, scope, ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			Collections.emptyList(), objectFields, Collections.emptyList(),
+			new ServiceContext());
 	}
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
@@ -6,10 +6,15 @@
 package com.liferay.object.internal.site.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
@@ -17,6 +22,7 @@ import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
@@ -29,7 +35,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -105,35 +110,25 @@ public class ObjectEntrySitemapURLProviderTest {
 		_layoutSet = _layoutSetLocalService.getLayoutSet(
 			_group.getGroupId(), false);
 
-		_initThemeDisplay();
+		_companyObjectDefinition = _publishCustomObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		_objectDefinition = ObjectDefinitionTestUtil.addCustomObjectDefinition(
-			Collections.singletonList(
-				new TextObjectFieldBuilder(
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap(
-						RandomTestUtil.randomString())
-				).name(
-					"textObjectField"
-				).objectFieldSettings(
-					Collections.emptyList()
-				).build()));
+		_depotObjectDefinition = _publishCustomObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_DEPOT);
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
 			TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId());
+			_depotObjectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+			StringPool.TRUE);
 
-		String objectDefinitionId = String.valueOf(
-			_objectDefinition.getObjectDefinitionId());
+		_siteObjectDefinition = _publishCustomObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		_themeDisplay = _getThemeDisplay(_group, _layoutSet);
 
 		_companyConfigurationTemporarySwapper =
-			new CompanyConfigurationTemporarySwapper(
-				TestPropsValues.getCompanyId(),
-				_PID_SITEMAP_COMPANY_CONFIGURATION,
-				HashMapDictionaryBuilder.<String, Object>put(
-					"companySitemapObjectDefinitionIds",
-					new String[] {objectDefinitionId}
-				).build());
+			_getCompanyConfigurationTemporarySwapper(_companyObjectDefinition);
 
 		LayoutTestUtil.addTypePortletLayout(_group);
 	}
@@ -144,23 +139,40 @@ public class ObjectEntrySitemapURLProviderTest {
 	}
 
 	@Test
+	public void testGetModifiedDateWithObjectEntryInConnectedDepotEntry()
+		throws Exception {
+
+		_depotEntry = _addDepotEntry();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(
+						_depotObjectDefinition)) {
+
+			_addObjectEntry(_depotEntry.getGroupId(), _depotObjectDefinition);
+
+			Assert.assertNull(
+				_objectEntrySitemapURLProvider.getModifiedDate(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			Assert.assertNotNull(
+				_objectEntrySitemapURLProvider.getModifiedDate(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
 	public void testIsIncludeWithSystemObjectDefinition() throws Exception {
 		_systemObjectDefinition =
 			ObjectDefinitionTestUtil.publishSystemObjectDefinition();
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						TestPropsValues.getCompanyId(),
-						_PID_SITEMAP_COMPANY_CONFIGURATION,
-						HashMapDictionaryBuilder.<String, Object>put(
-							"companySitemapObjectDefinitionIds",
-							new String[] {
-								String.valueOf(
-									_systemObjectDefinition.
-										getObjectDefinitionId())
-							}
-						).build())) {
+					_getCompanyConfigurationTemporarySwapper(
+						_systemObjectDefinition)) {
 
 			Assert.assertFalse(
 				_objectEntrySitemapURLProvider.isInclude(
@@ -198,7 +210,8 @@ public class ObjectEntrySitemapURLProviderTest {
 
 		Element rootElement = _getRootElement();
 
-		_assertRootElement(layout, _objectDefinition, objectEntry, rootElement);
+		_assertRootElement(
+			layout, _companyObjectDefinition, objectEntry, rootElement);
 
 		_updateObjectDefinition(false);
 
@@ -231,8 +244,6 @@ public class ObjectEntrySitemapURLProviderTest {
 
 	@Test
 	public void testVisitLayoutAsGuestUser() throws Exception {
-		Element rootElement = _getRootElement();
-
 		ObjectEntry objectEntry = _addObjectEntry();
 
 		_addObjectEntry();
@@ -240,32 +251,37 @@ public class ObjectEntrySitemapURLProviderTest {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_addDisplayPageTemplate();
 
-		Role role = _roleLocalService.getRole(
-			_group.getCompanyId(), RoleConstants.GUEST);
+		_assertRootElementAsGuestUser(
+			_layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid()),
+			_companyObjectDefinition, objectEntry);
+	}
 
-		_resourcePermissionLocalService.setResourcePermissions(
-			_group.getCompanyId(), _objectDefinition.getClassName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(objectEntry.getObjectEntryId()), role.getRoleId(),
-			new String[] {ActionKeys.VIEW});
+	@Test
+	public void testVisitLayoutAsGuestUserWithObjectEntryInConnectedDepotEntry()
+		throws Exception {
 
-		User guestUser = _userLocalService.getGuestUser(_group.getCompanyId());
+		_depotEntry = _addDepotEntry();
 
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(
+						_depotObjectDefinition)) {
 
-		try {
-			PermissionThreadLocal.setPermissionChecker(
-				PermissionCheckerFactoryUtil.create(guestUser));
+			ObjectEntry objectEntry = _addObjectEntry(
+				_depotEntry.getGroupId(), _depotObjectDefinition);
 
-			_assertRootElement(
+			_addObjectEntry(_depotEntry.getGroupId(), _depotObjectDefinition);
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_addDisplayPageTemplate(_depotObjectDefinition);
+
+			_assertRootElementAsGuestUser(
 				_layoutLocalService.getLayout(
 					layoutPageTemplateEntry.getPlid()),
-				_objectDefinition, objectEntry, rootElement);
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
+				_depotObjectDefinition, objectEntry);
 		}
 	}
 
@@ -299,47 +315,209 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 	}
 
-	private static void _initThemeDisplay() throws Exception {
-		_themeDisplay = new ThemeDisplay();
+	@Test
+	public void testVisitLayoutSetWithObjectEntryInParentSite()
+		throws Exception {
+
+		_childGroup = GroupTestUtil.addGroup(_group.getGroupId());
+
+		LayoutTestUtil.addTypePortletLayout(_childGroup);
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(
+						_siteObjectDefinition)) {
+
+			ObjectEntry childObjectEntry = _addObjectEntry(
+				_childGroup.getGroupId(), _siteObjectDefinition);
+			ObjectEntry parentObjectEntry = _addObjectEntry(
+				_group.getGroupId(), _siteObjectDefinition);
+
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_childGroup.getGroupId(),
+				_portal.getClassNameId(_siteObjectDefinition.getClassName()),
+				null, true, WorkflowConstants.STATUS_APPROVED);
+
+			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+				_childGroup.getGroupId(), false);
+
+			Element rootElement = _getRootElement();
+
+			_objectEntrySitemapURLProvider.visitLayoutSet(
+				rootElement, layoutSet,
+				_getThemeDisplay(_childGroup, layoutSet));
+
+			List<String> objectEntryURLs = new ArrayList<>();
+
+			for (Element element : rootElement.elements()) {
+				objectEntryURLs.add(element.elementText("loc"));
+			}
+
+			Assert.assertTrue(
+				objectEntryURLs.toString(),
+				_containsObjectEntry(childObjectEntry, objectEntryURLs));
+			Assert.assertFalse(
+				objectEntryURLs.toString(),
+				_containsObjectEntry(parentObjectEntry, objectEntryURLs));
+		}
+	}
+
+	@Test
+	public void testVisitLayoutWithObjectEntryInConnectedDepotEntry()
+		throws Exception {
+
+		_depotEntry = _addDepotEntry();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(
+						_depotObjectDefinition)) {
+
+			ObjectEntry objectEntry = _addObjectEntry(
+				_depotEntry.getGroupId(), _depotObjectDefinition);
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_addDisplayPageTemplate(_depotObjectDefinition);
+
+			Layout layout = _layoutLocalService.getLayout(
+				layoutPageTemplateEntry.getPlid());
+
+			Element rootElement = _getRootElement();
+
+			_objectEntrySitemapURLProvider.visitLayout(
+				rootElement, layout.getUuid(), _layoutSet, _themeDisplay);
+
+			Assert.assertFalse(rootElement.hasContent());
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			rootElement = _getRootElement();
+
+			_assertRootElement(
+				layout, _depotObjectDefinition, objectEntry, rootElement);
+		}
+	}
+
+	private static CompanyConfigurationTemporarySwapper
+			_getCompanyConfigurationTemporarySwapper(
+				ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return new CompanyConfigurationTemporarySwapper(
+			TestPropsValues.getCompanyId(), _PID_SITEMAP_COMPANY_CONFIGURATION,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySitemapObjectDefinitionIds",
+				new String[] {
+					String.valueOf(objectDefinition.getObjectDefinitionId())
+				}
+			).build());
+	}
+
+	private static ThemeDisplay _getThemeDisplay(
+			Group group, LayoutSet layoutSet)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		Company company = CompanyLocalServiceUtil.getCompany(
-			_group.getCompanyId());
+			group.getCompanyId());
 
-		_themeDisplay.setCompany(company);
+		themeDisplay.setCompany(company);
 
-		_themeDisplay.setLanguageId(_group.getDefaultLanguageId());
-		_themeDisplay.setLayoutSet(_layoutSet);
-		_themeDisplay.setLocale(
-			LocaleUtil.fromLanguageId(_group.getDefaultLanguageId()));
-		_themeDisplay.setPermissionChecker(
+		themeDisplay.setLanguageId(group.getDefaultLanguageId());
+		themeDisplay.setLayoutSet(layoutSet);
+		themeDisplay.setLocale(
+			LocaleUtil.fromLanguageId(group.getDefaultLanguageId()));
+		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-		_themeDisplay.setPortalDomain(company.getVirtualHostname());
-		_themeDisplay.setPortalURL(company.getPortalURL(_group.getGroupId()));
-		_themeDisplay.setRequest(new MockHttpServletRequest());
-		_themeDisplay.setScopeGroupId(_group.getGroupId());
-		_themeDisplay.setServerPort(PortalUtil.getPortalServerPort(false));
-		_themeDisplay.setSignedIn(true);
-		_themeDisplay.setSiteGroupId(_group.getGroupId());
-		_themeDisplay.setUser(TestPropsValues.getUser());
+		themeDisplay.setPortalDomain(company.getVirtualHostname());
+		themeDisplay.setPortalURL(company.getPortalURL(group.getGroupId()));
+		themeDisplay.setRequest(new MockHttpServletRequest());
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setServerPort(PortalUtil.getPortalServerPort(false));
+		themeDisplay.setSignedIn(true);
+		themeDisplay.setSiteGroupId(group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private static ObjectDefinition _publishCustomObjectDefinition(String scope)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						_OBJECT_FIELD_NAME
+					).objectFieldSettings(
+						Collections.emptyList()
+					).build()),
+				scope);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+
+		return objectDefinition;
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	private LayoutPageTemplateEntry _addDisplayPageTemplate() throws Exception {
+		return _addDisplayPageTemplate(_companyObjectDefinition);
+	}
+
+	private LayoutPageTemplateEntry _addDisplayPageTemplate(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
 		return DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 			_group.getGroupId(),
-			_portal.getClassNameId(_objectDefinition.getClassName()), null,
-			true, WorkflowConstants.STATUS_APPROVED);
+			_portal.getClassNameId(objectDefinition.getClassName()), null, true,
+			WorkflowConstants.STATUS_APPROVED);
 	}
 
 	private ObjectEntry _addObjectEntry() throws Exception {
 		return _objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(),
+			_companyObjectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
-				"textObjectField", RandomTestUtil.randomString()
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			long groupId, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			groupId, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(groupId));
 	}
 
 	private void _assertRootElement(
@@ -373,6 +551,51 @@ public class ObjectEntrySitemapURLProviderTest {
 			Assert.assertTrue(
 				objectEntryLocalizedURL.endsWith(objectEntryFriendlyURL));
 		}
+	}
+
+	private void _assertRootElementAsGuestUser(
+			Layout layout, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		Role role = _roleLocalService.getRole(
+			_group.getCompanyId(), RoleConstants.GUEST);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_group.getCompanyId(), objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntry.getObjectEntryId()), role.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					_userLocalService.getGuestUser(_group.getCompanyId())));
+
+			_assertRootElement(
+				layout, objectDefinition, objectEntry, _getRootElement());
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+	}
+
+	private boolean _containsObjectEntry(
+		ObjectEntry objectEntry, List<String> objectEntryURLs) {
+
+		for (String objectEntryURL : objectEntryURLs) {
+			if (objectEntryURL.endsWith(
+					String.valueOf(objectEntry.getObjectEntryId()))) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private String[] _getAvailableLanguageIds(
@@ -433,30 +656,49 @@ public class ObjectEntrySitemapURLProviderTest {
 	private void _updateObjectDefinition(boolean active) throws Exception {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.getObjectDefinition(
-				_objectDefinition.getObjectDefinitionId());
+				_companyObjectDefinition.getObjectDefinitionId());
 
 		objectDefinition.setActive(active);
 
 		_objectDefinitionLocalService.updateObjectDefinition(objectDefinition);
 	}
 
+	private static final String _OBJECT_FIELD_NAME = StringUtil.randomId();
+
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
 	private static CompanyConfigurationTemporarySwapper
 		_companyConfigurationTemporarySwapper;
+	private static ObjectDefinition _companyObjectDefinition;
+	private static ObjectDefinition _depotObjectDefinition;
 	private static Group _group;
 	private static LayoutSet _layoutSet;
 
 	@Inject
 	private static LayoutSetLocalService _layoutSetLocalService;
 
-	private static ObjectDefinition _objectDefinition;
-
 	@Inject
 	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	@Inject
+	private static ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	private static ObjectDefinition _siteObjectDefinition;
 	private static ThemeDisplay _themeDisplay;
+
+	@DeleteAfterTestRun
+	private Group _childGroup;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private Language _language;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97394

## What Is Being Fixed

Content created in Liferay CMS never appeared in the XML sitemap, even with the object definition marked sitemapable and selected in the instance's XML Sitemap configuration.

CMS Spaces are depots, and the four CMS content types are depot-scoped object definitions. `ObjectEntrySitemapURLProvider` resolved entries from a single group — the layout set's own group — so a depot-scoped entry was never in scope for the query. The same single-group assumption applied to `getModifiedDate`, so the `lastmod` value the sitemap reports ignored CMS content as well.

## How It Is Being Fixed

The provider resolves entries across the site's own group plus the groups of any depot connected to it, via `DepotEntryLocalService.getGroupConnectedDepotEntries`. A Space connected to a site therefore brings its content into that site's sitemap with no new configuration.

`_getApprovedObjectEntries` iterates the resolved group IDs and accumulates approved entries per group, keeping the permission-checked `ObjectEntryService` call intact. `_getLatestModifiedDate` takes the same array and widens its predicate from `groupId.eq` to `groupId.in`, returning null on an empty array rather than issuing a query that cannot match. `visitLayoutSet` hoists the lookup above the object definition loop since the value is loop invariant, and `_visitObjectEntries` now takes the group array in place of the `LayoutSet` it no longer needs.

The group set is deliberately limited to connected depots. An earlier revision used `SiteConnectedGroupGroupProvider.getCurrentAndAncestorSiteAndDepotGroupIds`, which also returns ancestor sites and the Global site, and does so without honoring a parent's "content sharing with children" setting. That pulled a site-scoped entry belonging to a parent site into the child site's sitemap, and because `getCanonicalURL` derives the group prefix from the layout being rendered, the same entry was published under two different canonical URLs — one per site. Only the depot half is needed for CMS Spaces, so the ancestor-site half was dropped.

Four tests cover the new behavior: entry URLs, the modified date, and guest visibility for an entry in a connected Space, plus a parent/child pair asserting that a parent site's entry stays out of the child's sitemap. `ObjectDefinitionTestUtil` gains a scope-aware `addCustomObjectDefinition` overload so depot- and site-scoped definitions can be created in a test; existing signatures are unchanged.

## PR Check

**pr-check: PASS** — tested on `1d7752f0014b7db6303e5b26cc3558359a86eda3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1d7752f0014b7db6303e5b26cc3558359a86eda3"} -->
