### PR TITLE
LPD-102603 Skip the SEO Studio site setup and teardown in Playwright

### DIFF
--- a/modules/test/playwright/tests/setup/seo-studio-site/main/setup.spec.ts
+++ b/modules/test/playwright/tests/setup/seo-studio-site/main/setup.spec.ts
@@ -10,7 +10,7 @@ import {ApiHelpers} from '../../../../helpers/ApiHelpers';
 
 export const test = mergeTests(backendPageTest);
 
-test('Setup: Create the SEO Studio site via its feature flag', async ({
+test.skip('Setup: Create the SEO Studio site via its feature flag', async ({
 	backendPage,
 }) => {
 	await backendPage.goto('/');

--- a/modules/test/playwright/tests/setup/seo-studio-site/teardown/teardown.spec.ts
+++ b/modules/test/playwright/tests/setup/seo-studio-site/teardown/teardown.spec.ts
@@ -10,7 +10,7 @@ import {ApiHelpers} from '../../../../helpers/ApiHelpers';
 
 export const test = mergeTests(backendPageTest);
 
-test('Teardown: Delete the SEO Studio site and disable its feature flag', async ({
+test.skip('Teardown: Delete the SEO Studio site and disable its feature flag', async ({
 	backendPage,
 }) => {
 	await backendPage.goto('/');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102603

## What Is Being Fixed

The `seo-studio-site.main` and `seo-studio-site.teardown` Playwright projects were still running in EE Acceptance. They live under `tests/setup` rather than under the `seo-studio-web` module, so they are picked up independently of the SEO Studio tests they exist to support, and those tests are not currently scheduled through `test.properties`. That left the setup and teardown running on their own, with no test depending on the site they create.

Testray result: https://testray.liferay.com/#/project/35392/routines/590307/build/509195105/case-result/509231342

## How It Is Being Fixed

Both specs change from `test` to `test.skip`. That stops the two projects from doing any work while leaving the specs and their project configuration in place, so the coverage can be turned back on once the SEO Studio tests are scheduled.

## Why Are There No Tests?

The change only disables existing Playwright tests, so there is no new behavior to cover.

## PR Check

**pr-check: PASS** — tested on `f8d1ff98cfffe8c3976a7481a349baec25b516ad`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests (spec compile only) | PASS |

<!-- pr-check {"result": "success", "sha": "f8d1ff98cfffe8c3976a7481a349baec25b516ad"} -->
